### PR TITLE
Have a TFLM-specific version of lite/kernels/op_macros.h

### DIFF
--- a/ci/tflite_files.txt
+++ b/ci/tflite_files.txt
@@ -84,7 +84,6 @@ tensorflow/lite/kernels/internal/tensor_ctypes.h
 tensorflow/lite/kernels/internal/tensor_utils_common.h
 tensorflow/lite/kernels/internal/types.h
 tensorflow/lite/kernels/kernel_util.h
-tensorflow/lite/kernels/op_macros.h
 tensorflow/lite/kernels/padding.h
 tensorflow/lite/portable_type_to_tflitetype.h
 tensorflow/lite/schema/schema_generated.h

--- a/tensorflow/lite/kernels/op_macros.h
+++ b/tensorflow/lite/kernels/op_macros.h
@@ -15,69 +15,23 @@ limitations under the License.
 #ifndef TENSORFLOW_LITE_KERNELS_OP_MACROS_H_
 #define TENSORFLOW_LITE_KERNELS_OP_MACROS_H_
 
-// If we're on a platform without standard IO functions, fall back to a
-// non-portable function.
-#ifdef TF_LITE_MCU_DEBUG_LOG
-
 #include "tensorflow/lite/micro/debug_log.h"
 
-#define DEBUG_LOG(x) \
-  do {               \
-    DebugLog(x);     \
-  } while (0)
-
-inline void InfiniteLoop() {
-  DEBUG_LOG("HALTED\n");
-  while (1) {
-  }
-}
-
-#define TFLITE_ABORT InfiniteLoop();
-
-#else  // TF_LITE_MCU_DEBUG_LOG
-
-#include <cstdio>
+#if !defined(TF_LITE_MCU_DEBUG_LOG)
 #include <cstdlib>
-
-#define DEBUG_LOG(x)            \
-  do {                          \
-    fprintf(stderr, "%s", (x)); \
-  } while (0)
-
-// Report Error for unsupported type by op 'op_name' and returns kTfLiteError.
-#define TF_LITE_UNSUPPORTED_TYPE(context, type, op_name)                    \
-  do {                                                                      \
-    TF_LITE_KERNEL_LOG((context), "%s:%d Type %s is unsupported by op %s.", \
-                       __FILE__, __LINE__, TfLiteTypeGetName(type),         \
-                       (op_name));                                          \
-    return kTfLiteError;                                                    \
-  } while (0)
-
 #define TFLITE_ABORT abort()
-
-#endif  // TF_LITE_MCU_DEBUG_LOG
+#else
+#define TFLITE_ABORT          \
+  do {                        \
+    DebugLog("HALTED\n");     \
+    while (1);                \
+  } while (0)
+#endif
 
 #if defined(NDEBUG) || defined(ARDUINO)
 #define TFLITE_ASSERT_FALSE (static_cast<void>(0))
 #else
 #define TFLITE_ASSERT_FALSE TFLITE_ABORT
 #endif
-
-#define TF_LITE_FATAL(msg)  \
-  do {                      \
-    DEBUG_LOG(msg);         \
-    DEBUG_LOG("\nFATAL\n"); \
-    TFLITE_ABORT;           \
-  } while (0)
-
-#define TF_LITE_ASSERT(x)        \
-  do {                           \
-    if (!(x)) TF_LITE_FATAL(#x); \
-  } while (0)
-
-#define TF_LITE_ASSERT_EQ(x, y)                            \
-  do {                                                     \
-    if ((x) != (y)) TF_LITE_FATAL(#x " didn't equal " #y); \
-  } while (0)
 
 #endif  // TENSORFLOW_LITE_KERNELS_OP_MACROS_H_

--- a/tensorflow/lite/kernels/op_macros.h
+++ b/tensorflow/lite/kernels/op_macros.h
@@ -21,11 +21,11 @@ limitations under the License.
 #include <cstdlib>
 #define TFLITE_ABORT abort()
 #else
-#define TFLITE_ABORT          \
-  do {                        \
-    DebugLog("HALTED\n");     \
-    while (1);                \
-  } while (0)
+inline void AbortImpl() {
+  DebugLog("HALTED\n");
+  while (1);
+}
+#define TFLITE_ABORT AbortImpl();
 #endif
 
 #if defined(NDEBUG) || defined(ARDUINO)

--- a/tensorflow/lite/micro/BUILD
+++ b/tensorflow/lite/micro/BUILD
@@ -254,6 +254,7 @@ cc_library(
     ],
     copts = micro_copts(),
     deps = [
+        ":micro_error_reporter",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/kernels:op_macros",
     ],

--- a/tensorflow/lite/micro/kernels/arc_mli/mli_tf_utils.h
+++ b/tensorflow/lite/micro/kernels/arc_mli/mli_tf_utils.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/common.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_error_reporter.h"
 
 constexpr int kFracBitsQ15 = 15;
 constexpr int kFracBitsQ31 = 31;
@@ -36,7 +37,8 @@ inline void ConvertToMliTensorData(const TfLiteTensor* tfT, mli_tensor* mliT) {
   } else if (tfT->type == kTfLiteInt32) {
     mliT->el_type = MLI_EL_ASYM_I32;
   } else {
-    TF_LITE_FATAL("Wrong data type. Expected int8_t or int32_t.");
+    MicroPrintf("Wrong data type. Expected int8_t or int32_t.");
+    TFLITE_ABORT;
   }
 
   mliT->capacity = tfT->bytes;

--- a/tensorflow/lite/micro/kernels/elu.cc
+++ b/tensorflow/lite/micro/kernels/elu.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_error_reporter.h"
 
 namespace tflite {
 namespace {
@@ -45,7 +46,10 @@ using TransformFunc = float (*)(float);
 template <typename T>
 void PopulateLookupTable(const TfLiteTensor* input, const TfLiteTensor* output,
                          const TransformFunc transform, OpData* data) {
-  if (sizeof(T) != 1) TF_LITE_FATAL("Lookup table valid only for 8bit");
+  if (sizeof(T) != 1) {
+    MicroPrintf("Lookup table valid only for 8bit");
+    TFLITE_ABORT;
+  }
 
   const float inverse_scale = 1 / output->params.scale;
   int32_t maxval = std::numeric_limits<T>::max();

--- a/tensorflow/lite/micro/micro_utils.cc
+++ b/tensorflow/lite/micro/micro_utils.cc
@@ -21,6 +21,7 @@ limitations under the License.
 
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/op_macros.h"
+#include "tensorflow/lite/micro/micro_error_reporter.h"
 
 namespace tflite {
 
@@ -50,7 +51,8 @@ void SignedSymmetricPerChannelQuantize(const float* values,
     stride = channel_count;
     channel_stride = 1;
   } else {
-    TF_LITE_FATAL("quantized dimension must be 0 or 3");
+    MicroPrintf("quantized dimension must be 0 or 3");
+    TFLITE_ABORT;
   }
 
   // Calculate scales for each channel.


### PR DESCRIPTION
 * After this change, we can remove the TFLM-specific code from upstream Tensorflow.
 * Both the TfLite and TFLM implementations of op_macros.h will be simplified.
 * Corresponding change in Tensorflow: http://cl/384575900

BUG=http://b/187728891