### PR TITLE
Add support for 8x16 kernels in TFLM.

### DIFF
--- a/tensorflow/lite/micro/kernels/concatenation.cc
+++ b/tensorflow/lite/micro/kernels/concatenation.cc
@@ -147,8 +147,8 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_EQ(context, params->activation, kTfLiteActNone);
   TF_LITE_ENSURE(context,
                  input_type == kTfLiteFloat32 || input_type == kTfLiteUInt8 ||
-                     input_type == kTfLiteInt8 || input_type == kTfLiteInt32 ||
-                     input_type == kTfLiteInt64);
+                     input_type == kTfLiteInt8 || input_type == kTfLiteInt16 ||
+                     input_type == kTfLiteInt32 || input_type == kTfLiteInt64);
 
   // Output type must match input type
   TF_LITE_ENSURE_EQ(context, output_type, input_type);
@@ -182,6 +182,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 
   switch (output_type) {  // Already know in/outtypes are same.
     case kTfLiteFloat32:
+    case kTfLiteInt16:
     case kTfLiteInt32:
     case kTfLiteInt64: {
       data->params.axis = CalculatePositiveAxis(params->axis, output);
@@ -246,6 +247,9 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       break;
     case kTfLiteInt64:
       EvalUnquantized<int64_t>(context, node);
+      break;
+    case kTfLiteInt16:
+      EvalUnquantized<int16_t>(context, node);
       break;
 
     default:

--- a/tensorflow/lite/micro/kernels/concatenation_test.cc
+++ b/tensorflow/lite/micro/kernels/concatenation_test.cc
@@ -65,12 +65,12 @@ void TestConcatenateTwoInputs(int* input1_dims_data, const float* input1_data,
   }
 }
 
+template <typename T>
 void TestConcatenateQuantizedTwoInputs(
-    int* input1_dims_data, const uint8_t* input1_data, int* input2_dims_data,
-    const uint8_t* input2_data, const float input_scale,
-    const int input_zero_point, int axis, int* output_dims_data,
-    const uint8_t* expected_output_data, const float output_scale,
-    const int output_zero_point, uint8_t* output_data) {
+    int* input1_dims_data, const T* input1_data, int* input2_dims_data,
+    const T* input2_data, const float input_scale, const int input_zero_point,
+    int axis, int* output_dims_data, const T* expected_output_data,
+    const float output_scale, const int output_zero_point, T* output_data) {
   TfLiteIntArray* input1_dims = IntArrayFromInts(input1_dims_data);
   TfLiteIntArray* input2_dims = IntArrayFromInts(input2_dims_data);
   TfLiteIntArray* output_dims = IntArrayFromInts(output_dims_data);
@@ -176,6 +176,52 @@ TF_LITE_MICRO_TEST(TwoInputsQuantizedUint8) {
   };
 
   uint8_t output_data[8];
+  tflite::testing::TestConcatenateQuantizedTwoInputs(
+      input_shape, input1_values, input_shape, input2_values, input_scale,
+      input_zero_point, axis, output_shape, output_value, output_scale,
+      output_zero_point, output_data);
+}
+
+TF_LITE_MICRO_TEST(TwoInputsQuantizedInt8) {
+  const int axis = 2;
+  int input_shape[] = {3, 2, 1, 2};
+  int output_shape[] = {3, 2, 1, 4};
+
+  const float input_scale = 0.1f;
+  const int input_zero_point = 0;
+  const float output_scale = 0.1f;
+  const int output_zero_point = 0;
+
+  const int8_t input1_values[] = {1, 2, 3, 4};
+
+  const int8_t input2_values[] = {5, 6, 7, 8};
+
+  const int8_t output_value[] = {1, 2, 5, 6, 3, 4, 7, 8};
+
+  int8_t output_data[8];
+  tflite::testing::TestConcatenateQuantizedTwoInputs(
+      input_shape, input1_values, input_shape, input2_values, input_scale,
+      input_zero_point, axis, output_shape, output_value, output_scale,
+      output_zero_point, output_data);
+}
+
+TF_LITE_MICRO_TEST(TwoInputsQuantizedInt16) {
+  const int axis = 2;
+  int input_shape[] = {3, 2, 1, 2};
+  int output_shape[] = {3, 2, 1, 4};
+
+  const float input_scale = 0.1f;
+  const int input_zero_point = 0;
+  const float output_scale = 0.1f;
+  const int output_zero_point = 0;
+
+  const int16_t input1_values[] = {1, 2, 3, 4};
+
+  const int16_t input2_values[] = {5, 6, 7, 8};
+
+  const int16_t output_value[] = {1, 2, 5, 6, 3, 4, 7, 8};
+
+  int16_t output_data[8];
   tflite::testing::TestConcatenateQuantizedTwoInputs(
       input_shape, input1_values, input_shape, input2_values, input_scale,
       input_zero_point, axis, output_shape, output_value, output_scale,

--- a/tensorflow/lite/micro/kernels/conv_common.cc
+++ b/tensorflow/lite/micro/kernels/conv_common.cc
@@ -154,7 +154,7 @@ TfLiteStatus ConvPrepare(TfLiteContext* context, TfLiteNode* node) {
           context, num_channels * sizeof(int32_t)));
 
   // All per-channel quantized tensors need valid zero point and scale arrays.
-  if (input->type == kTfLiteInt8) {
+  if (input->type == kTfLiteInt8 || input->type == kTfLiteInt16) {
     TF_LITE_ENSURE_EQ(context, filter->quantization.type,
                       kTfLiteAffineQuantization);
 

--- a/tensorflow/lite/micro/kernels/conv_test.h
+++ b/tensorflow/lite/micro/kernels/conv_test.h
@@ -86,6 +86,17 @@ TfLiteStatus TestConvQuantizedPerChannel(
     float output_scale, int output_zero_point, TfLiteConvParams* conv_params,
     TfLiteRegistration registration, int8_t* output_data);
 
+TfLiteStatus TestConvQuantizedPerChannel(
+    int* input_dims_data, const float* input_data, int16_t* input_quantized,
+    float input_scale, int input_zero_point, int* filter_dims_data,
+    const float* filter_data, int8_t* filter_data_quantized,
+    int* bias_dims_data, const float* bias_data,
+    std::int64_t* bias_data_quantized, float* bias_scales,
+    int* bias_zero_points, int* output_dims_data,
+    const float* expected_output_data, int16_t* expected_output_data_quantized,
+    float output_scale, int output_zero_point, TfLiteConvParams* conv_params,
+    TfLiteRegistration registration, int16_t* output_data);
+
 }  // namespace testing
 }  // namespace tflite
 

--- a/tensorflow/lite/micro/kernels/conv_test_common.cc
+++ b/tensorflow/lite/micro/kernels/conv_test_common.cc
@@ -121,15 +121,16 @@ TfLiteStatus TestConvFloat(int* input_dims_data, const float* input_data,
                              output_data);
 }
 
+template <typename T, typename BiasT>
 TfLiteStatus TestConvQuantizedPerChannel(
-    int* input_dims_data, const float* input_data, int8_t* input_quantized,
+    int* input_dims_data, const float* input_data, T* input_quantized,
     float input_scale, int input_zero_point, int* filter_dims_data,
     const float* filter_data, int8_t* filter_data_quantized,
-    int* bias_dims_data, const float* bias_data, int32_t* bias_data_quantized,
+    int* bias_dims_data, const float* bias_data, BiasT* bias_data_quantized,
     float* bias_scales, int* bias_zero_points, int* output_dims_data,
-    const float* expected_output_data, int8_t* expected_output_data_quantized,
+    const float* expected_output_data, T* expected_output_data_quantized,
     float output_scale, int output_zero_point, TfLiteConvParams* conv_params,
-    TfLiteRegistration registration, int8_t* output_data) {
+    TfLiteRegistration registration, T* output_data) {
   TfLiteIntArray* input_dims = IntArrayFromInts(input_dims_data);
   TfLiteIntArray* filter_dims = IntArrayFromInts(filter_dims_data);
   TfLiteIntArray* bias_dims = IntArrayFromInts(bias_dims_data);
@@ -180,6 +181,43 @@ TfLiteStatus TestConvQuantizedPerChannel(
   return ValidateConvGoldens(
       tensors, tensors_size, expected_output_data_quantized, output_dims_count,
       conv_params, registration, output_data, 1.0 /* tolerance */);
+}
+
+TfLiteStatus TestConvQuantizedPerChannel(
+    int* input_dims_data, const float* input_data, int8_t* input_quantized,
+    float input_scale, int input_zero_point, int* filter_dims_data,
+    const float* filter_data, int8_t* filter_data_quantized,
+    int* bias_dims_data, const float* bias_data, int32_t* bias_data_quantized,
+    float* bias_scales, int* bias_zero_points, int* output_dims_data,
+    const float* expected_output_data, int8_t* expected_output_data_quantized,
+    float output_scale, int output_zero_point, TfLiteConvParams* conv_params,
+    TfLiteRegistration registration, int8_t* output_data) {
+  return TestConvQuantizedPerChannel<int8_t, int32_t>(
+      input_dims_data, input_data, input_quantized, input_scale,
+      input_zero_point, filter_dims_data, filter_data, filter_data_quantized,
+      bias_dims_data, bias_data, bias_data_quantized, bias_scales,
+      bias_zero_points, output_dims_data, expected_output_data,
+      expected_output_data_quantized, output_scale, output_zero_point,
+      conv_params, registration, output_data);
+}
+
+TfLiteStatus TestConvQuantizedPerChannel(
+    int* input_dims_data, const float* input_data, int16_t* input_quantized,
+    float input_scale, int input_zero_point, int* filter_dims_data,
+    const float* filter_data, int8_t* filter_data_quantized,
+    int* bias_dims_data, const float* bias_data,
+    std::int64_t* bias_data_quantized, float* bias_scales,
+    int* bias_zero_points, int* output_dims_data,
+    const float* expected_output_data, int16_t* expected_output_data_quantized,
+    float output_scale, int output_zero_point, TfLiteConvParams* conv_params,
+    TfLiteRegistration registration, int16_t* output_data) {
+  return TestConvQuantizedPerChannel<int16_t, std::int64_t>(
+      input_dims_data, input_data, input_quantized, input_scale,
+      input_zero_point, filter_dims_data, filter_data, filter_data_quantized,
+      bias_dims_data, bias_data, bias_data_quantized, bias_scales,
+      bias_zero_points, output_dims_data, expected_output_data,
+      expected_output_data_quantized, output_scale, output_zero_point,
+      conv_params, registration, output_data);
 }
 
 }  // namespace testing

--- a/tensorflow/lite/micro/kernels/leaky_relu.cc
+++ b/tensorflow/lite/micro/kernels/leaky_relu.cc
@@ -68,7 +68,7 @@ TfLiteStatus CalculateOpData(TfLiteContext* context, TfLiteNode* node) {
                     GetOutputSafe(context, node, kOutputTensor, &output));
   TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
 
-  if (output->type == kTfLiteInt8) {
+  if (output->type == kTfLiteInt8 || output->type == kTfLiteInt16) {
     LeakyReluOpData* data = static_cast<LeakyReluOpData*>(node->user_data);
     const auto* params =
         static_cast<TfLiteLeakyReluParams*>(node->builtin_data);
@@ -125,6 +125,10 @@ TfLiteStatus LeakyReluEval(TfLiteContext* context, TfLiteNode* node) {
     } break;
     case kTfLiteInt8: {
       QuantizeLeakyRelu<int8_t>(data, input, output);
+      return kTfLiteOk;
+    } break;
+    case kTfLiteInt16: {
+      QuantizeLeakyRelu<int16_t>(data, input, output);
       return kTfLiteOk;
     } break;
     default:

--- a/tensorflow/lite/micro/kernels/reshape_test.cc
+++ b/tensorflow/lite/micro/kernels/reshape_test.cc
@@ -231,10 +231,12 @@ TF_LITE_MICRO_TEST(ReshapeWithRegularShapesShouldSucceed) {
   float output_data_float[32];
   int8_t output_data_int8[32];
   uint8_t output_data_uint8[32];
+  int16_t output_data_int16[32];
   int input_dims[] = {4, 1, 2, 4, 1};
   const float input_float[] = {1, 2, 3, 4, 5, 6, 7, 8};
   const int8_t input_int8[] = {1, 2, 3, 4, 5, 6, 7, 8};
   const uint8_t input_uint8[] = {1, 2, 3, 4, 5, 6, 7, 8};
+  const int16_t input_int16[] = {1, 2, 3, 4, 5, 6, 7, 8};
   int shape_dims[] = {1, 3};
   const int32_t shape_int32[] = {2, 2, 2};
   int output_dims[] = {3, 2, 2, 2};
@@ -242,6 +244,7 @@ TF_LITE_MICRO_TEST(ReshapeWithRegularShapesShouldSucceed) {
   const float golden_output_float[] = {1, 2, 3, 4, 5, 6, 7, 8};
   const int8_t golden_output_int8[] = {1, 2, 3, 4, 5, 6, 7, 8};
   const uint8_t golden_output_uint8[] = {1, 2, 3, 4, 5, 6, 7, 8};
+  const int16_t golden_output_int16[] = {1, 2, 3, 4, 5, 6, 7, 8};
   const int golden_dims_len = 3;
   int golden_dims[] = {2, 2, 2};
   tflite::testing::TestReshape(input_dims, input_float, shape_dims, shape_int32,
@@ -256,6 +259,10 @@ TF_LITE_MICRO_TEST(ReshapeWithRegularShapesShouldSucceed) {
       input_dims, input_uint8, shape_dims, shape_int32, output_dims,
       output_data_uint8, golden_output_uint8, golden_output_len, golden_dims,
       golden_dims_len, false);
+  tflite::testing::TestReshapeQuantized(
+      input_dims, input_int16, shape_dims, shape_int32, output_dims,
+      output_data_int16, golden_output_int16, golden_output_len, golden_dims,
+      golden_dims_len, false);
 }
 
 // Stretch is not supported with TF Micro
@@ -263,10 +270,12 @@ TF_LITE_MICRO_TEST(ReshapeWithStretchDimensionShouldSucceed) {
   float output_data_float[32];
   int8_t output_data_int8[32];
   uint8_t output_data_uint8[32];
+  int16_t output_data_int16[32];
   int input_dims[] = {4, 1, 2, 4, 1};
   const float input_float[] = {1, 2, 3, 4, 5, 6, 7, 8};
   const int8_t input_int8[] = {1, 2, 3, 4, 5, 6, 7, 8};
   const uint8_t input_uint8[] = {1, 2, 3, 4, 5, 6, 7, 8};
+  const int16_t input_int16[] = {1, 2, 3, 4, 5, 6, 7, 8};
   int shape_dims[] = {1, 3};
   const int32_t shape_int32[] = {2, 1, -1};
   int output_dims[] = {3, 2, 1, -1};
@@ -274,6 +283,7 @@ TF_LITE_MICRO_TEST(ReshapeWithStretchDimensionShouldSucceed) {
   const float golden_output_float[] = {1, 2, 3, 4, 5, 6, 7, 8};
   const int8_t golden_output_int8[] = {1, 2, 3, 4, 5, 6, 7, 8};
   const uint8_t golden_output_uint8[] = {1, 2, 3, 4, 5, 6, 7, 8};
+  const int16_t golden_output_int16[] = {1, 2, 3, 4, 5, 6, 7, 8};
   const int golden_dims_len = 3;
   int golden_dims[] = {2, 1, 4};
   tflite::testing::TestReshape(input_dims, input_float, shape_dims, shape_int32,
@@ -287,6 +297,10 @@ TF_LITE_MICRO_TEST(ReshapeWithStretchDimensionShouldSucceed) {
   tflite::testing::TestReshapeQuantized(
       input_dims, input_uint8, shape_dims, shape_int32, output_dims,
       output_data_uint8, golden_output_uint8, golden_output_len, golden_dims,
+      golden_dims_len, false);
+  tflite::testing::TestReshapeQuantized(
+      input_dims, input_int16, shape_dims, shape_int32, output_dims,
+      output_data_int16, golden_output_int16, golden_output_len, golden_dims,
       golden_dims_len, false);
 }
 

--- a/tensorflow/lite/micro/kernels/strided_slice.cc
+++ b/tensorflow/lite/micro/kernels/strided_slice.cc
@@ -167,6 +167,13 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                                   tflite::micro::GetTensorShape(output),
                                   tflite::micro::GetTensorData<int8_t>(output));
       break;
+    case kTfLiteInt16:
+      reference_ops::StridedSlice(
+          op_params, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int16_t>(input),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int16_t>(output));
+      break;
     default:
       TF_LITE_KERNEL_LOG(context, "Type %s (%d) not supported.",
                          TfLiteTypeGetName(input->type), input->type);

--- a/tensorflow/lite/micro/kernels/strided_slice_test.cc
+++ b/tensorflow/lite/micro/kernels/strided_slice_test.cc
@@ -1071,4 +1071,25 @@ TF_LITE_MICRO_TEST(In3D_IdentityShrinkAxis1int8) {
       golden, false);
 }
 
+TF_LITE_MICRO_TEST(In3D_IdentityShrinkAxis1int16) {
+  int input_shape[] = {3, 2, 3, 2};
+  int begin_shape[] = {1, 3};
+  int end_shape[] = {1, 3};
+  int strides_shape[] = {1, 3};
+  int output_shape[] = {2, 3, 2};
+  int16_t input_data[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  int32_t begin_data[] = {0, 0, 0};
+  int32_t end_data[] = {1, 3, 2};
+  int32_t strides_data[] = {1, 1, 1};
+  int16_t golden[] = {1, 2, 3, 4, 5, 6};
+  int16_t output_data[12];
+
+  TfLiteStridedSliceParams builtin_data = {0, 0, 0, 0, 1};
+
+  tflite::testing::TestStridedSliceQuantized(
+      input_shape, begin_shape, end_shape, strides_shape, &builtin_data,
+      input_data, begin_data, end_data, strides_data, output_shape, output_data,
+      golden, false);
+}
+
 TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/kernels/sub_test.cc
+++ b/tensorflow/lite/micro/kernels/sub_test.cc
@@ -303,6 +303,27 @@ TF_LITE_MICRO_TEST(QuantizedSubActivationRelu1Int8) {
       kTfLiteActReluN1To1, output);
 }
 
+TF_LITE_MICRO_TEST(QuantizedSubActivationRelu1Int16) {
+  const float scales[] = {0.25, 0.5, 1.0};
+  const int zero_points[] = {0, 0, 0};
+  const int output_dims_count = 4;
+  int inout_shape[] = {4, 1, 2, 2, 1};
+  const float input1_values[] = {-2.01, -1.01, -0.01, 0.98};
+  const float input2_values[] = {-1.01, -1.99, -2.99, -4.02};
+  const float golden_values[] = {-1, 1, 1, 1};
+
+  int16_t input1_quantized[output_dims_count];
+  int16_t input2_quantized[output_dims_count];
+  int16_t golden_quantized[output_dims_count];
+  int16_t output[output_dims_count];
+
+  tflite::testing::TestSubQuantized(
+      inout_shape, input1_values, input1_quantized, scales[0], zero_points[0],
+      inout_shape, input2_values, input2_quantized, scales[1], zero_points[1],
+      inout_shape, golden_values, golden_quantized, scales[2], zero_points[2],
+      kTfLiteActReluN1To1, output);
+}
+
 TF_LITE_MICRO_TEST(QuantizedSubVariousInputShapesUint8) {
   const float scales[] = {0.1, 0.05, 0.1};
   const int zero_points[] = {120, 130, 139};
@@ -357,6 +378,38 @@ TF_LITE_MICRO_TEST(QuantizedSubVariousInputShapesInt8) {
   int8_t input2_quantized[output_dims_count];
   int8_t golden_quantized[output_dims_count];
   int8_t output[output_dims_count];
+
+  for (int i = 0; i < num_shapes; i++) {
+    tflite::testing::TestSubQuantized(
+        test_shapes[i], input1_values, input1_quantized, scales[0],
+        zero_points[0], test_shapes[i], input2_values, input2_quantized,
+        scales[1], zero_points[1], test_shapes[i], golden_values,
+        golden_quantized, scales[2], zero_points[2], kTfLiteActNone, output);
+  }
+}
+
+TF_LITE_MICRO_TEST(QuantizedSubVariousInputShapesInt16) {
+  const float scales[] = {0.1, 0.05, 0.1};
+  const int zero_points[] = {0, 0, 0};
+  const int output_dims_count = 6;
+
+  constexpr int num_shapes = 4;
+  constexpr int max_shape_size = 5;
+  int test_shapes[num_shapes][max_shape_size] = {
+      {1, 6},
+      {2, 2, 3},
+      {3, 2, 1, 3},
+      {4, 1, 3, 1, 2},
+  };
+
+  const float input1_values[] = {-2.0, 0.2, 0.7, 0.8, 1.1, 2.0};
+  const float input2_values[] = {-0.1, -0.2, -0.3, -0.5, -1.1, -0.1};
+  const float golden_values[] = {-1.9, 0.4, 1.0, 1.3, 2.2, 2.1};
+
+  int16_t input1_quantized[output_dims_count];
+  int16_t input2_quantized[output_dims_count];
+  int16_t golden_quantized[output_dims_count];
+  int16_t output[output_dims_count];
 
   for (int i = 0; i < num_shapes; i++) {
     tflite::testing::TestSubQuantized(
@@ -448,6 +501,40 @@ TF_LITE_MICRO_TEST(QuantizedSubWithScalarBroadcastInt8) {
   }
 }
 
+TF_LITE_MICRO_TEST(QuantizedSubWithScalarBroadcastInt16) {
+  const int output_dims_count = 6;
+
+  const float input1_values[] = {-2.0, 0.2, 0.7, 0.8, 1.1, 2.0};
+  int input2_shape[] = {0};
+  const float input2_values[] = {-0.1};
+  const float golden[] = {-1.9, 0.3, 0.8, 0.9, 1.2, 2.1};
+
+  constexpr int num_shapes = 4;
+  constexpr int max_shape_size = 5;
+  int test_shapes[num_shapes][max_shape_size] = {
+      {1, 6},
+      {2, 2, 3},
+      {3, 2, 1, 3},
+      {4, 1, 3, 1, 2},
+  };
+
+  const float scales[] = {0.1, 0.05, 0.05};
+  const int zero_points[] = {0, 0, 0};
+
+  int16_t input1_quantized[output_dims_count];
+  int16_t input2_quantized[output_dims_count];
+  int16_t golden_quantized[output_dims_count];
+  int16_t output[output_dims_count];
+
+  for (int i = 0; i < num_shapes; ++i) {
+    tflite::testing::TestSubQuantized(
+        test_shapes[i], input1_values, input1_quantized, scales[0],
+        zero_points[0], input2_shape, input2_values, input2_quantized,
+        scales[1], zero_points[1], test_shapes[i], golden, golden_quantized,
+        scales[2], zero_points[2], kTfLiteActNone, output);
+  }
+}
+
 TF_LITE_MICRO_TEST(QuantizedSubWithMixedBroadcastUint8) {
   const float scales[] = {0.1, 0.05, 0.1};
   const int zero_points[] = {127, 131, 139};
@@ -475,6 +562,26 @@ TF_LITE_MICRO_TEST(QuantizedSubWithMixedBroadcastInt8) {
   int8_t input2_quantized[tflite::testing::broadcast_output_dims_count];
   int8_t golden_quantized[tflite::testing::broadcast_output_dims_count];
   int8_t output[tflite::testing::broadcast_output_dims_count];
+
+  for (int i = 0; i < tflite::testing::broadcast_num_shapes; ++i) {
+    tflite::testing::TestSubQuantized(
+        tflite::testing::broadcast_input1_shape,
+        tflite::testing::broadcast_input1_values, input1_quantized, scales[0],
+        zero_points[0], tflite::testing::broadcast_input2_shapes[i],
+        tflite::testing::broadcast_input2_values, input2_quantized, scales[1],
+        zero_points[1], tflite::testing::broadcast_output_shapes[i],
+        tflite::testing::broadcast_goldens[i], golden_quantized, scales[2],
+        zero_points[2], kTfLiteActNone, output);
+  }
+}
+
+TF_LITE_MICRO_TEST(QuantizedSubWithMixedBroadcastInt16) {
+  const float scales[] = {0.1, 0.05, 0.1};
+  const int zero_points[] = {0, 0, 0};
+  int16_t input1_quantized[tflite::testing::broadcast_output_dims_count];
+  int16_t input2_quantized[tflite::testing::broadcast_output_dims_count];
+  int16_t golden_quantized[tflite::testing::broadcast_output_dims_count];
+  int16_t output[tflite::testing::broadcast_output_dims_count];
 
   for (int i = 0; i < tflite::testing::broadcast_num_shapes; ++i) {
     tflite::testing::TestSubQuantized(

--- a/tensorflow/lite/micro/kernels/transpose_conv.cc
+++ b/tensorflow/lite/micro/kernels/transpose_conv.cc
@@ -153,8 +153,17 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
                       &(data->scratch_buffer_index)) == kTfLiteOk);
   }
 
+  // Quantized 16x8 kernels use an int64 scratch buffer.
+  if (input->type == kTfLiteInt16) {
+    TFLITE_DCHECK(context->RequestScratchBufferInArena != nullptr);
+    TFLITE_DCHECK(context->RequestScratchBufferInArena(
+                      context,
+                      GetTensorShape(output).FlatSize() * sizeof(std::int64_t),
+                      &(data->scratch_buffer_index)) == kTfLiteOk);
+  }
+
   // All per-channel quantized tensors need valid zero point and scale arrays.
-  if (input->type == kTfLiteInt8) {
+  if (input->type == kTfLiteInt8 || input->type == kTfLiteInt16) {
     TF_LITE_ENSURE_EQ(context, filter->quantization.type,
                       kTfLiteAffineQuantization);
 
@@ -211,8 +220,11 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   const OpData& data = *(static_cast<const OpData*>(node->user_data));
 
   TF_LITE_ENSURE_EQ(context, input->type, output->type);
-  TF_LITE_ENSURE_MSG(context, input->type == filter->type,
-                     "Hybrid models are not supported on TFLite Micro.");
+  TF_LITE_ENSURE_MSG(
+      context,
+      input->type == filter->type ||
+          (input->type == kTfLiteInt16 && filter->type == kTfLiteInt8),
+      "Hybrid models are not supported on TFLite Micro.");
 
   switch (input->type) {  // Already know in/out types are same.
     case kTfLiteFloat32: {
@@ -241,6 +253,22 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           tflite::micro::GetTensorData<int32_t>(bias),
           tflite::micro::GetTensorShape(output),
           tflite::micro::GetTensorData<int8_t>(output),
+          tflite::micro::GetTensorShape(nullptr), nullptr, scratch_buffer);
+      break;
+    }
+    case kTfLiteInt16: {
+      std::int64_t* scratch_buffer = static_cast<int64_t*>(
+          context->GetScratchBuffer(context, data.scratch_buffer_index));
+      reference_integer_ops::TransposeConv(
+          data.params, data.per_channel_output_multiplier,
+          data.per_channel_output_shift, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int16_t>(input),
+          tflite::micro::GetTensorShape(filter),
+          tflite::micro::GetTensorData<int8_t>(filter),
+          tflite::micro::GetTensorShape(bias),
+          tflite::micro::GetTensorData<std::int64_t>(bias),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int16_t>(output),
           tflite::micro::GetTensorShape(nullptr), nullptr, scratch_buffer);
       break;
     }

--- a/tensorflow/lite/micro/kernels/transpose_conv_test.cc
+++ b/tensorflow/lite/micro/kernels/transpose_conv_test.cc
@@ -171,6 +171,54 @@ TfLiteStatus TestTransposeConvQuantized(
       tensors, tensors_size, expected_output_quantized, output_dims_count,
       conv_params, output_data, 1.0f);
 }
+
+TfLiteStatus TestTransposeConvQuantized(
+    int* input_dims_data, const float* input_data, int16_t* input_quantized,
+    float input_scale, int input_zero_point, int* filter_dims_data,
+    const float* filter_data, int8_t* filter_quantized, float filter_scale,
+    int* bias_dims_data, const float* bias_data, std::int64_t* bias_quantized,
+    float* bias_scales, int* bias_zero_points, int* output_dims_data,
+    const float* expected_output_data, int16_t* expected_output_quantized,
+    float output_scale, int output_zero_point, TfLiteConvParams* conv_params,
+    int16_t* output_data) {
+  TfLiteIntArray* input_dims = IntArrayFromInts(input_dims_data);
+  TfLiteIntArray* filter_dims = IntArrayFromInts(filter_dims_data);
+  TfLiteIntArray* bias_dims = IntArrayFromInts(bias_dims_data);
+  TfLiteIntArray* output_dims = IntArrayFromInts(output_dims_data);
+  const int output_dims_count = ElementCount(*output_dims);
+
+  int filter_zero_points[5];
+  float filter_scales[5];
+  TfLiteAffineQuantization filter_quant;
+  TfLiteTensor filter_tensor = CreateSymmetricPerChannelQuantizedTensor(
+      filter_data, filter_quantized, filter_dims, filter_scales,
+      filter_zero_points, &filter_quant, 0 /* quantized dimension */);
+  tflite::Quantize(expected_output_data, expected_output_quantized,
+                   output_dims_count, output_scale, 0);
+
+  int output_shape_dims_data[] = {1, 0};
+  int32_t* output_shape = nullptr;
+  TfLiteIntArray* output_shape_dims = IntArrayFromInts(output_shape_dims_data);
+
+  constexpr int inputs_size = 4;
+  constexpr int outputs_size = 1;
+  constexpr int tensors_size = inputs_size + outputs_size;
+  TfLiteTensor tensors[tensors_size] = {
+      CreateTensor(output_shape, output_shape_dims), filter_tensor,
+      CreateQuantizedTensor(input_data, input_quantized, input_dims,
+                            input_scale, input_zero_point),
+      CreateQuantizedBiasTensor(bias_data, bias_quantized, bias_dims,
+                                input_scale, filter_scale),
+      CreateQuantizedTensor(output_data, output_dims, output_scale,
+                            output_zero_point)};
+
+  // Tolerance is slightly looser for 8x16 compared with float, since quant
+  // error is more pronounced on the finer-grained 16-bit output.
+  return ValidateTransposeConvGoldens(
+      tensors, tensors_size, expected_output_quantized, output_dims_count,
+      conv_params, output_data, 4.0f);
+}
+
 }  // namespace
 }  // namespace testing
 }  // namespace tflite
@@ -194,7 +242,7 @@ TF_LITE_MICRO_TEST(SimpleTestQuantizedPerChannel) {
   int8_t output_data[tflite::testing::kOutputElements];
 
   const float input_scale = 0.5f;
-  const float output_scale = 1.0f;
+  const float output_scale = 30.0f;
   const float filter_scale = 1.0f;
   const int input_zero_point = 0;
   const int output_zero_point = 0;
@@ -203,6 +251,35 @@ TF_LITE_MICRO_TEST(SimpleTestQuantizedPerChannel) {
   int8_t filter_quantized[tflite::testing::kFilterElements];
   int32_t bias_quantized[tflite::testing::kBiasElements];
   int8_t golden_quantized[tflite::testing::kOutputElements];
+  int zero_points[tflite::testing::kBiasElements + 1];
+  float scales[tflite::testing::kBiasElements + 1];
+
+  TF_LITE_MICRO_EXPECT_EQ(
+      kTfLiteOk,
+      tflite::testing::TestTransposeConvQuantized(
+          tflite::testing::kInputShape, tflite::testing::kInputData,
+          input_quantized, input_scale, input_zero_point,
+          tflite::testing::kFilterShape, tflite::testing::kFilterData,
+          filter_quantized, filter_scale, tflite::testing::kBiasShape,
+          tflite::testing::kBiasData, bias_quantized, scales, zero_points,
+          tflite::testing::kOutputShape, tflite::testing::kGoldenData,
+          golden_quantized, output_scale, output_zero_point,
+          &tflite::testing::common_conv_params, output_data));
+}
+
+TF_LITE_MICRO_TEST(SimpleTestQuantized16x8PerChannel) {
+  int16_t output_data[tflite::testing::kOutputElements];
+
+  const float input_scale = 1.0f;
+  const float output_scale = 1.0f;
+  const float filter_scale = 1.0f;
+  const int input_zero_point = 0;
+  const int output_zero_point = 0;
+
+  int16_t input_quantized[tflite::testing::kInputElements];
+  int8_t filter_quantized[tflite::testing::kFilterElements];
+  std::int64_t bias_quantized[tflite::testing::kBiasElements];
+  int16_t golden_quantized[tflite::testing::kOutputElements];
   int zero_points[tflite::testing::kBiasElements + 1];
   float scales[tflite::testing::kBiasElements + 1];
 

--- a/tensorflow/lite/micro/micro_utils.h
+++ b/tensorflow/lite/micro/micro_utils.h
@@ -44,11 +44,11 @@ T FloatToQuantizedType(const float value, const float scale, int zero_point) {
 
 template <typename T>
 T FloatToSymmetricQuantizedType(const float value, const float scale) {
-  int32_t result = round(value / scale);
-  result =
-      std::max(static_cast<int32_t>(std::numeric_limits<T>::min() + 1), result);
-  result =
-      std::min(static_cast<int32_t>(std::numeric_limits<T>::max()), result);
+  std::int64_t result = round(value / scale);
+  result = std::max(
+      static_cast<std::int64_t>(std::numeric_limits<T>::min() + 1), result);
+  result = std::min(static_cast<std::int64_t>(std::numeric_limits<T>::max()),
+                    result);
   return result;
 }
 

--- a/tensorflow/lite/micro/micro_utils.h
+++ b/tensorflow/lite/micro/micro_utils.h
@@ -44,6 +44,8 @@ T FloatToQuantizedType(const float value, const float scale, int zero_point) {
 
 template <typename T>
 T FloatToSymmetricQuantizedType(const float value, const float scale) {
+  // 64-bit values are required since 8x16 conv accumulates to int64, meaning
+  // an int64 bias is required.
   std::int64_t result = round(value / scale);
   result = std::max(
       static_cast<std::int64_t>(std::numeric_limits<T>::min() + 1), result);

--- a/tensorflow/lite/micro/test_helpers.cc
+++ b/tensorflow/lite/micro/test_helpers.cc
@@ -1212,11 +1212,27 @@ TfLiteTensor CreateQuantizedBiasTensor(const float* data, int32_t* quantized,
   return result;
 }
 
+TfLiteTensor CreateQuantizedBiasTensor(const float* data,
+                                       std::int64_t* quantized,
+                                       TfLiteIntArray* dims, float input_scale,
+                                       float weights_scale, bool is_variable) {
+  float bias_scale = input_scale * weights_scale;
+  tflite::SymmetricQuantize(data, quantized, ElementCount(*dims), bias_scale);
+
+  // Quantized int32_t tensors always have a zero point of 0, since the range of
+  // int32_t values is large, and because zero point costs extra cycles during
+  // processing.
+  TfLiteTensor result =
+      CreateQuantizedTensor(quantized, dims, bias_scale, 0, is_variable);
+  return result;
+}
+
 // Quantizes int32_t bias tensor with per-channel weights determined by input
 // scale multiplied by weight scale for each channel.
+template <typename T>
 TfLiteTensor CreatePerChannelQuantizedBiasTensor(
-    const float* input, int32_t* quantized, TfLiteIntArray* dims,
-    float input_scale, float* weight_scales, float* scales, int* zero_points,
+    const float* input, T* quantized, TfLiteIntArray* dims, float input_scale,
+    float* weight_scales, float* scales, int* zero_points,
     TfLiteAffineQuantization* affine_quant, int quantized_dimension,
     bool is_variable) {
   int input_size = ElementCount(*dims);
@@ -1230,8 +1246,8 @@ TfLiteTensor CreatePerChannelQuantizedBiasTensor(
     zero_points[i + 1] = 0;
   }
 
-  SymmetricPerChannelQuantize<int32_t>(input, quantized, input_size,
-                                       num_channels, scales_array);
+  SymmetricPerChannelQuantize<T>(input, quantized, input_size, num_channels,
+                                 scales_array);
 
   affine_quant->scale = FloatArrayFromFloats(scales);
   affine_quant->zero_point = IntArrayFromInts(zero_points);
@@ -1240,6 +1256,26 @@ TfLiteTensor CreatePerChannelQuantizedBiasTensor(
   TfLiteTensor result = CreateTensor(quantized, dims, is_variable);
   result.quantization = {kTfLiteAffineQuantization, affine_quant};
   return result;
+}
+
+TfLiteTensor CreatePerChannelQuantizedBiasTensor(
+    const float* input, int32_t* quantized, TfLiteIntArray* dims,
+    float input_scale, float* weight_scales, float* scales, int* zero_points,
+    TfLiteAffineQuantization* affine_quant, int quantized_dimension,
+    bool is_variable) {
+  return CreatePerChannelQuantizedBiasTensor<int32_t>(
+      input, quantized, dims, input_scale, weight_scales, scales, zero_points,
+      affine_quant, quantized_dimension, is_variable);
+}
+
+TfLiteTensor CreatePerChannelQuantizedBiasTensor(
+    const float* input, std::int64_t* quantized, TfLiteIntArray* dims,
+    float input_scale, float* weight_scales, float* scales, int* zero_points,
+    TfLiteAffineQuantization* affine_quant, int quantized_dimension,
+    bool is_variable) {
+  return CreatePerChannelQuantizedBiasTensor<std::int64_t>(
+      input, quantized, dims, input_scale, weight_scales, scales, zero_points,
+      affine_quant, quantized_dimension, is_variable);
 }
 
 TfLiteTensor CreateSymmetricPerChannelQuantizedTensor(

--- a/tensorflow/lite/micro/test_helpers.h
+++ b/tensorflow/lite/micro/test_helpers.h
@@ -211,10 +211,24 @@ TfLiteTensor CreateQuantizedBiasTensor(const float* data, int32_t* quantized,
                                        float weights_scale,
                                        bool is_variable = false);
 
+TfLiteTensor CreateQuantizedBiasTensor(const float* data,
+                                       std::int64_t* quantized,
+                                       TfLiteIntArray* dims, float input_scale,
+                                       float weights_scale,
+                                       bool is_variable = false);
+
 // Quantizes int32_t bias tensor with per-channel weights determined by input
 // scale multiplied by weight scale for each channel.
 TfLiteTensor CreatePerChannelQuantizedBiasTensor(
     const float* input, int32_t* quantized, TfLiteIntArray* dims,
+    float input_scale, float* weight_scales, float* scales, int* zero_points,
+    TfLiteAffineQuantization* affine_quant, int quantized_dimension,
+    bool is_variable = false);
+
+// Quantizes int64_t bias tensor with per-channel weights determined by input
+// scale multiplied by weight scale for each channel.
+TfLiteTensor CreatePerChannelQuantizedBiasTensor(
+    const float* input, std::int64_t* quantized, TfLiteIntArray* dims,
     float input_scale, float* weight_scales, float* scales, int* zero_points,
     TfLiteAffineQuantization* affine_quant, int quantized_dimension,
     bool is_variable = false);


### PR DESCRIPTION
Add support for 8x16 kernels in TFLM.

Support 16-bit activations and 8-bit weights for a subset of the TFLM kernels.

BUG=http://b/184839019