### PR TITLE
Also add any new files to the sync PR.

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -22,7 +22,12 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Sync the code
-        run: ./ci/sync_from_upstream_tf.sh
+        run: |
+          ./ci/sync_from_upstream_tf.sh
+          git config user.name "Advait Jain"
+          git config user.email "advaitjain@users.noreply.github.com"
+          git add *
+          git commit -m "Adding new files as a result of the sync."
 
       - name: Create Pull Request
         id: create-pr


### PR DESCRIPTION
Without the additional step of `git add`, any untracked files will not be part of the PR that is created with the sync workflow.

Manually tested this change on my fork of tensorflow by removing a file, pushing it to main and then confirming that the sync workflow does not add to the PR prior to this change, but does add it to the PR after this change.
