### PR TITLE
Remove distinction between fusion_f1 and hifi4.

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv.cc
@@ -40,7 +40,7 @@ void* Init(TfLiteContext* context, const char* buffer, size_t length) {
 TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_OK(context, ConvPrepare(context, node));
 
-#if defined(FUSION_F1) || defined(HIFI5)
+#if defined(HIFI4) || defined(HIFI5)
   TF_LITE_ENSURE_OK(context, ConvPrepareHifi(context, node));
 #endif
   return kTfLiteOk;
@@ -53,7 +53,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   const TfLiteEvalTensor* input =
       tflite::micro::GetEvalInput(context, node, kConvInputTensor);
 
-#if defined(HIFIMINI) || defined(FUSION_F1) || defined(HIFI5)
+#if defined(HIFIMINI) || defined(HIFI4) || defined(HIFI5)
   const auto& params =
       *(reinterpret_cast<TfLiteConvParams*>(node->builtin_data));
   const auto& op_data = *(reinterpret_cast<XtensaConvOpData*>(node->user_data));
@@ -107,7 +107,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                        tflite::micro::GetTensorData<int32_t>(bias),
                        tflite::micro::GetTensorShape(output),
                        tflite::micro::GetTensorData<int8_t>(output));
-#elif defined(FUSION_F1) || defined(HIFI5)
+#elif defined(HIFI4) || defined(HIFI5)
       ConvEvalHifi(context, node, params, op_data, input, filter, bias, output);
 #else
       return ConvReferenceEvalInt8(context, node);

--- a/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(FUSION_F1) || defined(HIFI5)
+#if defined(HIFI4) || defined(HIFI5)
 
 #include <cstdint>
 
@@ -192,4 +192,4 @@ TfLiteStatus ConvEvalHifi(TfLiteContext* context, TfLiteNode* node,
 }
 
 }  // namespace tflite
-#endif  // defined(FUSION_F1) || defined(HIFI5)
+#endif  // defined(HIFI4) || defined(HIFI5)

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
@@ -42,7 +42,7 @@ void* Init(TfLiteContext* context, const char* buffer, size_t length) {
 TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_OK(context, DepthwiseConvPrepare(context, node));
 
-#if defined(FUSION_F1) || defined(HIFI5)
+#if defined(HIFI4) || defined(HIFI5)
   TF_LITE_ENSURE_OK(context, DepthwiseConvPrepareHifi(context, node));
 #endif  // defined(FUISON_F1) || defined(HIFI5)
   return kTfLiteOk;
@@ -107,7 +107,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           tflite::micro::GetTensorData<int32_t>(bias),
           tflite::micro::GetTensorShape(output),
           tflite::micro::GetTensorData<int8_t>(output));
-#elif defined(FUSION_F1) || defined(HIFI5)
+#elif defined(HIFI4) || defined(HIFI5)
       DepthwiseConvEvalHifi(context, node, params, op_data, input, filter, bias,
                             output);
 #else

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
@@ -29,7 +29,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h"
 
-#if defined(FUSION_F1) || defined(HIFI5)
+#if defined(HIFI4) || defined(HIFI5)
 namespace tflite {
 TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
                                       TfLiteNode* node) {
@@ -179,4 +179,4 @@ TfLiteStatus DepthwiseConvEvalHifi(TfLiteContext* context, TfLiteNode* node,
   return kTfLiteOk;
 }
 }  // namespace tflite
-#endif  // defined(FUSION_F1) || defined(HIFI5)
+#endif  // defined(HIFI4) || defined(HIFI5)

--- a/tensorflow/lite/micro/kernels/xtensa/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/fully_connected.cc
@@ -202,7 +202,7 @@ TfLiteStatus EvalQuantizedInt8(TfLiteContext* context, TfLiteNode* node,
                  tflite::micro::GetTensorData<int32_t>(bias),
                  tflite::micro::GetTensorShape(output),
                  tflite::micro::GetTensorData<int8_t>(output));
-#elif ((defined(FUSION_F1)) || (defined(HIFI5)))
+#elif ((defined(HIFI4)) || (defined(HIFI5)))
   const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
   const int num_batches = output_shape.Dims(0);
   const int output_depth = output_shape.Dims(1);

--- a/tensorflow/lite/micro/kernels/xtensa/quantize.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/quantize.cc
@@ -110,14 +110,14 @@ void AffineQuantize(int scale_multiplier, const int32_t zero_point,
 
 #endif  // defined(HIFIMINI)
 
-#if defined(HIFIMINI) || defined(FUSION_F1) || defined(HIFI5)
+#if defined(HIFIMINI) || defined(HIFI4) || defined(HIFI5)
 TfLiteStatus EvalXtensa(TfLiteContext* context, TfLiteNode* node) {
   TFLITE_DCHECK(node->user_data != nullptr);
 #if defined(HIFIMINI)
   auto* op_data = static_cast<OpData*>(node->user_data);
-#elif defined(FUSION_F1) || defined(HIFI5)
+#elif defined(HIFI4) || defined(HIFI5)
   auto* op_data = static_cast<OpDataQuantizeReference*>(node->user_data);
-#endif  // defined(HIFIMINI) || defined(FUSION_F1) || defined(HIFI5)
+#endif  // defined(HIFIMINI) || defined(HIFI4) || defined(HIFI5)
 
   const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
   TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
@@ -129,7 +129,7 @@ TfLiteStatus EvalXtensa(TfLiteContext* context, TfLiteNode* node) {
                    tflite::micro::GetTensorData<int16_t>(input),
                    tflite::micro::GetTensorShape(output),
                    tflite::micro::GetTensorData<int8_t>(output));
-#elif defined(FUSION_F1)
+#elif defined(HIFI4)
     int size = ElementCount(*input->dims);
     TF_LITE_ENSURE_EQ(
         context,
@@ -153,7 +153,7 @@ TfLiteStatus EvalXtensa(TfLiteContext* context, TfLiteNode* node) {
         0);
 #else
     static_assert(false, "Unsupported xtensa architecture.");
-#endif  // defined(HIFIMINI) || defined(FUSION_F1) || defined(HIFI5)
+#endif  // defined(HIFIMINI) || defined(HIFI4) || defined(HIFI5)
   } else if (output->type == kTfLiteInt32 &&
              (input->type == kTfLiteInt16 || input->type == kTfLiteInt8)) {
     int size = ElementCount(*input->dims);
@@ -163,9 +163,9 @@ TfLiteStatus EvalXtensa(TfLiteContext* context, TfLiteNode* node) {
     // same structs as much as possible and reduce the need for such ifdefs.
 #if defined(HIFIMINI)
     int32_t zero_point = op_data->zero_point;
-#elif defined(FUSION_F1) || defined(HIFI5)
+#elif defined(HIFI4) || defined(HIFI5)
     int32_t zero_point = op_data->quantization_params.zero_point;
-#endif  // defined(HIFIMINI) || defined(FUSION_F1) || defined(HIFI5)
+#endif  // defined(HIFIMINI) || defined(HIFI4) || defined(HIFI5)
     if (input->type == kTfLiteInt16) {
 #if defined(HIFI5)
       int size = ElementCount(*input->dims);
@@ -215,7 +215,7 @@ TfLiteStatus EvalXtensa(TfLiteContext* context, TfLiteNode* node) {
   }
   return kTfLiteOk;
 }
-#endif  // defined(HIFIMINI) || defined(FUSION_F1) || defined(HIFI5)
+#endif  // defined(HIFIMINI) || defined(HIFI4) || defined(HIFI5)
 
 void* Init(TfLiteContext* context, const char* buffer, size_t length) {
   TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
@@ -257,11 +257,11 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 }
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
-#if defined(HIFIMINI) || defined(FUSION_F1) || defined(HIFI5)
+#if defined(HIFIMINI) || defined(HIFI4) || defined(HIFI5)
   return EvalXtensa(context, node);
 #else
   return EvalQuantizeReference(context, node);
-#endif  // defined(HIFIMINI) || defined(FUSION_F1) || defined(HIFI5)
+#endif  // defined(HIFIMINI) || defined(HIFI4) || defined(HIFI5)
 }
 
 }  // namespace

--- a/tensorflow/lite/micro/kernels/xtensa/softmax.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/softmax.cc
@@ -39,7 +39,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   }
 
   TFLITE_DCHECK(node->user_data != nullptr);
-#if defined(FUSION_F1) || defined(HIFI5)
+#if defined(HIFI4) || defined(HIFI5)
   XtensaSoftmaxOpData op_data =
       *static_cast<XtensaSoftmaxOpData*>(node->user_data);
   SoftmaxParams params = op_data.params;

--- a/tensorflow/lite/micro/kernels/xtensa/softmax_int8_int16.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/softmax_int8_int16.cc
@@ -172,7 +172,7 @@ TfLiteStatus PrepareHifimini(TfLiteContext* context, TfLiteNode* node) {
 }
 #endif  // defined(HIFIMINI)
 
-#if defined(FUSION_F1) || defined(HIFI5)
+#if defined(HIFI4) || defined(HIFI5)
 TfLiteStatus PrepareHifi(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_OK(context, SoftmaxPrepare(context, node));
 
@@ -225,13 +225,13 @@ TfLiteStatus EvalHifi(const XtensaSoftmaxOpData* op_data,
   }
   return kTfLiteOk;
 }
-#endif  // defined(FUSION_F1) || defined(HIFI5)
+#endif  // defined(HIFI4) || defined(HIFI5)
 
 }  // namespace
 
 void* XtensaInitSoftmax(TfLiteContext* context, const char* buffer,
                         size_t length) {
-#if defined(HIFIMINI) || defined(FUSION_F1) || defined(HIFI5)
+#if defined(HIFIMINI) || defined(HIFI4) || defined(HIFI5)
   TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
   return context->AllocatePersistentBuffer(context,
                                            sizeof(XtensaSoftmaxOpData));
@@ -243,7 +243,7 @@ void* XtensaInitSoftmax(TfLiteContext* context, const char* buffer,
 TfLiteStatus XtensaPrepareSoftmax(TfLiteContext* context, TfLiteNode* node) {
 #if defined(HIFIMINI)
   return PrepareHifimini(context, node);
-#elif defined(FUSION_F1) || defined(HIFI5)
+#elif defined(HIFI4) || defined(HIFI5)
   return PrepareHifi(context, node);
 #else
   return SoftmaxPrepare(context, node);
@@ -263,7 +263,7 @@ TfLiteStatus XtensaEvalSoftmaxInt8Int16(TfLiteContext* context,
                            tflite::micro::GetTensorData<int8_t>(input),
                            tflite::micro::GetTensorShape(output),
                            tflite::micro::GetTensorData<int16_t>(output));
-#elif defined(FUSION_F1) || defined(HIFI5)
+#elif defined(HIFI4) || defined(HIFI5)
     return EvalHifi(static_cast<XtensaSoftmaxOpData*>(node->user_data), input,
                     output, context);
 #else

--- a/tensorflow/lite/micro/kernels/xtensa/svdf.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/svdf.cc
@@ -244,7 +244,7 @@ void EvalIntegerSvdfHifimini(TfLiteContext* context, TfLiteNode* node,
   }
 }
 
-#elif defined(FUSION_F1) || defined(HIFI5)
+#elif defined(HIFI4) || defined(HIFI5)
 
 TfLiteStatus EvalIntegerSvdfHifi(TfLiteContext* context, TfLiteNode* node,
                                  const TfLiteEvalTensor* input_tensor,
@@ -317,7 +317,7 @@ TfLiteStatus EvalIntegerSvdfHifi(TfLiteContext* context, TfLiteNode* node,
   }
   return kTfLiteOk;
 }
-#endif  // defined(FUSION_F1) || defined(HIFIMINI) || defined(HIFI5)
+#endif  // defined(HIFI4) || defined(HIFIMINI) || defined(HIFI5)
 
 void* Init(TfLiteContext* context, const char* buffer, size_t length) {
   TFLITE_DCHECK(context != nullptr);
@@ -477,7 +477,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   EvalIntegerSvdfHifimini(context, node, input, weights_feature, weights_time,
                           bias, params, activation_state, output, data);
   return kTfLiteOk;
-#elif defined(FUSION_F1) || defined(HIFI5)
+#elif defined(HIFI4) || defined(HIFI5)
   return EvalIntegerSvdfHifi(context, node, input, weights_feature,
                              weights_time, bias, params, activation_state,
                              output, data);

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa.h
@@ -18,7 +18,7 @@ limitations under the License.
 
 #if defined(HIFIMINI)
 #include <xtensa/tie/xt_hifi2.h>
-#elif ((defined(FUSION_F1)) || (defined(HIFI5)))
+#elif ((defined(HIFI4)) || (defined(HIFI5)))
 #include "include/nnlib/xa_nnlib_api.h"
 #include "include/nnlib/xa_nnlib_standards.h"
 

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_conv.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_conv.h
@@ -25,9 +25,9 @@ namespace tflite {
 struct XtensaConvOpData {
   OpDataConv reference_op_data;
 
-#if defined(FUSION_F1) || defined(HIFI5)
+#if defined(HIFI4) || defined(HIFI5)
   int scratch_tensor_index;
-#endif  // defined(FUSION_F1) || defined(HIFI5)
+#endif  // defined(HIFI4) || defined(HIFI5)
 };
 
 #if defined(HIFIMINI)
@@ -49,7 +49,7 @@ void Conv1x32Input32x32FilterHifiMini(
     const RuntimeShape& bias_shape, const int32_t* bias_data,
     const RuntimeShape& output_shape, int8_t* output_data);
 
-#elif defined(FUSION_F1) || defined(HIFI5)
+#elif defined(HIFI4) || defined(HIFI5)
 TfLiteStatus ConvPrepareHifi(TfLiteContext* context, TfLiteNode* node);
 
 TfLiteStatus ConvEvalHifi(TfLiteContext* context, TfLiteNode* node,

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h
@@ -25,9 +25,9 @@ namespace tflite {
 struct XtensaDepthwiseConvOpData {
   OpDataConv reference_op_data;
 
-#if defined(FUSION_F1) || defined(HIFI5)
+#if defined(HIFI4) || defined(HIFI5)
   int scratch_tensor_index;
-#endif  // defined(FUSION_F1) || defined(HIFI5)
+#endif  // defined(HIFI4) || defined(HIFI5)
 };
 
 #if defined(HIFIMINI)
@@ -48,7 +48,7 @@ inline void DepthwiseConv4x32MatchingInputAndFilterHifiMini(
     const RuntimeShape& bias_shape, const int32_t* bias_data,
     const RuntimeShape& output_shape, int8_t* output_data);
 
-#elif defined(FUSION_F1) || defined(HIFI5)
+#elif defined(HIFI4) || defined(HIFI5)
 TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context, TfLiteNode* node);
 
 TfLiteStatus DepthwiseConvEvalHifi(TfLiteContext* context, TfLiteNode* node,

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_softmax.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_softmax.h
@@ -26,7 +26,7 @@ namespace tflite {
 struct XtensaSoftmaxOpData {
   uint16_t* exp_lut;
 };
-#elif defined(FUSION_F1) || defined(HIFI5)
+#elif defined(HIFI4) || defined(HIFI5)
 struct XtensaSoftmaxOpData {
   SoftmaxParams params;
   int scratch_tensor_index;

--- a/tensorflow/lite/micro/tools/ci_build/test_xtensa_fusion_f1.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_xtensa_fusion_f1.sh
@@ -30,7 +30,7 @@ readable_run make -f tensorflow/lite/micro/tools/make/Makefile third_party_downl
 
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile \
   TARGET=xtensa \
-  TARGET_ARCH=fusion_f1 \
+  TARGET_ARCH=hifi4 \
   OPTIMIZED_KERNEL_DIR=xtensa \
   XTENSA_CORE=F1_190305_swupgrade \
   test -j$(nproc)

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -8,8 +8,7 @@ MICROLITE_CC_KERNEL_SRCS += \
   tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifimini.cc \
   tensorflow/lite/micro/kernels/xtensa/softmax_int8_int16.cc
 
-ifeq ($(TARGET_ARCH), $(findstring $(TARGET_ARCH), "hifi5"))
-
+ifeq ($(TARGET_ARCH), "hifi5")
   DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/xtensa_download.sh ${MAKEFILE_DIR}/downloads hifi5)
   ifneq ($(DOWNLOAD_RESULT), SUCCESS)
     $(error Something went wrong with the xtensa download: $(DOWNLOAD_RESULT))
@@ -57,9 +56,7 @@ ifeq ($(TARGET_ARCH), $(findstring $(TARGET_ARCH), "hifi5"))
     -I$(NNLIB_PATH)/algo/common/include/ \
     -I$(NNLIB_PATH)/algo/ndsp/hifi5/include/
 
-endif
-
-ifeq ($(TARGET_ARCH), $(findstring $(TARGET_ARCH), "fusion_f1 hifi4"))
+else ifeq ($(TARGET_ARCH), "hifi4")
 
   DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/xtensa_download.sh ${MAKEFILE_DIR}/downloads hifi4)
   ifneq ($(DOWNLOAD_RESULT), SUCCESS)
@@ -97,6 +94,10 @@ ifeq ($(TARGET_ARCH), $(findstring $(TARGET_ARCH), "fusion_f1 hifi4"))
     -I$(NNLIB_PATH)/algo/common/include/ \
     -I$(NNLIB_PATH)/algo/ndsp/hifi4/include/
 
+else ifeq ($(TARGET_ARCH), "vision_p6")
+  $(info We do not have XaNNlib for TARGET_ARCH=vision_p6)
+else
+  $(error Unsupported TARGET_ARCH=$(TARGET_ARCH))
 endif
 
 # tensorflow/tensorflow#49117 enabled support for all datatypes for the

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -8,7 +8,7 @@ MICROLITE_CC_KERNEL_SRCS += \
   tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifimini.cc \
   tensorflow/lite/micro/kernels/xtensa/softmax_int8_int16.cc
 
-ifeq ($(TARGET_ARCH), "hifi5")
+ifeq ($(TARGET_ARCH), hifi5)
   DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/xtensa_download.sh ${MAKEFILE_DIR}/downloads hifi5)
   ifneq ($(DOWNLOAD_RESULT), SUCCESS)
     $(error Something went wrong with the xtensa download: $(DOWNLOAD_RESULT))
@@ -56,7 +56,7 @@ ifeq ($(TARGET_ARCH), "hifi5")
     -I$(NNLIB_PATH)/algo/common/include/ \
     -I$(NNLIB_PATH)/algo/ndsp/hifi5/include/
 
-else ifeq ($(TARGET_ARCH), "hifi4")
+else ifeq ($(TARGET_ARCH), hifi4)
 
   DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/xtensa_download.sh ${MAKEFILE_DIR}/downloads hifi4)
   ifneq ($(DOWNLOAD_RESULT), SUCCESS)
@@ -94,7 +94,7 @@ else ifeq ($(TARGET_ARCH), "hifi4")
     -I$(NNLIB_PATH)/algo/common/include/ \
     -I$(NNLIB_PATH)/algo/ndsp/hifi4/include/
 
-else ifeq ($(TARGET_ARCH), "vision_p6")
+else ifeq ($(TARGET_ARCH), vision_p6)
   $(info We do not have XaNNlib for TARGET_ARCH=vision_p6)
 else
   $(error Unsupported TARGET_ARCH=$(TARGET_ARCH))

--- a/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
@@ -28,8 +28,7 @@ ifeq ($(TARGET_ARCH), )
 endif
 
 # Create a cflag based on the specified TARGET_ARCH. For example:
-#   TARGET_ARCH=hifimini --> -DHIFIMINI
-#   TARGET_ARCH=fusion_f1 --> -DFUSION_F1
+#   TARGET_ARCH=hifi4 --> -DHIFI4
 TARGET_ARCH_DEFINES := -D$(shell echo $(TARGET_ARCH) | tr [a-z] [A-Z])
 
 PLATFORM_FLAGS = \


### PR DESCRIPTION
Hifi4, Fusion F1 and Hifi3Z all use the same underlying xannlib hifi4 optimizations and with this change we can specify TARGET_ARCH=hifi4 for each of these cores.

BUG=http://b/194225949
