### PR TITLE
Updated QC implementation no longer needs additional arena for keyword_benchmark.

### DIFF
--- a/tensorflow/lite/micro/benchmarks/keyword_benchmark.cc
+++ b/tensorflow/lite/micro/benchmarks/keyword_benchmark.cc
@@ -37,16 +37,9 @@ namespace tflite {
 using KeywordBenchmarkRunner = MicroBenchmarkRunner<int16_t>;
 using KeywordOpResolver = MicroMutableOpResolver<6>;
 
-#if defined(HEXAGON)
-// TODO(b/174781826): reduce arena usage for optimized Hexagon kernels.
-constexpr int kOptimizedKernelArenaIncrement = 21000;
-#else
-constexpr int kOptimizedKernelArenaIncrement = 0;
-#endif
-
 // Create an area of memory to use for input, output, and intermediate arrays.
 // Align arena to 16 bytes to avoid alignment warnings on certain platforms.
-constexpr int kTensorArenaSize = 21 * 1024 + kOptimizedKernelArenaIncrement;
+constexpr int kTensorArenaSize = 21 * 1024;
 alignas(16) uint8_t tensor_arena[kTensorArenaSize];
 
 uint8_t benchmark_runner_buffer[sizeof(KeywordBenchmarkRunner)];


### PR DESCRIPTION
Verified that the following commands work:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=hexagon OPTIMIZED_KERNEL_DIR=hexagon OPTIMIZED_KERNEL_DIR_PREFIX=third_party HEXAGON_TFLM_LIB=~/Qualcomm/tflm_google/hexagon_tflm_core.a test_kernel_fully_connected_test
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=hexagon OPTIMIZED_KERNEL_DIR=hexagon OPTIMIZED_KERNEL_DIR_PREFIX=third_party HEXAGON_TFLM_LIB=~/Qualcomm/tflm_google/hexagon_tflm_core.a test_kernel_svdf_test
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=hexagon OPTIMIZED_KERNEL_DIR=hexagon OPTIMIZED_KERNEL_DIR_PREFIX=third_party HEXAGON_TFLM_LIB=~/Qualcomm/tflm_google/hexagon_tflm_core.a run_keyword_benchmark
```

BUG=http://b/174781826
