### PR TITLE
Fixes to the check tflite files workflow

### DIFF
--- a/.github/workflows/check_tflite_files.yml
+++ b/.github/workflows/check_tflite_files.yml
@@ -6,23 +6,22 @@ on:
 jobs:
   check_tflite_files:
     runs-on: ubuntu-latest
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'ci:run') &&
-      ${{ !contains(github.event.pull_request.body, 'NO_CHECK_TFLITE_FILES') }}
+    if: contains(github.event.pull_request.labels.*.name, 'ci:run')
     name: Check PR Modifies TfLite Files
     steps:
-    - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
-    - name: Check Files
-      run: |
-        URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
-        PR_FILES=$(curl -s -X GET -H "Authorization: Bearer ${{ secrets.TFLM_BOT_REPO_TOKEN }}" $URL | jq -r '.[] | .filename')
-        rm -rf /tmp/pull_request_files.txt
-        echo "${PR_FILES}" >> /tmp/pull_request_files.txt
+      - name: Check Files
+        if: ${{ !contains(github.event.pull_request.body, 'NO_CHECK_TFLITE_FILES=') }}
+        run: |
+          URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
+          PR_FILES=$(curl -s -X GET -H "Authorization: Bearer ${{ secrets.TFLM_BOT_REPO_TOKEN }}" $URL | jq -r '.[] | .filename')
+          rm -rf /tmp/pull_request_files.txt
+          echo "${PR_FILES}" >> /tmp/pull_request_files.txt
 
-        python3 ci/check_tflite_files.py /tmp/pull_request_files.txt
-        TFLITE_FILE_TEST_STATUS=$?
-        rm -f /tmp/pull_request_files.txt
-        exit ${TFLITE_FILE_TEST_STATUS}
+          python3 ci/check_tflite_files.py /tmp/pull_request_files.txt
+          TFLITE_FILE_TEST_STATUS=$?
+          rm -f /tmp/pull_request_files.txt
+          exit ${TFLITE_FILE_TEST_STATUS}

--- a/ci/check_tflite_files.py
+++ b/ci/check_tflite_files.py
@@ -21,7 +21,7 @@ if __name__=="__main__":
   parser.add_argument("pr_files", help="File with list of files modified by the Pull Request", default="")
   args = parser.parse_args()
 
-  tflite_files = set(line.strip() for line in open("ci/upstream_list.txt"))
+  tflite_files = set(line.strip() for line in open("ci/tflite_files.txt"))
   pr_files = set(line.strip() for line in open(args.pr_files))
 
   tflite_files_in_pr = tflite_files.intersection(pr_files)

--- a/tensorflow/lite/core/api/flatbuffer_conversions.cc
+++ b/tensorflow/lite/core/api/flatbuffer_conversions.cc
@@ -30,6 +30,8 @@ namespace tflite {
 
 namespace {
 
+// Add new comment
+//
 // Utility class for safely allocating POD data. This is useful for avoiding
 // leaks in cases where op params are allocated but fail to propagate to the
 // parsed op data (e.g., when model parameters are invalid).

--- a/tensorflow/lite/core/api/flatbuffer_conversions.cc
+++ b/tensorflow/lite/core/api/flatbuffer_conversions.cc
@@ -30,8 +30,6 @@ namespace tflite {
 
 namespace {
 
-// Add new comment
-//
 // Utility class for safely allocating POD data. This is useful for avoiding
 // leaks in cases where op params are allocated but fail to propagate to the
 // parsed op data (e.g., when model parameters are invalid).


### PR DESCRIPTION
 * Update the file name for the tflite file list.
 * modify workflow logic to allow it to complete when NO_CHECK_TFLITE_FILES= is in the PR description (instead of skipping the workflow). This is needed to allow the check to be required (i.e. it hass to pass for a PR to be merged).
