### PR TITLE
Revert "Renaming the workflow."

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -5,7 +5,7 @@
 # https://yaml-online-parser.appspot.com/
 #
 
-name: Sync
+name: Sync from Upstream TF
 
 on:
   schedule:


### PR DESCRIPTION
Reverts tensorflow/tflite-micro#39

The changes to sync.yml from https://github.com/tensorflow/tflite-micro/pull/38 had ill-formed YAML and that was the cause of the name not being parsed correctly (which was the reason I created tensorflow/tflite-micro#39).
