### PR TITLE
Update sync script now that TFLM has been deleted from upstream Tensorflow.

### DIFF
--- a/ci/sync_from_upstream_tf.sh
+++ b/ci/sync_from_upstream_tf.sh
@@ -131,7 +131,7 @@ do
   /bin/cp /tmp/tensorflow/${filepath} ${filepath}
 done
 
-# The microfrontend is sync'd from upstream but not as part of the explicitly
-# specified SHARED_TFL_CODE since this is only needed for the examples.
-rm -rf tensorflow/lite/experimental/microfrontend/lib
-cp -r /tmp/tensorflow/tensorflow/lite/experimental/microfrontend/lib tensorflow/lite/experimental/microfrontend/lib
+# Since the TFLM code was deleted from the tensorflow repository, the
+# microfrontend is no longer sync'd from upstream and instead maintaned as a
+# fork.
+git checkout tensorflow/lite/experimental/microfrontend/lib/


### PR DESCRIPTION
The TFLM directory was almost completely deleted with https://github.com/tensorflow/tensorflow/commit/fbae3858da32d9e70ae8791433723f86ad6c02af

After that change, it is easier to maintain the microfrontend library (and tests) as a fork in the tflite-micro instead of sync'ing that code from tensorflow.