### PR TITLE
Renaming the workflow.

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -5,7 +5,7 @@
 # https://yaml-online-parser.appspot.com/
 #
 
-name: Sync from Upstream TF
+name: Sync
 
 on:
   schedule:


### PR DESCRIPTION
For some reason the actions dashboard has stopped showing me the name of the sync workflow. Instead it is showing me the path to the yml file which is somewhat annoying.
