### PR TITLE
Test case to demonstrate that the Xtensa linker does not appear to be dropping all unused symbols.

### DIFF
--- a/tensorflow/lite/kernels/kernel_util.cc
+++ b/tensorflow/lite/kernels/kernel_util.cc
@@ -21,9 +21,7 @@ limitations under the License.
 #include <complex>
 #include <limits>
 #include <memory>
-#ifndef TF_LITE_STATIC_MEMORY
 #include <string>
-#endif  // TF_LITE_STATIC_MEMORY
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
@@ -409,7 +407,6 @@ bool HaveSameShapes(const TfLiteTensor* input1, const TfLiteTensor* input2) {
   return TfLiteIntArrayEqual(input1->dims, input2->dims);
 }
 
-#ifndef TF_LITE_STATIC_MEMORY
 
 // TODO(b/172067338): Having this function be part of TF_LITE_STATIC_MEMORY
 // build results in a 6KB size increase, even though the function is unsused for
@@ -428,6 +425,7 @@ std::string GetShapeDebugString(const TfLiteIntArray* shape) {
   return str;
 }
 
+#ifndef TF_LITE_STATIC_MEMORY
 TfLiteStatus CalculateShapeForBroadcast(TfLiteContext* context,
                                         const TfLiteTensor* input1,
                                         const TfLiteTensor* input2,


### PR DESCRIPTION
With the following commands:

```
make -f tensorflow/lite/micro/tools/make/Makefile clean
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa TARGET_ARCH=hifi4 OPTIMIZED_KERNEL_DIR=xtensa XTENSA_CORE=F1_190305_swupgrade keyword_benchmark -j8
xt-size tensorflow/lite/micro/tools/make/gen/xtensa_hifi4_default/bin/keyword_benchmark
```

We get the following size with this PR:
``` 
   text   data    bss    dec    hex filename
  75184  55556  24984 155724  2604c tensorflow/lite/micro/tools/make/gen/xtensa_hifi4_default/bin/keyword_benchmark
```

And a reduction of ~10KB overall if we put the unused functions inside an ifdef (i.e. revert the changes from this PR):
```
  text   data    bss    dec    hex filename
  70592  51484  24968 147044  23e64 tensorflow/lite/micro/tools/make/gen/xtensa_hifi4_default/bin/keyword_benchmark
```

BUG=http://b/172067338#comment9