### PR TITLE
Fix incorrect values in recorded_allocation on BE machines

### DIFF
--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -370,8 +370,8 @@ TfLiteStatus FlatBufferVectorToTfLiteTypeArray(
     // Big-endian architecture can not use the same memory layout as
     // flatbuffers::Vector<kFlatBufferVectorType>. Allocate from the tail and
     // copy values from the flatbuffer into the newly allocated chunk.
-    kTfLiteArrayType* array =
-        reinterpret_cast<kTfLiteArrayType*>(allocator->AllocateFromTail(
+    kTfLiteArrayType* array = reinterpret_cast<kTfLiteArrayType*>(
+        allocator->SimpleMemoryAllocator::AllocateFromTail(
             TfLiteIntArrayGetSizeInBytes(flatbuffer_array->size()),
             alignof(kTfLiteArrayType)));
     if (array == nullptr) {


### PR DESCRIPTION
This PR addresses incorrect `count `and `requested_bytes` values in `recorded_allocation` when testing model allocations.

Test case `//tensorflow/lite/micro:recording_micro_allocator_test` fails on Big-Endian systems because `RecordingSimpleMemoryAllocator::AllocateFromTail()` would be called one more time and the `alloc_count_` and `requested_tail_bytes_` fields would be added repeatedly.

`FlatBufferVectorToTfLiteTypeArray()` function in `micro_allocated.cc` has been modified to fix this by invoking the base class version of `AllocateFromTail()` function (`allocator->SimpleMemoryAllocator::AllocateFromTail()`) on BE machines, rather than the derived class version (`allocator->AllocateFromTail()`) which might update the value of `alloc_count_` and `requested_tail_bytes_` fields besides allocating the space.

This PR will fix #297.

BUG=#297