### PR TITLE
Remove no longer necessary -Wno-type-limits

### DIFF
--- a/tensorflow/lite/core/api/op_resolver.cc
+++ b/tensorflow/lite/core/api/op_resolver.cc
@@ -30,8 +30,7 @@ TfLiteStatus GetRegistrationFromOpCode(
   auto builtin_code = GetBuiltinCode(opcode);
   int version = opcode->version();
 
-  if (builtin_code > BuiltinOperator_MAX ||
-      builtin_code < BuiltinOperator_MIN) {
+  if (builtin_code > BuiltinOperator_MAX) {
     TF_LITE_REPORT_ERROR(
         error_reporter,
         "Op builtin_code out of range: %d. Are you using old TFLite binary "

--- a/tensorflow/lite/micro/tools/make/targets/bluepill_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/bluepill_makefile.inc
@@ -28,7 +28,6 @@ PLATFORM_FLAGS = \
   -mthumb \
   -Wno-vla \
   -Wno-shadow \
-  -Wno-type-limits \
   -fomit-frame-pointer \
   -nostdlib
 

--- a/tensorflow/lite/micro/tools/make/targets/stm32f4_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/stm32f4_makefile.inc
@@ -44,7 +44,6 @@ PLATFORM_FLAGS = \
   -Wextra \
   -Wno-shadow \
   -Wno-vla \
-  -Wno-type-limits \
   -Wno-unused-parameter \
   -Wno-missing-field-initializers \
   -Wno-write-strings \


### PR DESCRIPTION
With http://cl/386537127  (https://github.com/tensorflow/tensorflow/commit/d4987a91fc1d57821d5ea751deeba0e5dbfff780) we do not run into the type-limits warning and `-Wno-type-limits` can be removed.

BUG=http://b/194523886
