### PR TITLE
Adding simple workflow for ci testing

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,0 +1,22 @@
+on:
+  pull_request:
+    types: [labeled]
+    branches:
+      - main
+
+jobs:
+  trivial:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'ci:test')
+    name: CI Machinery Tests
+    steps:
+      - name: show ci file
+        run: echo "this file is checked in main"
+      - name: show selected vars
+        run: |
+          echo "GITHUB_ACTOR:  ${{ GITHUB_ACTOR }}"
+          echo "GITHUB_HEAD_REF:  ${{ GITHUB_HEAD_REF }}"
+          echo "GITHUB_BASE_REF:  ${{ GITHUB_BASE_REF }}"
+          echo "GITHUB_REF:  ${{ GITHUB_REF }}"
+          echo "GITHUB_REPOSITORY:  ${{ GITHUB_REPOSITORY }}"
+          echo "GITHUB_SHA:  ${{ GITHUB_SHA }}"


### PR DESCRIPTION
This adds a simple workflow triggered on a `ci:test` label so we can do ci machinery tests without running the full test suite.