### PR TITLE
Explicitly use python3 from the Makefile.

### DIFF
--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -560,7 +560,7 @@ ifneq ($(OPTIMIZED_KERNEL_DIR),)
 
   include $(MAKEFILE_DIR)/ext_libs/$(OPTIMIZED_KERNEL_DIR).inc
   # Specialize for the optimized kernels
-  MICROLITE_CC_KERNEL_SRCS := $(shell python $(MAKEFILE_DIR)/specialize_files.py \
+  MICROLITE_CC_KERNEL_SRCS := $(shell python3 $(MAKEFILE_DIR)/specialize_files.py \
 		--base_files "$(MICROLITE_CC_KERNEL_SRCS)" \
 		--specialize_directory $(PATH_TO_OPTIMIZED_KERNELS))
 endif


### PR DESCRIPTION
For the Xtensa docker container, we were getting an error message along the lines of `python not found`. And the result was that the specialization was happening incorrectly (i.e. the specialization for the kernels was failing since it relies on python since #160).

https://github.com/tensorflow/tflite-micro/issues/182 is likely the reason why this error passed the CI for #160 but started failing after.
