### PR TITLE
Allow specialize_files to be given an invalid directory.

### DIFF
--- a/tensorflow/lite/micro/tools/make/specialize_files.py
+++ b/tensorflow/lite/micro/tools/make/specialize_files.py
@@ -21,6 +21,11 @@ import os
 # same name in base_file_list and returns a list containing all the files as a
 # result of this specialization merge.
 def _specialize_files(base_file_list, directory):
+  # If the specialized directory is not a valid path, then return the
+  # base_file_list.
+  if not os.path.isdir(directory):
+    return base_file_list
+
   specialize_files = os.listdir(directory)
   specialized_list = []
   for fpath in base_file_list:


### PR DESCRIPTION
The TFLM Makefile itself ensures that `OPTIMIZED_KERNEL_DIR` is a valid path. However, for some special cases (such as http://cl/379964344), we would like to allow the specialization to gracefully handle a directory that does not exist in the tree.

BUG=see use-case from http://cl/379964344