### PR TITLE
Increase CI converage to match upstream test_all.sh

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
   arduino:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'ci:run')
-    name: Makefile x86 tests
+    name: Arduino
     steps:
       - uses: actions/checkout@v2
       - name: Test
@@ -21,10 +21,10 @@ jobs:
     name: Bazel Tests
     steps:
       - uses: actions/checkout@v2
-      - name: "Set up bazel"
+      - name: Set up bazel
         run: |
           sudo ci/install_bazel.sh
-      - name: "Test"
+      - name: Test
         run: |
           tensorflow/lite/micro/tools/ci_build/test_bazel.sh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,17 +5,15 @@ on:
     types: [labeled]
 
 jobs:
-  check_code_style:
+  arduino:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'ci:run')
-    name: Code Style
+    name: Makefile x86 tests
     steps:
       - uses: actions/checkout@v2
-      - name: Check
-        # TODO(#11): Update the docker image to be hosted via github packages.
-        uses: docker://jpwithers/tflite-micro-tests
-        with:
-          args: /bin/sh -c "/opt/tflm/tensorflow/lite/micro/tools/ci_build/test_code_style.sh"
+      - name: Test
+        run: |
+          tensorflow/lite/micro/tools/ci_build/test_arduino.sh
 
   bazel_tests:
     runs-on: ubuntu-latest
@@ -30,6 +28,42 @@ jobs:
         run: |
           tensorflow/lite/micro/tools/ci_build/test_bazel.sh
 
+  cortex_m_tests:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'ci:run')
+    name: Cortex-M tests
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test
+        run: |
+          tensorflow/lite/micro/tools/ci_build/test_bluepill.sh
+          tensorflow/lite/micro/tools/ci_build/test_cortex_m_corstone_300.sh
+          tensorflow/lite/micro/tools/ci_build/test_cortex_m_generic.sh
+          tensorflow/lite/micro/tools/ci_build/test_sparkfun.sh
+          tensorflow/lite/micro/tools/ci_build/test_stm32f4.sh
+
+  check_code_style:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'ci:run')
+    name: Code Style
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check
+        # TODO(#11): Update the docker image to be hosted via github packages.
+        uses: docker://jpwithers/tflite-micro-tests
+        with:
+          args: /bin/sh -c "/opt/tflm/tensorflow/lite/micro/tools/ci_build/test_code_style.sh"
+
+  project_generation:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'ci:run')
+    name: Project generation
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test
+        run: |
+          tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
+
   x86_tests:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'ci:run')
@@ -38,17 +72,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Test
         run: |
+          tensorflow/lite/micro/tools/ci_build/test_makefile.sh
           tensorflow/lite/micro/tools/ci_build/test_x86.sh
-
-  bluepill_tests:
-    runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'ci:run')
-    name: Bluepill tests
-    steps:
-      - uses: actions/checkout@v2
-      - name: Test
-        run: |
-          tensorflow/lite/micro/tools/ci_build/test_bluepill.sh
 
       # TODO(#13): Uncomment the lines below once we can appropriately change
       # labels from PRs created from forks.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Test
         run: |
+          # TODO(b/184886633): the downloads should happen as part of the create_tflm_tree
+          # script or should optinally not be required.
+          make -f tensorflow/lite/micro/tools/make/Makefile third_party_downloads
           tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
 
   x86_tests:

--- a/ci/sync_from_upstream_tf.sh
+++ b/ci/sync_from_upstream_tf.sh
@@ -79,6 +79,6 @@ rm -rf tensorflow/lite/micro/tools/ci_build/tflm_bazel
 # the rsync command and any files whose source of truth is the new TFLM repo
 # should be manually restored.
 git checkout \
-  tensorflow/lite/micro/tools/ci_build/test_all.sh \
-  tensorflow/lite/micro/tools/ci_build/test_bazel.sh
+  tensorflow/lite/micro/tools/ci_build/test_bazel.sh \
+  tensorflow/lite/micro/tools/ci_build/test_makefile.sh
 

--- a/tensorflow/lite/micro/tools/ci_build/test_makefile.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_makefile.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR=${SCRIPT_DIR}/../../../../..
+cd "${ROOT_DIR}"
+pwd
+
+make -f tensorflow/lite/micro/tools/make/Makefile clean_downloads DISABLE_DOWNLOADS=true
+make -f tensorflow/lite/micro/tools/make/Makefile OPTIMIZED_KERNEL_DIR=cmsis_nn clean DISABLE_DOWNLOADS=true
+if [ -d tensorflow/lite/micro/tools/make/downloads ]; then
+  echo "ERROR: Downloads directory should not exist, but it does."
+  exit 1
+fi
+
+# Check that an incorrect optimized kernel directory results in an error.
+# Without such an error, an incorrect optimized kernel directory can result in
+# an unexpected fallback to reference kernels and which can be hard to debug. We
+# add some complexity to the CI to make sure that we do not repeat the same
+# mistake as described in http://b/183546742.
+INCORRECT_CMD="make -f tensorflow/lite/micro/tools/make/Makefile OPTIMIZED_KERNEL_DIR=does_not_exist clean"
+EXT_LIBS_INC=tensorflow/lite/micro/tools/make/ext_libs/does_not_exist.inc
+touch ${EXT_LIBS_INC}
+if ${INCORRECT_CMD} &> /dev/null ; then
+  echo "'${INCORRECT_CMD}' should have failed but it did not have any errors."
+  rm -f ${EXT_LIBS_INC}
+  exit 1
+fi
+rm -f ${EXT_LIBS_INC}

--- a/tensorflow/lite/micro/tools/make/targets/apollo3evb_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/apollo3evb_makefile.inc
@@ -36,9 +36,7 @@ PLATFORM_FLAGS = \
   -DTF_LITE_MCU_DEBUG_LOG \
   -D __FPU_PRESENT=1 \
   -DARM_MATH_CM4 \
-  -fno-rtti \
   -fmessage-length=0 \
-  -fno-exceptions \
   -fno-unwind-tables \
   -ffunction-sections \
   -fdata-sections \
@@ -48,24 +46,30 @@ PLATFORM_FLAGS = \
   -mthumb \
   -mfpu=fpv4-sp-d16 \
   -mfloat-abi=hard \
-  -std=gnu++11 \
   -Wvla \
   -Wall \
   -Wextra \
+  -Wno-implicit-fallthrough \
   -Wno-missing-field-initializers \
+  -Wno-return-type \
+  -Wno-sign-compare \
   -Wno-strict-aliasing \
   -Wno-type-limits \
   -Wno-unused-function \
   -Wno-unused-parameter \
   -fno-delete-null-pointer-checks \
-  -fno-threadsafe-statics \
   -fomit-frame-pointer \
-  -fno-use-cxa-atexit \
   -nostdlib \
   -ggdb \
   -O3
-CXXFLAGS += $(PLATFORM_FLAGS)
-CCFLAGS += $(PLATFORM_FLAGS)
+
+CXXFLAGS += \
+  $(PLATFORM_FLAGS) \
+  -fno-use-cxa-atexit
+
+CCFLAGS += $(PLATFORM_FLAGS) \
+  -Wno-int-conversion
+
 LDFLAGS += \
   -mthumb -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard \
   -nostartfiles -static \


### PR DESCRIPTION
 * With this change, the github actions should have exactly the same checks as the TFLM checks in upstream tensorflow.
 * Needed to fix the SParkfun edge makefiles (corresponding change in TF: https://github.com/tensorflow/tensorflow/pull/48682)
 * Since we are no longer using test_all.sh as part of CI, we can go back to sync'ing from upstream.
