### PR TITLE
Stop the kernel sources from being compiled into both the core objects and kernel objects.

### DIFF
--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -609,10 +609,10 @@ THIRD_PARTY_CC_HDRS += $(addprefix third_party/,$(THIRD_PARTY_CC_HDRS_BASE))
 
 # Specialize for debug_log. micro_time etc.
 MICROLITE_CC_SRCS := $(call substitute_specialized_implementations,$(MICROLITE_CC_SRCS),$(TARGET))
-MICROLITE_CC_SRCS += $(MICROLITE_CC_KERNEL_SRCS)
 
 ALL_SRCS := \
 	$(MICROLITE_CC_SRCS) \
+	$(MICROLITE_CC_KERNEL_SRCS) \
 	$(MICROLITE_TEST_SRCS)
 
 MICROLITE_LIB_PATH := $(LIBDIR)$(MICROLITE_LIB_NAME)

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -833,8 +833,7 @@ generate_arduino_zip: $(ARDUINO_PROJECT_TARGETS) $(ARDUINO_LIBRARY_ZIPS)
 	python tensorflow/lite/micro/tools/make/merge_arduino_zips.py $(PRJDIR)/tensorflow_lite.zip $(ARDUINO_LIBRARY_ZIPS)
 
 list_library_sources:
-	@echo $(MICROLITE_CC_SRCS) \
-	@echo $(MICROLITE_CC_KERNEL_SRCS)
+	@echo $(MICROLITE_CC_SRCS) $(MICROLITE_CC_KERNEL_SRCS)
 
 list_library_headers:
 	@echo $(MICROLITE_CC_HDRS)

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -833,7 +833,8 @@ generate_arduino_zip: $(ARDUINO_PROJECT_TARGETS) $(ARDUINO_LIBRARY_ZIPS)
 	python tensorflow/lite/micro/tools/make/merge_arduino_zips.py $(PRJDIR)/tensorflow_lite.zip $(ARDUINO_LIBRARY_ZIPS)
 
 list_library_sources:
-	@echo $(MICROLITE_CC_SRCS)
+	@echo $(MICROLITE_CC_SRCS) \
+	@echo $(MICROLITE_CC_KERNEL_SRCS)
 
 list_library_headers:
 	@echo $(MICROLITE_CC_HDRS)


### PR DESCRIPTION
Solves #242. The kernel sources are being compiled into both the core objects and kernels objects, which are built with different optimization flags. If the kernels are linked from the core objects, this leads to slower execution of the kernels.

BUG=#242 