### PR TITLE
Sync reference implementation of SPACE_TO_DEPTH from lite

### DIFF
--- a/ci/sync_from_upstream_tf.sh
+++ b/ci/sync_from_upstream_tf.sh
@@ -101,6 +101,7 @@ tensorflow/lite/kernels/internal/reference/resize_nearest_neighbor.h \
 tensorflow/lite/kernels/internal/reference/round.h \
 tensorflow/lite/kernels/internal/reference/softmax.h \
 tensorflow/lite/kernels/internal/reference/space_to_batch_nd.h \
+tensorflow/lite/kernels/internal/reference/space_to_depth.h \
 tensorflow/lite/kernels/internal/reference/sub.h \
 tensorflow/lite/kernels/internal/reference/logistic.h \
 tensorflow/lite/kernels/internal/reference/strided_slice.h \


### PR DESCRIPTION
Add the header containing the reference implementation of op SPACE_TO_DEPTH to the list of files which are synced from the upstream TensorFlow repository. This reference is needed for the forthcoming implementation of SPACE_TO_DEPTH here in micro.

This PR is part of the effort to port SPACE_TO_DEPTH from lite as documented in issue #113.