### PR TITLE
patch TFLM visibility updates from #73 prior to sync from upstream TF.

### DIFF
--- a/ci/sync_from_upstream_tf.sh
+++ b/ci/sync_from_upstream_tf.sh
@@ -33,7 +33,12 @@ rm -rf /tmp/tflm-tree
 
 git clone https://github.com/tensorflow/tensorflow.git --depth=1 /tmp/tensorflow
 
-cd /tmp/tensorflow/
+# Manually apply some patches to avoid having to upstream changes to TF that
+# are very specific to the new TFLM repo.
+cp ci/temp_patches/tf_update_visibility.patch /tmp/tensorflow
+cd /tmp/tensorflow
+git apply tf_update_visibility.patch
+
 # TODO(b/184886633): the downloads should happen as part of the create_tflm_tree
 # script.
 make -f tensorflow/lite/micro/tools/make/Makefile third_party_downloads

--- a/ci/temp_patches/tf_update_visibility.patch
+++ b/ci/temp_patches/tf_update_visibility.patch
@@ -1,0 +1,66 @@
+diff --git a/tensorflow/lite/micro/kernels/BUILD b/tensorflow/lite/micro/kernels/BUILD
+index 22bcf2b1efd..6f27814f6a2 100644
+--- a/tensorflow/lite/micro/kernels/BUILD
++++ b/tensorflow/lite/micro/kernels/BUILD
+@@ -1,7 +1,5 @@
+-load(
+-    "//tensorflow/lite/micro:build_def.bzl",
+-    "micro_copts",
+-)
++load("//tensorflow/lite/micro:build_def.bzl", "micro_copts")
++load("//tensorflow:extra_rules.bzl", "tflm_kernel_friends")
+ 
+ package(
+     features = ["-layering_check"],
+@@ -23,6 +21,11 @@ package_group(
+     packages = ["//tensorflow/lite/micro"],
+ )
+ 
++package_group(
++    name = "kernel_friends",
++    packages = tflm_kernel_friends(),
++)
++
+ ####################################
+ # C++ libraries
+ ####################################
+@@ -245,6 +248,7 @@ cc_library(
+     ],
+     hdrs = ["kernel_util.h"],
+     visibility = [
++        ":kernel_friends",
+         ":micro",
+     ],
+     deps = [
+diff --git a/tensorflow/lite/micro/testing/BUILD b/tensorflow/lite/micro/testing/BUILD
+index 6d8c74dd7e8..3dea5752f1e 100644
+--- a/tensorflow/lite/micro/testing/BUILD
++++ b/tensorflow/lite/micro/testing/BUILD
+@@ -1,8 +1,15 @@
++load("//tensorflow:extra_rules.bzl", "tflm_kernel_friends")
++
+ package(
+     features = ["-layering_check"],
+     licenses = ["notice"],
+ )
+ 
++package_group(
++    name = "kernel_friends",
++    packages = tflm_kernel_friends(),
++)
++
+ package_group(
+     name = "micro",
+     packages = ["//tensorflow/lite/micro/..."],
+@@ -19,9 +26,10 @@ cc_library(
+         "micro_test.h",
+     ],
+     visibility = [
++        ":kernel_friends",
+         ":micro",
+         ":microfrontend",
+-    ],
++    ],  # TODO(b/188226023)
+     deps = [
+         "//tensorflow/lite/c:common",
+         "//tensorflow/lite/core/api",


### PR DESCRIPTION
These visibility changes are specific to the TFLM code in github.com/tensorflow/tflite-micro and would be awkward to upstream to github.com/tensorflow/tensorflow.

Additionally, we are getting close to switching the current repository to be the source of truth for TFLM code and have thus made the decision to temporarily add some patches during the sync from upstream TF to the current repo.

Manually tested that running `ci/sync_from_upstream_tf.sh` with the current change avoids reverting the changes from #73 (such as with #76).
