### PR TITLE
Fixing style check container and calls to have it actually work corre…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Check
-        # TODO(#11): Update the docker image to be hosted via github packages.
-        uses: docker://jpwithers/tflite-micro-tests
+        # TODO(#11): Update the docker image to be hosted via tflm-bot's github packages.
+        uses: docker://ghcr.io/jwithersci/tflm_style:latest
         with:
-          args: /bin/sh -c "/opt/tflm/tensorflow/lite/micro/tools/ci_build/test_code_style.sh"
+          args: /bin/sh -c "tensorflow/lite/micro/tools/ci_build/test_code_style.sh"
 
   project_generation:
     runs-on: ubuntu-latest

--- a/ci/Dockerfile.stylechk
+++ b/ci/Dockerfile.stylechk
@@ -1,0 +1,24 @@
+# Use a prebuilt Python image instead of base Ubuntu to speed up the build process,
+# since it has all the build dependencies we need for Micro and downloads much faster
+# than the install process.
+FROM python:3.9.0-buster
+
+RUN echo deb http://apt.llvm.org/buster/ llvm-toolchain-buster-12 main > /etc/apt/sources.list.d/llvm.list
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+
+RUN apt-get update
+
+RUN apt-get install -y zip xxd sudo
+
+RUN apt-get install -y clang-12 clang-format-12
+# Set clang-12 and clang-format-12 as the default to ensure that the pigweed
+# formatting scripts use the desired version.
+RUN ln -s /usr/bin/clang-12 /usr/bin/clang
+RUN ln -s /usr/bin/clang++-12 /usr/bin/clang++
+RUN ln -s /usr/bin/clang-format-12 /usr/bin/clang-format
+
+RUN pip install six
+# Install Renode test dependencies
+RUN pip install pyyaml requests psutil robotframework==3.1
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Created a new container and modified the script call to work correctly against the current pull instead of running against a static copy. 

Tried to move this out of docker entirely but it turns out that getting the llvm buster toolchain running on the github action virtual environment descends into dependency hell pretty quickly. Dropped back to an ubuntu-18.04 runner, which is an ubuntu version based off Buster, but no joy. Given enough time I could probably sort it, but there are a crapload of packages that appear to already be installed and configured in the python:3.9.0 image, including libtinfo6 which after multiple rounds of having to install prereqs seems to be unavailable to the ubuntu-18.04 distro and that's when I decided way too much time had gone into pulling this out of a container. 

If we stick with this, it should be moved into the tflm-bot's ghcr space and the call changed to match.