### PR TITLE
fixing env var calls

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -14,9 +14,9 @@ jobs:
         run: echo "this file is checked in main"
       - name: show selected vars
         run: |
-          echo "GITHUB_ACTOR:  ${{ GITHUB_ACTOR }}"
-          echo "GITHUB_HEAD_REF:  ${{ GITHUB_HEAD_REF }}"
-          echo "GITHUB_BASE_REF:  ${{ GITHUB_BASE_REF }}"
-          echo "GITHUB_REF:  ${{ GITHUB_REF }}"
-          echo "GITHUB_REPOSITORY:  ${{ GITHUB_REPOSITORY }}"
-          echo "GITHUB_SHA:  ${{ GITHUB_SHA }}"
+          echo "GITHUB_ACTOR: $GITHUB_ACTOR"
+          echo "GITHUB_HEAD_REF:  $GITHUB_HEAD_REF"
+          echo "GITHUB_BASE_REF:  $GITHUB_BASE_REF"
+          echo "GITHUB_REF:  $GITHUB_REF"
+          echo "GITHUB_REPOSITORY:  $GITHUB_REPOSITORY"
+          echo "GITHUB_SHA:  $GITHUB_SHA"


### PR DESCRIPTION
Was using the format for calling secrets instead of env variables, doh.