### PR TITLE
Workaround for Corstone-300 target

### DIFF
--- a/tensorflow/lite/micro/tools/make/targets/cortex_m_corstone_300_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/cortex_m_corstone_300_makefile.inc
@@ -16,6 +16,9 @@
 # ARM Cortex M makefile targeted for a FVP based on Arm Corstone-300 software.
 # For more info see: tensorflow/lite/micro/cortex_m_corstone_300/README.md
 
+# TODO(#193): Remove this.
+CORE_OPTIMIZATION_LEVEL := -O2
+
 export PATH := $(MAKEFILE_DIR)/downloads/corstone300/models/Linux64_GCC-6.4:$(PATH)
 DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/corstone_300_download.sh ${MAKEFILE_DIR}/downloads)
 ifneq ($(DOWNLOAD_RESULT), SUCCESS)


### PR DESCRIPTION
Overrides core optimization level from -Os to -O2.

This is a workaround for: https://github.com/tensorflow/tflite-micro/issues/193

I have tested it on a local PR and it seems to work: https://github.com/mansnils/tflite-micro/pull/3