### PR TITLE
Add community supported build for esp32

### DIFF
--- a/.github/workflows/esp32.yml
+++ b/.github/workflows/esp32.yml
@@ -1,0 +1,26 @@
+
+name: ESP32
+
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule
+on:
+  schedule:
+    # 10am UTC is 3am or 4am PT depending on daylight savings.
+    - cron: '0 10 * * *'
+
+  # Allow manually triggering of the workflow.
+  workflow_dispatch: {}
+
+jobs:
+  esp32_daily:
+    runs-on: ubuntu-latest
+
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.repository == 'tensorflow/tflite-micro')
+
+    name: ESP32 Continuous Builds
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test
+        run: |
+          tensorflow/lite/micro/tools/ci_build/test_esp32.sh

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Build Type      |    Status     |
 -----------     | --------------|
 Arduino         | [![Arduino](https://github.com/tensorflow/tflite-micro/actions/workflows/arduino.yml/badge.svg)](https://github.com/tensorflow/tflite-micro/actions/workflows/arduino.yml) [![Antmicro](https://github.com/antmicro/tensorflow-arduino-examples/actions/workflows/test_examples.yml/badge.svg)](https://github.com/antmicro/tensorflow-arduino-examples/actions/workflows/test_examples.yml) |
 Cortex-M        | [![Cortex-M](https://github.com/tensorflow/tflite-micro/actions/workflows/cortex_m.yml/badge.svg)](https://github.com/tensorflow/tflite-micro/actions/workflows/cortex_m.yml) |
+ESP32   | [![ESP32](https://github.com/tensorflow/tflite-micro/actions/workflows/esp32.yml/badge.svg)](https://github.com/tensorflow/tflite-micro/actions/workflows/esp32.yml) |
 Sparkfun Edge   | [![Sparkfun Edge](https://github.com/tensorflow/tflite-micro/actions/workflows/sparkfun_edge.yml/badge.svg)](https://github.com/tensorflow/tflite-micro/actions/workflows/sparkfun_edge.yml) |
 Xtensa     | [![Xtensa](https://github.com/tensorflow/tflite-micro/actions/workflows/xtensa.yml/badge.svg?event=schedule)](https://github.com/tensorflow/tflite-micro/actions/workflows/xtensa.yml?query=event%3Aschedule) [![Xtensa](https://raw.githubusercontent.com/advaitjain/tflite-micro/local-continuous-builds/tensorflow/lite/micro/docs/local_continuous_builds/xtensa-build-status.svg)](https://github.com/advaitjain/tflite-micro/tree/local-continuous-builds/tensorflow/lite/micro/docs/local_continuous_builds/xtensa.md#summary) |
-
 
 # Contributing
 See our [contribution documentation](CONTRIBUTING.md).


### PR DESCRIPTION
Fixes #292 

This adds a github action for running the esp32 ci script daily.

I adjusted the constraints and tested that the action will run: https://github.com/mocleiri/tflite-micro/actions/runs/1040366564

There is a problem with the ci script where it is failing but I think it is a separate issue.

BUG=#292