### PR TITLE
Fixes for Xtensa workflow.

### DIFF
--- a/.github/workflows/xtensa.yml
+++ b/.github/workflows/xtensa.yml
@@ -26,7 +26,7 @@ jobs:
 
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:run')) ||
+      (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ci:run')) ||
       (github.event_name == 'schedule' && github.repository == 'tensorflow/tflite-micro')
 
     name: Fusion F1 Unit Tests (presubmit)

--- a/tensorflow/lite/micro/tools/ci_build/test_xtensa_fusion_f1.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_xtensa_fusion_f1.sh
@@ -24,6 +24,10 @@ pwd
 source tensorflow/lite/micro/tools/ci_build/helper_functions.sh
 
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
+
+# TODO(b/143904317): downloading first to allow for parallel builds.
+readable_run make -f tensorflow/lite/micro/tools/make/Makefile third_party_downloads
+
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile \
   TARGET=xtensa \
   TARGET_ARCH=fusion_f1 \


### PR DESCRIPTION
 * Trigger workflow from pull_request_target.
 * Explicitly call third_party_downloads prior to running the tests.

BUG=http://b/190108540
