### PR TITLE
Do not remove ci:run label from the sync PRs.

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -76,26 +76,6 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: 'ci:run'
-            })
-      - uses: actions/github-script@v4
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'Removing ci:run label so that future label changes do not trigger the CI checks again.'
-            })
-      - uses: actions/github-script@v4
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.issues.removeLabel({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
               name: 'cla: no'
             })
       - uses: actions/github-script@v4


### PR DESCRIPTION
Since we trigger the CI workflow on any label change, when the cla:yes label is applied the CI workflow will be run, and there is no way around that with the current setup.

If the sync PR does not have the ci:run label, the checks will be skipped but will still need to be run again prior to merge since skipping the checks invalidates the previous completion of the required checks.

As a result, we are keeping the ci:run label. What this means is that the reviewer can manually apply the cla:yes label and then start auto-merge (which will wait for another round of the required checks to be run).
