### PR TITLE
Add BUG=<reason> to sync PR description (required after #187)

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -53,7 +53,7 @@ jobs:
           commit-message: Automated sync from github.com/tensorflow/tensorflow
           committer: TFLM-bot <tflm-github-bot@google.com>
           author: TFLM-bot <tflm-github-bot@google.com>
-          body: ""
+          body: "BUG=automated sync from upstream"
           labels: bot:sync-tf, ci:run
           reviewers: advaitjain
 


### PR DESCRIPTION
Without this change, the sync PRs will fail the required `Check PR Has Bug` presubmit check.

BUG=small change to improve workflow.