### PR TITLE
Fix esp32 ci build

### DIFF
--- a/.github/workflows/esp32.yml
+++ b/.github/workflows/esp32.yml
@@ -23,4 +23,4 @@ jobs:
       - uses: actions/checkout@v2
       - name: Test
         run: |
-          tensorflow/lite/micro/tools/ci_build/test_esp32.sh
+          docker run --rm -v `pwd`:/opt/tflite-micro espressif/idf:release-v4.3 /opt/tflite-micro/tensorflow/lite/micro/tools/ci_build/test_esp32.sh

--- a/tensorflow/lite/micro/tools/ci_build/test_esp32.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_esp32.sh
@@ -26,34 +26,34 @@ pwd
 source tensorflow/lite/micro/tools/ci_build/helper_functions.sh
 
 TARGET=esp
+TARGET_ARCH=xtensa-esp32
 
-# setup esp-idf and toolchains
-echo "Checking out esp-idf..."
-readable_run git clone --recursive --single-branch --branch release/v4.2 https://github.com/espressif/esp-idf.git
-export IDF_PATH="${ROOT_DIR}"/esp-idf
-cd $IDF_PATH
-readable_run ./install.sh
-readable_run . ./export.sh
-cd "${ROOT_DIR}"
+readable_run make -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} third_party_downloads
 
 # clean all
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
 
+# validate esp32 build for libtensorflow-microlite.a
+readable_run make -j8 -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} TARGET_TOOLCHAIN_PREFIX=xtensa-esp32-elf-
+
 # generate examples
-readable_run make -j8 -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} generate_hello_world_esp_project
-readable_run make -j8 -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} generate_person_detection_esp_project
-readable_run make -j8 -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} generate_micro_speech_esp_project
+readable_run make -j8 -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} generate_hello_world_esp_project
+
+# readable_run make -j8 -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} generate_person_detection_int8_esp_project
+
+readable_run make -j8 -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} generate_micro_speech_esp_project
 
 # build examples
-cd "${ROOT_DIR}"/tensorflow/lite/micro/tools/make/gen/esp_xtensa-esp32/prj/hello_world/esp-idf
+cd "${ROOT_DIR}"/tensorflow/lite/micro/tools/make/gen/esp_xtensa-esp32_default/prj/hello_world/esp-idf
 readable_run idf.py build
 
-cd "${ROOT_DIR}"/tensorflow/lite/micro/tools/make/gen/esp_xtensa-esp32/prj/person_detection/esp-idf
-readable_run git clone https://github.com/espressif/esp32-camera.git components/esp32-camera
-cd components/esp32-camera/
-readable_run git checkout eacd640b8d379883bff1251a1005ebf3cf1ed95c
-cd ../../
+#cd "${ROOT_DIR}"/tensorflow/lite/micro/tools/make/gen/esp_xtensa-esp32_default/prj/person_detection_int8/esp-idf
+#readable_run git clone https://github.com/espressif/esp32-camera.git components/esp32-camera
+#cd components/esp32-camera/
+#readable_run git checkout eacd640b8d379883bff1251a1005ebf3cf1ed95c
+#cd ../../
+#readable_run idf.py build
+
+cd "${ROOT_DIR}"/tensorflow/lite/micro/tools/make/gen/esp_xtensa-esp32_default/prj/micro_speech/esp-idf
 readable_run idf.py build
 
-cd "${ROOT_DIR}"/tensorflow/lite/micro/tools/make/gen/esp_xtensa-esp32/prj/micro_speech/esp-idf
-readable_run idf.py build


### PR DESCRIPTION
BUG=Fixes #294

I was able to run this with some minor alterations on when the job ran on my fork:
https://github.com/mocleiri/tflite-micro/actions/runs/1054903715

Copy from xtensa ci scripts to run the test script inside of a docker
container.

We use the espressif/idf:release-v4.3 image.

Add a build that builds the full tensorflow-microlite.a library.

The person detection example is more complicated and not fixed here.