### PR TITLE
Limit parallel builds to nproc.

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_cortex_m_corstone_300.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_cortex_m_corstone_300.sh
@@ -33,5 +33,5 @@ readable_run make -f tensorflow/lite/micro/tools/make/Makefile OPTIMIZED_KERNEL_
 
 # Avoid running tests in parallel.
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
-readable_run make -j -f tensorflow/lite/micro/tools/make/Makefile OPTIMIZED_KERNEL_DIR=${OPTIMIZED_KERNEL_DIR} TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} build
+readable_run make -j$(nproc) -f tensorflow/lite/micro/tools/make/Makefile OPTIMIZED_KERNEL_DIR=${OPTIMIZED_KERNEL_DIR} TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} build
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile OPTIMIZED_KERNEL_DIR=${OPTIMIZED_KERNEL_DIR} TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} test


### PR DESCRIPTION
Without such a limit, when github actions kills the build (possibly because of some load monitoring). As a result, the build terminates with an error like:

```
arm-none-eabi-g++ -std=c++11 -fno-rtti -fno-exceptions -fno-threadsafe-statics -fno-unwind-tables -ffunction-sections -fdata-sections -fmessage-length=0 -DTF_LITE_STATIC_MEMORY -DTF_LITE_DISABLE_X86_NEON -O3 -Werror -Wsign-compare -Wdouble-promotion -Wshadow -Wunused-variable -Wmissing-field-initializers -Wunused-function -Wswitch -Wvla -Wall -Wextra -Wstrict-aliasing -Wno-unused-parameter -DCORTEX_M_CORSTONE_300 -DCMSIS_NN -mcpu=cortex-m55 -mfpu=auto -DTF_LITE_MCU_DEBUG_LOG -mthumb -mfloat-abi=hard -funsigned-char -mlittle-endian -Wno-implicit-fallthrough -Wno-strict-aliasing -fomit-frame-pointer -MD -DCPU_M55=1 -DARMCM55 -I. -Itensorflow/lite/micro/tools/make/downloads/gemmlowp -Itensorflow/lite/micro/tools/make/downloads/flatbuffers/include -Itensorflow/lite/micro/tools/make/downloads/ruy -Itensorflow/lite/micro/tools/make/downloads/cmsis/Device/ARM/ARMCM55/Include -Itensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/Core/Include -Itensorflow/lite/micro/tools/make/downloads/cmsis -Itensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/Core/Include -Itensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/DSP/Include -Itensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/NN/Include -c tensorflow/lite/micro/kernels/zeros_like_test.cc -o tensorflow/lite/micro/tools/make/gen/cortex_m_corstone_300_cortex-m55_default/obj/tensorflow/lite/micro/kernels/zeros_like_test.o
arm-none-eabi-g++: fatal error: Killed signal terminated program cc1plus
compilation terminated.
make: *** [tensorflow/lite/micro/tools/make/Makefile:696: tensorflow/lite/micro/tools/make/gen/cortex_m_corstone_300_cortex-m55_default/obj/tensorflow/lite/core/api/flatbuffer_conversions.o] Error 1
make: *** Waiting for unfinished jobs....
Error: Process completed with exit code 2.
```

Tested on my fork of tflite-micro that with this change, the build completes successfully.