### PR TITLE
Check for the case where the Operators vector in a tflite model is missing

### DIFF
--- a/tensorflow/lite/micro/BUILD
+++ b/tensorflow/lite/micro/BUILD
@@ -113,6 +113,7 @@ cc_library(
     srcs = ["flatbuffer_utils.cc"],
     hdrs = ["flatbuffer_utils.h"],
     deps = [
+	"//tensorflow/lite/schema:schema_fbs",
         "@flatbuffers//:runtime_cc",
     ],
 )

--- a/tensorflow/lite/micro/BUILD
+++ b/tensorflow/lite/micro/BUILD
@@ -114,7 +114,7 @@ cc_library(
     srcs = ["flatbuffer_utils.cc"],
     hdrs = ["flatbuffer_utils.h"],
     deps = [
-	"//tensorflow/lite/schema:schema_fbs",
+        "//tensorflow/lite/schema:schema_fbs",
         "@flatbuffers//:runtime_cc",
     ],
 )

--- a/tensorflow/lite/micro/BUILD
+++ b/tensorflow/lite/micro/BUILD
@@ -92,6 +92,7 @@ cc_library(
     ],
     copts = micro_copts(),
     deps = [
+        ":flatbuffer_utils",
         ":memory_helpers",
         ":micro_compatibility",
         ":micro_error_reporter",

--- a/tensorflow/lite/micro/build_def.bzl
+++ b/tensorflow/lite/micro/build_def.bzl
@@ -1,2 +1,3 @@
 def micro_copts():
-    return []
+
+    return ["-DFLATBUFFERS_LOCALE_INDEPENDENT=0"]

--- a/tensorflow/lite/micro/build_def.bzl
+++ b/tensorflow/lite/micro/build_def.bzl
@@ -1,3 +1,2 @@
 def micro_copts():
-
-    return ["-DFLATBUFFERS_LOCALE_INDEPENDENT=0"]
+    return []

--- a/tensorflow/lite/micro/examples/hello_world/BUILD
+++ b/tensorflow/lite/micro/examples/hello_world/BUILD
@@ -72,7 +72,6 @@ cc_binary(
     ],
     copts = [
         "-Werror",
-        "-Wdouble-promotion",
         "-Wsign-compare",
     ],
     deps = [

--- a/tensorflow/lite/micro/examples/magic_wand/BUILD
+++ b/tensorflow/lite/micro/examples/magic_wand/BUILD
@@ -142,7 +142,6 @@ cc_binary(
     ],
     copts = [
         "-Werror",
-        "-Wdouble-promotion",
         "-Wsign-compare",
     ],
     deps = [

--- a/tensorflow/lite/micro/flatbuffer_utils.cc
+++ b/tensorflow/lite/micro/flatbuffer_utils.cc
@@ -47,4 +47,18 @@ float FlexbufferWrapper::ElementAsFloat(size_t i) const {
   return static_cast<float>(FlexbufferWrapper::ElementAsDouble(i));
 }
 
+// TODO(b/192589496): Ops must always be there. Remove this function when fixed
+uint32_t NumSubgraphOperators(const SubGraph* subgraph) {
+  if (subgraph->operators() != nullptr) {
+    return subgraph->operators()->size();
+  } else {
+    return 0;
+  }
+}
+// TODO(b/192589496): Ops must always be there. Remove this function when fixed
+uint32_t NumSubgraphOperators(const Model* model, int subgraph_idx) {
+  const SubGraph* subgraph = model->subgraphs()->Get(subgraph_idx);
+  return NumSubgraphOperators(subgraph);
+}
+
 }  // namespace tflite

--- a/tensorflow/lite/micro/flatbuffer_utils.h
+++ b/tensorflow/lite/micro/flatbuffer_utils.h
@@ -17,7 +17,9 @@ limitations under the License.
 #define THIRD_PARTY_TFLITE_MICRO_TENSORFLOW_LITE_MICRO_FLATBUFFER_UTILS_H_
 
 #define FLATBUFFERS_LOCALE_INDEPENDENT 0
+#include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/flexbuffers.h"
+#include "tensorflow/lite/schema/schema_generated.h"
 
 namespace tflite {
 // Kernels use flexbuffers::Map to pack their init parameters in a tflite file,
@@ -45,6 +47,10 @@ class FlexbufferWrapper : public flexbuffers::Vector {
   double ElementAsDouble(size_t i) const;
   float ElementAsFloat(size_t i) const;
 };
+
+// Return the number of operators in a subgraph tflite
+uint32_t NumSubgraphOperators(const SubGraph* subgraph);
+uint32_t NumSubgraphOperators(const Model* model, int subgraph_idx);
 
 }  // namespace tflite
 

--- a/tensorflow/lite/micro/flatbuffer_utils.h
+++ b/tensorflow/lite/micro/flatbuffer_utils.h
@@ -16,7 +16,6 @@ limitations under the License.
 #ifndef THIRD_PARTY_TFLITE_MICRO_TENSORFLOW_LITE_MICRO_FLATBUFFER_UTILS_H_
 #define THIRD_PARTY_TFLITE_MICRO_TENSORFLOW_LITE_MICRO_FLATBUFFER_UTILS_H_
 
-#define FLATBUFFERS_LOCALE_INDEPENDENT 0
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/flexbuffers.h"
 #include "tensorflow/lite/schema/schema_generated.h"

--- a/tensorflow/lite/micro/flatbuffer_utils.h
+++ b/tensorflow/lite/micro/flatbuffer_utils.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef THIRD_PARTY_TFLITE_MICRO_TENSORFLOW_LITE_MICRO_FLATBUFFER_UTILS_H_
 #define THIRD_PARTY_TFLITE_MICRO_TENSORFLOW_LITE_MICRO_FLATBUFFER_UTILS_H_
 
+#define FLATBUFFERS_LOCALE_INDEPENDENT 0
+
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/flexbuffers.h"
 #include "tensorflow/lite/schema/schema_generated.h"

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -105,7 +105,6 @@ cc_library(
         "//tensorflow/lite/kernels/internal:compatibility",
         "//tensorflow/lite/kernels/internal:types",
         "//tensorflow/lite/micro:debug_log",
-        "@flatbuffers//:runtime_cc",
     ],
 )
 

--- a/tensorflow/lite/micro/kernels/detection_postprocess.cc
+++ b/tensorflow/lite/micro/kernels/detection_postprocess.cc
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include <numeric>
 
+#include "flatbuffers/flatbuffers.h"
+#include "flatbuffers/flexbuffers.h"
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/common.h"

--- a/tensorflow/lite/micro/kernels/detection_postprocess.cc
+++ b/tensorflow/lite/micro/kernels/detection_postprocess.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include <numeric>
 
-#include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/flexbuffers.h"
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"

--- a/tensorflow/lite/micro/kernels/detection_postprocess.cc
+++ b/tensorflow/lite/micro/kernels/detection_postprocess.cc
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+#define FLATBUFFERS_LOCALE_INDEPENDENT 0
 
 #include <numeric>
 

--- a/tensorflow/lite/micro/kernels/detection_postprocess_test.cc
+++ b/tensorflow/lite/micro/kernels/detection_postprocess_test.cc
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+#define FLATBUFFERS_LOCALE_INDEPENDENT 0
 
 #include "flatbuffers/flexbuffers.h"
 #include "tensorflow/lite/c/builtin_op_data.h"

--- a/tensorflow/lite/micro/kernels/kernel_util.cc
+++ b/tensorflow/lite/micro/kernels/kernel_util.cc
@@ -20,27 +20,6 @@ limitations under the License.
 namespace tflite {
 namespace micro {
 
-const flexbuffers::Map FlexbuffersWrapperGetRootAsMap(const uint8_t* buffer,
-                                                      size_t size) {
-  return flexbuffers::GetRoot(buffer, size).AsMap();
-}
-
-int32_t FlexbuffersWrapperAsInt32(const flexbuffers::Map& m, const char* key) {
-  return m[key].AsInt32();
-}
-
-bool FlexbuffersWrapperAsBool(const flexbuffers::Map& m, const char* key) {
-  return m[key].AsBool();
-}
-
-float FlexbuffersWrapperAsFloat(const flexbuffers::Map& m, const char* key) {
-  return m[key].AsFloat();
-}
-
-bool FlexbuffersWrapperIsNull(const flexbuffers::Map& m, const char* key) {
-  return m[key].IsNull();
-}
-
 bool HaveSameShapes(const TfLiteEvalTensor* input1,
                     const TfLiteEvalTensor* input2) {
   TFLITE_DCHECK(input1 != nullptr);

--- a/tensorflow/lite/micro/kernels/kernel_util.h
+++ b/tensorflow/lite/micro/kernels/kernel_util.h
@@ -18,7 +18,6 @@ limitations under the License.
 
 #include <cstdint>
 
-#include "flatbuffers/flexbuffers.h"
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/compatibility.h"
@@ -26,20 +25,6 @@ limitations under the License.
 
 namespace tflite {
 namespace micro {
-
-// The Flexbuffer library is inline heavy, which causes code bloat when
-// custom ops are used. Wrapping with a function is a portable way to avoid
-// this bloat
-const flexbuffers::Map FlexbuffersWrapperGetRootAsMap(const uint8_t* buffer,
-                                                      size_t size);
-
-int32_t FlexbuffersWrapperAsInt32(const flexbuffers::Map& m, const char* key);
-
-bool FlexbuffersWrapperAsBool(const flexbuffers::Map& m, const char* key);
-
-float FlexbuffersWrapperAsFloat(const flexbuffers::Map& m, const char* key);
-
-bool FlexbuffersWrapperIsNull(const flexbuffers::Map& m, const char* key);
 
 // Returns a mutable tensor for a given input index. is_variable must be checked
 // during prepare when the full TfLiteTensor is available.

--- a/tensorflow/lite/micro/kernels/kernel_util.h
+++ b/tensorflow/lite/micro/kernels/kernel_util.h
@@ -18,7 +18,6 @@ limitations under the License.
 
 #include <cstdint>
 
-#define FLATBUFFERS_LOCALE_INDEPENDENT 0
 #include "flatbuffers/flexbuffers.h"
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"

--- a/tensorflow/lite/micro/memory_helpers.h
+++ b/tensorflow/lite/micro/memory_helpers.h
@@ -15,6 +15,8 @@ limitations under the License.
 #ifndef TENSORFLOW_LITE_MICRO_MEMORY_HELPERS_H_
 #define TENSORFLOW_LITE_MICRO_MEMORY_HELPERS_H_
 
+#define FLATBUFFERS_LOCALE_INDEPENDENT 0
+
 #include <cstddef>
 #include <cstdint>
 

--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -211,13 +211,7 @@ TfLiteStatus AllocationInfoBuilder::AddTensors(const SubGraph* subgraph,
     }
   }
 
-  // TODO(b/192589496): Ops must always be there. Remove this check when fixed
-  int operators_size;
-  if (subgraph->operators() != nullptr) {
-    operators_size = subgraph->operators()->size();
-  } else {
-    operators_size = 0;
-  }
+  uint32_t operators_size = NumSubgraphOperators(subgraph);
 
   for (size_t i = 0; i < subgraph->inputs()->size(); ++i) {
     const int tensor_index = subgraph->inputs()->Get(i);
@@ -750,13 +744,7 @@ TfLiteStatus MicroAllocator::AllocateNodeAndRegistrations(
     const SubGraph* subgraph = model->subgraphs()->Get(subgraph_idx);
     TFLITE_DCHECK(subgraph != nullptr);
 
-    // TODO(b/192589496): Ops must always be there. Remove this check when fixed
-    int operators_size;
-    if (subgraph->operators() != nullptr) {
-      operators_size = subgraph->operators()->size();
-    } else {
-      operators_size = 0;
-    }
+    uint32_t operators_size = NumSubgraphOperators(subgraph);
 
     // Initialize NodeAndRegistrations for the subgraph.
     NodeAndRegistration* output = reinterpret_cast<NodeAndRegistration*>(

--- a/tensorflow/lite/micro/micro_allocator.h
+++ b/tensorflow/lite/micro/micro_allocator.h
@@ -18,7 +18,7 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 
-#include "flatbuffers/flatbuffers.h"  // from @flatbuffers
+#include "tensorflow/lite/micro/flatbuffer_utils.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/core/api/error_reporter.h"
 #include "tensorflow/lite/core/api/flatbuffer_conversions.h"

--- a/tensorflow/lite/micro/micro_allocator.h
+++ b/tensorflow/lite/micro/micro_allocator.h
@@ -18,11 +18,12 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 
-#include "tensorflow/lite/micro/flatbuffer_utils.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/core/api/error_reporter.h"
+#define FLATBUFFERS_LOCALE_INDEPENDENT 0
 #include "tensorflow/lite/core/api/flatbuffer_conversions.h"
 #include "tensorflow/lite/micro/compatibility.h"
+#include "tensorflow/lite/micro/flatbuffer_utils.h"
 #include "tensorflow/lite/micro/simple_memory_allocator.h"
 #include "tensorflow/lite/schema/schema_generated.h"
 

--- a/tensorflow/lite/micro/micro_allocator.h
+++ b/tensorflow/lite/micro/micro_allocator.h
@@ -20,7 +20,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/core/api/error_reporter.h"
-#define FLATBUFFERS_LOCALE_INDEPENDENT 0
 #include "tensorflow/lite/core/api/flatbuffer_conversions.h"
 #include "tensorflow/lite/micro/compatibility.h"
 #include "tensorflow/lite/micro/flatbuffer_utils.h"

--- a/tensorflow/lite/micro/micro_allocator.h
+++ b/tensorflow/lite/micro/micro_allocator.h
@@ -15,6 +15,8 @@ limitations under the License.
 #ifndef TENSORFLOW_LITE_MICRO_MICRO_ALLOCATOR_H_
 #define TENSORFLOW_LITE_MICRO_MICRO_ALLOCATOR_H_
 
+#define FLATBUFFERS_LOCALE_INDEPENDENT 0
+
 #include <cstddef>
 #include <cstdint>
 

--- a/tensorflow/lite/micro/micro_graph.cc
+++ b/tensorflow/lite/micro/micro_graph.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "tensorflow/lite/micro/micro_graph.h"
 
+#define FLATBUFFERS_LOCALE_INDEPENDENT 0
 #include "flatbuffers/flatbuffers.h"  // from @flatbuffers
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/compatibility.h"

--- a/tensorflow/lite/micro/micro_graph.cc
+++ b/tensorflow/lite/micro/micro_graph.cc
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#define FLATBUFFERS_LOCALE_INDEPENDENT 0
+
 #include "tensorflow/lite/micro/micro_graph.h"
 
 #include "flatbuffers/flatbuffers.h"  // from @flatbuffers

--- a/tensorflow/lite/micro/micro_graph.cc
+++ b/tensorflow/lite/micro/micro_graph.cc
@@ -57,9 +57,8 @@ TfLiteStatus MicroGraph::InitSubgraphs() {
   for (size_t subgraph_idx = 0; subgraph_idx < subgraphs_->size();
        subgraph_idx++) {
     current_subgraph_index_ = subgraph_idx;
-
-    const SubGraph* subgraph = (*subgraphs_)[subgraph_idx];
-    for (size_t i = 0; i < subgraph->operators()->size(); ++i) {
+    int operators_size = NumSubgraphOperators(subgraph_idx);
+    for (size_t i = 0; i < operators_size; ++i) {
       TfLiteNode* node =
           &(subgraph_allocations_[subgraph_idx].node_and_registrations[i].node);
       const TfLiteRegistration* registration =
@@ -92,9 +91,8 @@ TfLiteStatus MicroGraph::PrepareSubgraphs() {
   for (size_t subgraph_idx = 0; subgraph_idx < subgraphs_->size();
        subgraph_idx++) {
     current_subgraph_index_ = subgraph_idx;
-
-    const SubGraph* subgraph = (*subgraphs_)[subgraph_idx];
-    for (size_t i = 0; i < subgraph->operators()->size(); ++i) {
+    int operators_size = NumSubgraphOperators(subgraph_idx);
+    for (size_t i = 0; i < operators_size; ++i) {
       TfLiteNode* node =
           &(subgraph_allocations_[subgraph_idx].node_and_registrations[i].node);
       const TfLiteRegistration* registration =
@@ -123,8 +121,8 @@ TfLiteStatus MicroGraph::FreeSubgraphs() {
   for (size_t subgraph_idx = 0; subgraph_idx < subgraphs_->size();
        subgraph_idx++) {
     current_subgraph_index_ = subgraph_idx;
-    const SubGraph* subgraph = (*subgraphs_)[subgraph_idx];
-    for (size_t i = 0; i < subgraph->operators()->size(); ++i) {
+    int operators_size = NumSubgraphOperators(subgraph_idx);
+    for (size_t i = 0; i < operators_size; ++i) {
       TfLiteNode* node =
           &(subgraph_allocations_[subgraph_idx].node_and_registrations[i].node);
       const TfLiteRegistration* registration =
@@ -152,9 +150,8 @@ TfLiteStatus MicroGraph::InvokeSubgraph(int subgraph_idx) {
                 subgraph_idx, subgraphs_->size());
     return kTfLiteError;
   }
-  const SubGraph* subgraph = (*subgraphs_)[subgraph_idx];
-
-  for (size_t i = 0; i < subgraph->operators()->size(); ++i) {
+  int operators_size = NumSubgraphOperators(subgraph_idx);
+  for (size_t i = 0; i < operators_size; ++i) {
     TfLiteNode* node =
         &(subgraph_allocations_[subgraph_idx].node_and_registrations[i].node);
     const TfLiteRegistration* registration = subgraph_allocations_[subgraph_idx]
@@ -242,6 +239,16 @@ TfLiteEvalTensor* MicroGraph::GetSubgraphOutput(int subgraph_idx,
   int tensor_idx =
       model_->subgraphs()->Get(subgraph_idx)->outputs()->Get(output_idx);
   return &subgraph_allocations_[subgraph_idx].tensors[tensor_idx];
+}
+
+int MicroGraph::NumSubgraphOperators(int subgraph_idx) {
+  const SubGraph* subgraph = model_->subgraphs()->Get(subgraph_idx);
+  // TODO(b/192589496): Ops must always be there. Remove this check when fixed
+  if (subgraph->operators() != nullptr) {
+    return subgraph->operators()->size();
+  } else {
+    return 0;
+  }
 }
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/micro_graph.cc
+++ b/tensorflow/lite/micro/micro_graph.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/micro/micro_graph.h"
 
-#define FLATBUFFERS_LOCALE_INDEPENDENT 0
 #include "flatbuffers/flatbuffers.h"  // from @flatbuffers
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/compatibility.h"

--- a/tensorflow/lite/micro/micro_graph.h
+++ b/tensorflow/lite/micro/micro_graph.h
@@ -66,9 +66,6 @@ class MicroGraph {
   // Get the specified output tensor of a specified subgraph in the model.
   virtual TfLiteEvalTensor* GetSubgraphOutput(int subgraph_idx, int output_idx);
 
-  // Number of operators in the specified subgraph in the model.
-  virtual int NumSubgraphOperators(int subgraph_idx);
-
   // Number of subgraphs in the model.
   virtual int NumSubgraphs();
 

--- a/tensorflow/lite/micro/micro_graph.h
+++ b/tensorflow/lite/micro/micro_graph.h
@@ -60,11 +60,14 @@ class MicroGraph {
   // Get the specified input tensor of a specified subgraph in the model.
   virtual TfLiteEvalTensor* GetSubgraphInput(int subgraph_idx, int input_idx);
 
-  // Number of tensor outputs to a specified subgraph in the model.
+  // Number of tensor outputs from a specified subgraph in the model.
   virtual size_t NumSubgraphOutputs(int subgraph_idx);
 
   // Get the specified output tensor of a specified subgraph in the model.
   virtual TfLiteEvalTensor* GetSubgraphOutput(int subgraph_idx, int output_idx);
+
+  // Number of operators in the specified subgraph in the model.
+  virtual int NumSubgraphOperators(int subgraph_idx);
 
   // Number of subgraphs in the model.
   virtual int NumSubgraphs();

--- a/tensorflow/lite/micro/micro_interpreter.cc
+++ b/tensorflow/lite/micro/micro_interpreter.cc
@@ -96,7 +96,8 @@ TfLiteStatus MicroInterpreter::PrepareNodeAndRegistrationDataFromFlatbuffer() {
     auto* opcodes = model_->operator_codes();
     BuiltinDataAllocator* builtin_data_allocator =
         allocator_.GetBuiltinDataAllocator();
-    for (size_t i = 0; i < subgraph->operators()->size(); ++i) {
+    int operators_size = graph_.NumSubgraphOperators(subgraph_idx);
+    for (size_t i = 0; i < operators_size; ++i) {
       const auto* op = subgraph->operators()->Get(i);
       const size_t index = op->opcode_index();
       if (index >= opcodes->size()) {

--- a/tensorflow/lite/micro/micro_interpreter.cc
+++ b/tensorflow/lite/micro/micro_interpreter.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/core/api/error_reporter.h"
 #include "tensorflow/lite/core/api/tensor_utils.h"
+#include "tensorflow/lite/micro/flatbuffer_utils.h"
 #include "tensorflow/lite/micro/memory_helpers.h"
 #include "tensorflow/lite/micro/micro_allocator.h"
 #include "tensorflow/lite/micro/micro_error_reporter.h"
@@ -96,7 +97,7 @@ TfLiteStatus MicroInterpreter::PrepareNodeAndRegistrationDataFromFlatbuffer() {
     auto* opcodes = model_->operator_codes();
     BuiltinDataAllocator* builtin_data_allocator =
         allocator_.GetBuiltinDataAllocator();
-    int operators_size = graph_.NumSubgraphOperators(subgraph_idx);
+    uint32_t operators_size = NumSubgraphOperators(subgraph);
     for (size_t i = 0; i < operators_size; ++i) {
       const auto* op = subgraph->operators()->Get(i);
       const size_t index = op->opcode_index();

--- a/tensorflow/lite/micro/micro_interpreter.h
+++ b/tensorflow/lite/micro/micro_interpreter.h
@@ -110,10 +110,6 @@ class MicroInterpreter {
 
   TfLiteStatus initialization_status() const { return initialization_status_; }
 
-  size_t operators_size() const {
-    return model_->subgraphs()->Get(0)->operators()->size();
-  }
-
   // Populates node and registration pointers representing the inference graph
   // of the model from values inside the flatbuffer (loaded from the TfLiteModel
   // instance). Persistent data (e.g. operator data) is allocated from the

--- a/tensorflow/lite/micro/micro_interpreter.h
+++ b/tensorflow/lite/micro/micro_interpreter.h
@@ -18,7 +18,6 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 
-#define FLATBUFFERS_LOCALE_INDEPENDENT 0
 #include "flatbuffers/flatbuffers.h"  // from @flatbuffers
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/core/api/error_reporter.h"

--- a/tensorflow/lite/micro/micro_interpreter.h
+++ b/tensorflow/lite/micro/micro_interpreter.h
@@ -18,6 +18,7 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 
+#define FLATBUFFERS_LOCALE_INDEPENDENT 0
 #include "flatbuffers/flatbuffers.h"  // from @flatbuffers
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/core/api/error_reporter.h"

--- a/tensorflow/lite/micro/micro_interpreter.h
+++ b/tensorflow/lite/micro/micro_interpreter.h
@@ -15,6 +15,8 @@ limitations under the License.
 #ifndef TENSORFLOW_LITE_MICRO_MICRO_INTERPRETER_H_
 #define TENSORFLOW_LITE_MICRO_MICRO_INTERPRETER_H_
 
+#define FLATBUFFERS_LOCALE_INDEPENDENT 0
+
 #include <cstddef>
 #include <cstdint>
 

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -15,6 +15,8 @@ limitations under the License.
 #ifndef TENSORFLOW_LITE_MICRO_MICRO_MUTABLE_OP_RESOLVER_H_
 #define TENSORFLOW_LITE_MICRO_MICRO_MUTABLE_OP_RESOLVER_H_
 
+#define FLATBUFFERS_LOCALE_INDEPENDENT 0
+
 #include <cstdio>
 #include <cstring>
 

--- a/tensorflow/lite/micro/micro_op_resolver.h
+++ b/tensorflow/lite/micro/micro_op_resolver.h
@@ -15,6 +15,8 @@ limitations under the License.
 #ifndef TENSORFLOW_LITE_MICRO_MICRO_OP_RESOLVER_H_
 #define TENSORFLOW_LITE_MICRO_MICRO_OP_RESOLVER_H_
 
+#define FLATBUFFERS_LOCALE_INDEPENDENT 0
+
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/core/api/error_reporter.h"
 #include "tensorflow/lite/core/api/flatbuffer_conversions.h"

--- a/tensorflow/lite/micro/mock_micro_graph.h
+++ b/tensorflow/lite/micro/mock_micro_graph.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef TENSORFLOW_LITE_MICRO_MOCK_MICRO_GRAPH_H_
 #define TENSORFLOW_LITE_MICRO_MOCK_MICRO_GRAPH_H_
 
+#define FLATBUFFERS_LOCALE_INDEPENDENT 0
+
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/micro_allocator.h"
 #include "tensorflow/lite/micro/micro_graph.h"

--- a/tensorflow/lite/micro/test_helpers.h
+++ b/tensorflow/lite/micro/test_helpers.h
@@ -16,7 +16,7 @@ limitations under the License.
 #ifndef TENSORFLOW_LITE_MICRO_TEST_HELPERS_H_
 #define TENSORFLOW_LITE_MICRO_TEST_HELPERS_H_
 
-// Useful functions for writing tests.
+#define FLATBUFFERS_LOCALE_INDEPENDENT 0
 
 #include <cstdint>
 #include <limits>

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -147,7 +147,6 @@ COMMON_FLAGS := \
   -ffunction-sections \
   -fdata-sections \
   -fmessage-length=0 \
-  -DFLATBUFFERS_LOCALE_INDEPENDENT=0 \
   -DTF_LITE_STATIC_MEMORY \
   -DTF_LITE_DISABLE_X86_NEON \
   $(CC_WARNINGS) \

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -147,6 +147,7 @@ COMMON_FLAGS := \
   -ffunction-sections \
   -fdata-sections \
   -fmessage-length=0 \
+  -DFLATBUFFERS_LOCALE_INDEPENDENT=0 \
   -DTF_LITE_STATIC_MEMORY \
   -DTF_LITE_DISABLE_X86_NEON \
   $(CC_WARNINGS) \


### PR DESCRIPTION
Some of our tools remove the vector if it's empty (i.e. the subgraph doesn't contain ops). The check is added until the tools are fixed.

Note that to properly build the code, we needed to add `#define FLATBUFFERS_LOCALE_INDEPENDENT 0` to a number of sources and headers in the TFLM code. http://b/193264978 has more context on why that was needed and what options we might have to get the same outcome in a more maintainable manner.

BUG=http://b/192589496