### PR TITLE
tools to check in json value files from ci

### DIFF
--- a/.github/assets/write_json.py
+++ b/.github/assets/write_json.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+# writes a key/value json pair to an arbitrary file
+# defaults to writing a random number (1-1000) to checkin_test.json in the current directory
+
+import os
+import random
+import json
+import argparse
+
+def write_json(output_file, values):
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
+    json_dict = {values[0]: values[1]}
+    with open(output_file, 'w') as outfile:
+        json.dump(json_dict, outfile)
+
+
+if __name__=="__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-f', '--file', help="output file path", default="./checkin_test.json")
+    parser.add_argument('-v', '--values', help="key value pair, must be two strings", nargs=2, default=['random', '22'])
+    args = parser.parse_args()
+    if args.values[0] == 'random': args.values[1] = random.randrange(1000)
+    write_json(args.file, args.values)    
+    
+

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,17 +1,16 @@
+name: CI Tests
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
-    branches:
-      - main
-
+    
 jobs:
   trivial:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'ci:test')
     name: CI Machinery Tests
     steps:
-      - name: show ci file
-        run: echo "this file is checked in main"
+      - name: Checkout Repo
+        uses: actions/checkout@v2
       - name: show selected vars
         run: |
           echo "GITHUB_ACTOR: $GITHUB_ACTOR"
@@ -20,3 +19,17 @@ jobs:
           echo "GITHUB_REF:  $GITHUB_REF"
           echo "GITHUB_REPOSITORY:  $GITHUB_REPOSITORY"
           echo "GITHUB_SHA:  $GITHUB_SHA"
+          echo ${{ github.event.number }}
+      - name: create json file
+        run: |
+          python3 .github/assets/write_json.py -f ./.tests/test.json
+      - name: commit ci info file
+        run: |
+          git config --local user.email "$(git log --format='%ae' HEAD^!)"
+          git config --local user.name "$(git log --format='%an' HEAD^!)"
+          git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
+          git pull github ${GITHUB_REF}
+          git add .
+          git commit -m "adding ci data"
+          git push --force github HEAD:${GITHUB_HEAD_REF}
+


### PR DESCRIPTION
This is going to have to be merged to test it because it changes the trigger to pull_request_target from pull_request on the ci-test.yml file. I have tested this pretty extensively on my toy setup and it works as expected.

There are two bits here. The first is a short python script living in .github/assets (we can change that, obviously) that will write an arbitrary key value pair to an arbitrary json file location. By default it writes a random number between 1 and 1000 as the key value pair.

The second part is adding some github checkin goodness to ci-test.yml. 

These are very modular and will be easy to drop into any scripts we are working on and should be fairly obvious on the face of them. There is no dependence on outside actions and the python script should work on any of the default github runners without doing an explicit load of a given version of python3 since everything used has been in python since 3.4.1