### PR TITLE
Kernel variants for keyword benchmark operators

### DIFF
--- a/tensorflow/lite/micro/benchmarks/keyword_benchmark.cc
+++ b/tensorflow/lite/micro/benchmarks/keyword_benchmark.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/benchmarks/keyword_scrambled_model_data.h"
 #include "tensorflow/lite/micro/benchmarks/micro_benchmark.h"
 #include "tensorflow/lite/micro/kernels/fully_connected.h"
+#include "tensorflow/lite/micro/kernels/quantize.h"
 #include "tensorflow/lite/micro/kernels/softmax.h"
 #include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
@@ -60,7 +61,7 @@ KeywordBenchmarkRunner* CreateBenchmarkRunner(MicroProfiler* profiler) {
   // lifetime must exceed that of the KeywordBenchmarkRunner object.
   KeywordOpResolver* op_resolver = new (op_resolver_buffer) KeywordOpResolver();
   op_resolver->AddFullyConnected(tflite::Register_FULLY_CONNECTED_INT8());
-  op_resolver->AddQuantize();
+  op_resolver->AddQuantize(tflite::Register_QUANTIZE_INT8());
   op_resolver->AddSoftmax(tflite::Register_SOFTMAX_INT8_INT16());
   op_resolver->AddSvdf();
 

--- a/tensorflow/lite/micro/benchmarks/keyword_benchmark.cc
+++ b/tensorflow/lite/micro/benchmarks/keyword_benchmark.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/fully_connected.h"
 #include "tensorflow/lite/micro/kernels/quantize.h"
 #include "tensorflow/lite/micro/kernels/softmax.h"
+#include "tensorflow/lite/micro/kernels/svdf.h"
 #include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 #include "tensorflow/lite/micro/micro_profiler.h"
@@ -63,7 +64,7 @@ KeywordBenchmarkRunner* CreateBenchmarkRunner(MicroProfiler* profiler) {
   op_resolver->AddFullyConnected(tflite::Register_FULLY_CONNECTED_INT8());
   op_resolver->AddQuantize(tflite::Register_QUANTIZE_INT8());
   op_resolver->AddSoftmax(tflite::Register_SOFTMAX_INT8_INT16());
-  op_resolver->AddSvdf();
+  op_resolver->AddSvdf(tflite::Register_SVDF_INT8());
 
   return new (benchmark_runner_buffer)
       KeywordBenchmarkRunner(g_keyword_scrambled_model_data, op_resolver,

--- a/tensorflow/lite/micro/kernels/fully_connected.h
+++ b/tensorflow/lite/micro/kernels/fully_connected.h
@@ -65,7 +65,6 @@ TfLiteStatus CalculateOpDataFullyConnected(
 // (reference or optimized) must define this function.
 TfLiteRegistration Register_FULLY_CONNECTED();
 
-#if defined(CMSIS_NN) || defined(ARDUINO)
 // The Arduino is a special case where we use the CMSIS kernels, but because of
 // the current approach to building for Arduino, we do not support -DCMSIS_NN as
 // part of the build. As a result, we use defined(ARDUINO) as proxy for the
@@ -75,17 +74,6 @@ TfLiteRegistration Register_FULLY_CONNECTED();
 // supports int8.
 TfLiteRegistration Register_FULLY_CONNECTED_INT8();
 
-#else
-// Note that while this block gets used for both reference and optimized kernels
-// that do not have any specialized implementations, the only goal here is to
-// define fallback implementation that allow reference kernels to still be used
-// from applications that call a more specific kernel variant.
-
-inline TfLiteRegistration Register_FULLY_CONNECTED_INT8() {
-  return Register_FULLY_CONNECTED();
-}
-
-#endif
 }  // namespace tflite
 
 #endif  // TENSORFLOW_LITE_MICRO_KERNELS_FULLY_CONNECTED_H_

--- a/tensorflow/lite/micro/kernels/quantize.h
+++ b/tensorflow/lite/micro/kernels/quantize.h
@@ -32,6 +32,9 @@ struct OpDataQuantizeReference {
 
 TfLiteStatus EvalQuantizeReference(TfLiteContext* context, TfLiteNode* node);
 TfLiteStatus PrepareQuantizeReference(TfLiteContext* context, TfLiteNode* node);
+
+TfLiteRegistration Register_QUANTIZE_INT8();
+
 }  // namespace tflite
 
 #endif  // TENSORFLOW_LITE_MICRO_KERNELS_QUANTIZE_H_

--- a/tensorflow/lite/micro/kernels/softmax.h
+++ b/tensorflow/lite/micro/kernels/softmax.h
@@ -30,15 +30,9 @@ TfLiteStatus SoftmaxPrepare(TfLiteContext* context, TfLiteNode* node);
 // (reference or optimized) must define this function.
 TfLiteRegistration Register_SOFTMAX();
 
-#if defined(XTENSA)
 // Returns a TfLiteRegistration struct for kernel variant that only supports
 // int8 input and int16 output.
 TfLiteRegistration Register_SOFTMAX_INT8_INT16();
-#else
-inline TfLiteRegistration Register_SOFTMAX_INT8_INT16() {
-  return Register_SOFTMAX();
-}
-#endif
 
 }  // namespace tflite
 

--- a/tensorflow/lite/micro/kernels/svdf.h
+++ b/tensorflow/lite/micro/kernels/svdf.h
@@ -66,6 +66,10 @@ void EvalFloatSvdfReference(
 
 TfLiteStatus PrepareSvdf(TfLiteContext* context, TfLiteNode* node);
 
+// Returns a TfLiteRegistration struct for kernel variant that only supports
+// int8 input and output tensors.
+TfLiteRegistration Register_SVDF_INT8();
+
 }  // namespace tflite
 
 #endif  // TENSORFLOW_LITE_MICRO_KERNELS_SVDF_H_

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -396,8 +396,9 @@ class MicroMutableOpResolver : public MicroOpResolver {
                       tflite::ops::micro::Register_PRELU(), ParsePrelu);
   }
 
-  TfLiteStatus AddQuantize() {
-    return AddBuiltin(BuiltinOperator_QUANTIZE, Register_QUANTIZE(),
+  TfLiteStatus AddQuantize(
+      const TfLiteRegistration& registration = Register_QUANTIZE()) {
+    return AddBuiltin(BuiltinOperator_QUANTIZE, registration,
                       ParseQuantize);
   }
 
@@ -497,8 +498,8 @@ class MicroMutableOpResolver : public MicroOpResolver {
                       ParseSub);
   }
 
-  TfLiteStatus AddSvdf() {
-    return AddBuiltin(BuiltinOperator_SVDF, Register_SVDF(), ParseSvdf);
+  TfLiteStatus AddSvdf(const TfLiteRegistration& registration = Register_SVDF()) {
+    return AddBuiltin(BuiltinOperator_SVDF, registration, ParseSvdf);
   }
 
   TfLiteStatus AddTanh() {


### PR DESCRIPTION
Add reference kernel variants for operators used in the keyword benchmark: FULLY_CONNECTED, QUANTIZE, SOFTMAX, SVDF.

keyword benchmark before:
```
   text    data     bss     dec
  57436   37663   46612  141711

Total: Insns=2450168 Pcycles=1761566
```

keyword benchmark after:
```
   text    data     bss     dec     hex filename
  49692   37487   46612  133791

Total: Insns=2438595 Pcycles=1751834
```


