### PR TITLE
Workflow cleanup

### DIFF
--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 6 * * *'
 
+  # Allow manually triggering of the workflow.
+  workflow_dispatch: {}
+
 jobs:
   arduino:
     runs-on: ubuntu-latest

--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -4,10 +4,12 @@
 # Helpful YAML parser to clarify YAML syntax:
 # https://yaml-online-parser.appspot.com/
 
+name: Arduino
+
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 4 * * *'
 
   # Allow manually triggering of the workflow.
   workflow_dispatch: {}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ on:
     types: [labeled]
 
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 4 * * *'
 
   # Allow manually triggering of the workflow.
   workflow_dispatch: {}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,12 @@ on:
   pull_request:
     types: [labeled]
 
+  schedule:
+    - cron: '0 6 * * *'
+
+  # Allow manually triggering of the workflow.
+  workflow_dispatch: {}
+
 jobs:
   bazel_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/cortex_m.yml
+++ b/.github/workflows/cortex_m.yml
@@ -4,11 +4,12 @@
 # Helpful YAML parser to clarify YAML syntax:
 # https://yaml-online-parser.appspot.com/
 
+name: Cortex-M
 
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 4 * * *'
 
   # Allow manually triggering of the workflow.
   workflow_dispatch: {}
@@ -21,6 +22,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: Test
         run: |
-          tensorflow/lite/micro/tools/ci_build/test_cortex_m_corstone_300.sh
           tensorflow/lite/micro/tools/ci_build/test_cortex_m_generic.sh
-          tensorflow/lite/micro/tools/ci_build/test_sparkfun.sh
+          tensorflow/lite/micro/tools/ci_build/test_cortex_m_corstone_300.sh

--- a/.github/workflows/cortex_m.yml
+++ b/.github/workflows/cortex_m.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '0 6 * * *'
 
+  # Allow manually triggering of the workflow.
+  workflow_dispatch: {}
+
 jobs:
   cortex_m_daily:
     runs-on: ubuntu-latest

--- a/.github/workflows/sparkfun_edge.yml
+++ b/.github/workflows/sparkfun_edge.yml
@@ -1,0 +1,20 @@
+
+name: Sparkfun Edge
+
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule
+on:
+  schedule:
+    - cron: '0 4 * * *'
+
+  # Allow manually triggering of the workflow.
+  workflow_dispatch: {}
+
+jobs:
+  cortex_m_daily:
+    runs-on: ubuntu-latest
+    name: Cortex-M Continuous Builds
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test
+        run: |
+          tensorflow/lite/micro/tools/ci_build/test_sparkfun.sh


### PR DESCRIPTION
 * Daily build for CI workflow (for buyild badge).
 * Separate builds for Sparkfun Edge and COrtex-M for more separation in the build badge.
 * Added names to the workflows.
 * Manual triggers for all the workflows.
