### PR TITLE
Fixed person detection example for ESP platform

### DIFF
--- a/tensorflow/lite/micro/examples/person_detection/Makefile.inc
+++ b/tensorflow/lite/micro/examples/person_detection/Makefile.inc
@@ -77,8 +77,13 @@ $(eval $(call microlite_test,detection_responder_test_int8,\
 $(DETECTION_RESPONDER_TEST_SRCS),$(DETECTION_RESPONDER_TEST_HDRS)))
 
 # Builds a standalone object recognition binary.
-$(eval $(call microlite_test,person_detection_int8,\
-$(person_detection_SRCS),$(person_detection_HDRS)))
+ifneq ($(TARGET), esp)
+ $(eval $(call microlite_test,person_detection_int8,\
+ $(person_detection_SRCS),$(person_detection_HDRS)))
+else
+ $(eval $(call microlite_test,person_detection,\
+ $(person_detection_SRCS),$(person_detection_HDRS)))
+endif
 
 list_person_detection_example_sources:
 	@echo $(person_detection_SRCS)

--- a/tensorflow/lite/micro/examples/person_detection/esp/Makefile.inc
+++ b/tensorflow/lite/micro/examples/person_detection/esp/Makefile.inc
@@ -33,12 +33,12 @@ person_detection_ESP_PROJECT_FILES := \
   main/Kconfig.projbuild
 
 # Remap downloaded model files as if they were in tensorflow/lite/micro/examples/..
-MODEL_DOWNLOADS_DIR := tensorflow/lite/micro/tools/make/downloads/person_model_grayscale
-MODEL_EXAMPLES_DIR := tensorflow/lite/micro/examples/person_detection/person_model_grayscale
+MODEL_DOWNLOADS_DIR := tensorflow/lite/micro/tools/make/downloads/person_model_int8
+MODEL_EXAMPLES_DIR := tensorflow/lite/micro/examples/person_detection/person_model_int8
 person_detection_SRCS := $(patsubst $(MODEL_DOWNLOADS_DIR)/%,$(MODEL_EXAMPLES_DIR)/%,$(person_detection_SRCS))
 
 # Custom rule to transform downloaded model files
-$(PRJDIR)person_detection/esp-idf/main/person_model_grayscale/%: $(MODEL_DOWNLOADS_DIR)/%
+$(PRJDIR)person_detection/esp-idf/main/person_model_int8/%: $(MODEL_DOWNLOADS_DIR)/%
 	@mkdir -p $(dir $@)
 	@python tensorflow/lite/micro/tools/make/transform_source.py \
         --platform=esp \

--- a/tensorflow/lite/micro/examples/person_detection/esp/image_provider.cc
+++ b/tensorflow/lite/micro/examples/person_detection/esp/image_provider.cc
@@ -50,16 +50,22 @@ extern "C" int capture_image() {
   }
   return 0;
 }
+
 // Begin the capture and wait for it to finish
 TfLiteStatus PerformCapture(tflite::ErrorReporter* error_reporter,
-                            uint8_t* image_data) {
+                            int8_t* image_data) {
   /* 2. Get one image with camera */
   int ret = capture_image();
   if (ret != 0) {
     return kTfLiteError;
   }
   TF_LITE_REPORT_ERROR(error_reporter, "Image Captured\n");
-  memcpy(image_data, fb->buf, fb->len);
+
+  // Convert camera data from uint to int8
+  for (int i = 0; i < fb->len; i++) {
+    image_data[i] = (int8_t) ((int) fb->buf[i] - 128);
+  }
+
   esp_camera_fb_return(fb);
   /* here the esp camera can give you grayscale image directly */
   return kTfLiteOk;
@@ -67,7 +73,7 @@ TfLiteStatus PerformCapture(tflite::ErrorReporter* error_reporter,
 
 // Get an image from the camera module
 TfLiteStatus GetImage(tflite::ErrorReporter* error_reporter, int image_width,
-                      int image_height, int channels, uint8_t* image_data) {
+                      int image_height, int channels, int8_t* image_data) {
   static bool g_is_camera_initialized = false;
   if (!g_is_camera_initialized) {
     TfLiteStatus init_status = InitCamera(error_reporter);

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -233,19 +233,6 @@ else ifeq ($(BUILD_TYPE), no_tf_lite_static_memory)
 	CCFLAGS := $(filter-out -DTF_LITE_STATIC_MEMORY, $(CCFLAGS))
 endif
 
-# This library is the main target for this makefile. It will contain a minimal
-# runtime that can be linked in to other programs.
-MICROLITE_LIB_NAME := libtensorflow-microlite.a
-
-# Where compiled objects are stored.
-GENDIR := $(MAKEFILE_DIR)/gen/$(TARGET)_$(TARGET_ARCH)_$(BUILD_TYPE)/
-CORE_OBJDIR := $(GENDIR)obj/core/
-KERNEL_OBJDIR := $(GENDIR)obj/kernels/
-THIRD_PARTY_OBJDIR := $(GENDIR)obj/third_party/
-BINDIR := $(GENDIR)bin/
-LIBDIR := $(GENDIR)lib/
-PRJDIR := $(GENDIR)prj/
-
 # These two must be defined before we include the target specific Makefile.inc
 # because we filter out the examples that are not supported for those targets.
 # See targets/xtensa_xpg_makefile.inc for an example.
@@ -619,6 +606,19 @@ ALL_SRCS := \
 	$(MICROLITE_CC_SRCS) \
 	$(MICROLITE_CC_KERNEL_SRCS) \
 	$(MICROLITE_TEST_SRCS)
+
+# This library is the main target for this makefile. It will contain a minimal
+# runtime that can be linked in to other programs.
+MICROLITE_LIB_NAME := libtensorflow-microlite.a
+
+# Where compiled objects are stored.
+GENDIR := $(MAKEFILE_DIR)/gen/$(TARGET)_$(TARGET_ARCH)_$(BUILD_TYPE)/
+CORE_OBJDIR := $(GENDIR)obj/core/
+KERNEL_OBJDIR := $(GENDIR)obj/kernels/
+THIRD_PARTY_OBJDIR := $(GENDIR)obj/third_party/
+BINDIR := $(GENDIR)bin/
+LIBDIR := $(GENDIR)lib/
+PRJDIR := $(GENDIR)prj/
 
 MICROLITE_LIB_PATH := $(LIBDIR)$(MICROLITE_LIB_NAME)
 


### PR DESCRIPTION
BUG=Broken person_detection example for ESP platform

Following changes to fix the example:

* Use int8 model
* Avoid build issues with target rule: Changed the rule from person_detection_int8 to person_detection for esp
* Convert uint8 camera buffer to int8