### PR TITLE
Up the maximum number of profiled events to 1024

### DIFF
--- a/tensorflow/lite/micro/micro_profiler.h
+++ b/tensorflow/lite/micro/micro_profiler.h
@@ -60,7 +60,7 @@ class MicroProfiler {
   // Maximum number of events that this class can keep track of. If we call
   // AddEvent more than kMaxEvents number of times, then the oldest event's
   // profiling information will be overwritten.
-  static constexpr int kMaxEvents = 50;
+  static constexpr int kMaxEvents = 1024;
 
   const char* tags_[kMaxEvents];
   int32_t start_ticks_[kMaxEvents];


### PR DESCRIPTION
Lots of large models have >50 ops, so upping the max number to 1024 seems reasonable. Most TFLM models should not exceed 1024 ops.

BUG=http://b/192301172