### PR TITLE
Make the neon check header empty since we do not need it for TFLM.

### DIFF
--- a/ci/sync_from_upstream_tf.sh
+++ b/ci/sync_from_upstream_tf.sh
@@ -57,6 +57,9 @@ git checkout \
   tensorflow/lite/kernels/internal/BUILD \
   tensorflow/lite/schema/BUILD
 
+git checkout \
+  tensorflow/lite/kernels/internal/optimized/neon_check.h
+
 rsync -r --delete /tmp/tensorflow/tensorflow/lite/micro tensorflow/lite/
 
 # TODO(b/184876027): properly handle the micro_speech example and its

--- a/tensorflow/lite/kernels/internal/optimized/neon_check.h
+++ b/tensorflow/lite/kernels/internal/optimized/neon_check.h
@@ -15,26 +15,6 @@ limitations under the License.
 #ifndef TENSORFLOW_LITE_KERNELS_INTERNAL_OPTIMIZED_NEON_CHECK_H_
 #define TENSORFLOW_LITE_KERNELS_INTERNAL_OPTIMIZED_NEON_CHECK_H_
 
-#if defined(__ARM_NEON__) || defined(__ARM_NEON)
-#define USE_NEON
-#include <arm_neon.h>
-#endif
-
-#if defined __GNUC__ && defined __SSE4_1__ && !defined TF_LITE_DISABLE_X86_NEON
-#define USE_NEON
-#include "NEON_2_SSE.h"
-#endif
-
-// NEON_OR_PORTABLE(SomeFunc, args) calls NeonSomeFunc(args) if USE_NEON is
-// defined, PortableSomeFunc(args) otherwise.
-#ifdef USE_NEON
-// Always use Neon code
-#define NEON_OR_PORTABLE(funcname, ...) Neon##funcname(__VA_ARGS__)
-
-#else
-// No NEON available: Use Portable code
-#define NEON_OR_PORTABLE(funcname, ...) Portable##funcname(__VA_ARGS__)
-
-#endif  // defined(USE_NEON)
+// TFLM does not need to utilize any Neon optimizations.
 
 #endif  // TENSORFLOW_LITE_KERNELS_INTERNAL_OPTIMIZED_NEON_CHECK_H_


### PR DESCRIPTION
Transformation between open-source and internal google is complicated by the code in neon_check.h and since we do not need it for TFLM, we can instead have the file be empty.
