### PR TITLE
Initial ci framework pass. Triggers when  ci:run tag added to a pull request.

### DIFF
--- a/.github/actions/docker_action/Dockerfile
+++ b/.github/actions/docker_action/Dockerfile
@@ -1,0 +1,34 @@
+# Use a prebuilt Python image instead of base Ubuntu to speed up the build process,
+# since it has all the build dependencies we need for Micro and downloads much faster
+# than the install process.
+FROM python:3.9.0-buster
+
+RUN echo deb http://apt.llvm.org/buster/ llvm-toolchain-buster-12 main > /etc/apt/sources.list.d/llvm.list
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+
+RUN apt-get update
+
+RUN apt-get install -y zip xxd sudo
+
+RUN apt-get install -y clang-12 clang-format-12
+# Set clang-12 and clang-format-12 as the default to ensure that the pigweed
+# formatting scripts use the desired version.
+RUN ln -s /usr/bin/clang-12 /usr/bin/clang
+RUN ln -s /usr/bin/clang++-12 /usr/bin/clang++
+RUN ln -s /usr/bin/clang-format-12 /usr/bin/clang-format
+
+RUN pip install six
+# Install Renode test dependencies
+RUN pip install pyyaml requests psutil robotframework==3.1
+
+# Install bazel and buildifier so that the bazel presubmit checks can be run
+# from the micro docker container and are consistent with the rest of the CI.
+
+COPY ci/*.sh /install/
+RUN /install/install_bazel.sh
+RUN /install/install_buildifier.sh
+
+COPY . /opt/tflm/
+WORKDIR /opt/tflm
+
+CMD ["/opt/tflm/tensorflow/lite/micro/tools/ci_build/test_all_new.sh"]

--- a/.github/actions/docker_action/action.yml
+++ b/.github/actions/docker_action/action.yml
@@ -1,0 +1,6 @@
+#Prototype Docker Action
+name: 'Prototype Docker Action'
+description: 'First pass docker action'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  trivial:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'ci:run')
+    name: First Pass Trigger Testing
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Show Workspace Context
+        run: echo 'Workspace is ${{ github.workspace }}'
+      - name: Nasty Hack To Get Right Docker Build Context
+        run: cp ./.github/actions/docker_action/Dockerfile . && cp ./.github/actions/docker_action/action.yml .
+      - name: Run Docker Tests
+        uses: ./
+      - name: Show commit
+        run: git show -q


### PR DESCRIPTION
This is a starting point. Triggers when ci:run tag added to a pull request. The dockerfile being used isn't the one in ./ci, but a slightly modified version living in ./github/actions/docker_action. It still runs whatever is in test_all_new.sh. The entire dockerfile build and run strategy will be changing to use a checked in container which will make this a lot cleaner. 