### PR TITLE
Add special TARGET_ARCH=project_generation to cortex_m_generic.

### DIFF
--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -75,10 +75,10 @@ class MicroBuiltinDataAllocator : public BuiltinDataAllocator {
     // of the model.
   }
 
+  TF_LITE_REMOVE_VIRTUAL_DELETE
+
  private:
   SimpleMemoryAllocator* memory_allocator_;
-
-  TF_LITE_REMOVE_VIRTUAL_DELETE
 };
 
 #if !defined(__clang__)

--- a/tensorflow/lite/micro/simple_memory_allocator.h
+++ b/tensorflow/lite/micro/simple_memory_allocator.h
@@ -87,6 +87,8 @@ class SimpleMemoryAllocator {
   // account any temporary allocations.
   size_t GetUsedBytes() const;
 
+  TF_LITE_REMOVE_VIRTUAL_DELETE
+
  protected:
   // Returns a pointer to the current end of the head buffer.
   uint8_t* head() const;
@@ -103,8 +105,6 @@ class SimpleMemoryAllocator {
   uint8_t* head_;
   uint8_t* tail_;
   uint8_t* temp_;
-
-  TF_LITE_REMOVE_VIRTUAL_DELETE
 };
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
@@ -26,7 +26,7 @@ EXAMPLES="-e hello_world -e magic_wand -e micro_speech -e person_detection"
 
 TEST_OUTPUT_DIR=$(mktemp -d)
 
-#readable_run \
+readable_run \
   python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py \
   ${TEST_OUTPUT_DIR} \
   ${EXAMPLES}

--- a/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
@@ -51,6 +51,8 @@ rm -rf ${TEST_OUTPUT_DIR}
 
 # Check that we can export a TFLM tree with additional makefile options.
 TEST_OUTPUT_DIR_CMSIS=$(mktemp -d)
+
+
 readable_run \
   python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py \
   --makefile_options="TARGET=cortex_m_generic OPTIMIZED_KERNEL_DIR=cmsis_nn TARGET_ARCH=project_generation" \
@@ -58,11 +60,17 @@ readable_run \
   ${EXAMPLES}
 
 readable_run cp tensorflow/lite/micro/tools/project_generation/Makefile ${TEST_OUTPUT_DIR_CMSIS}
+
+#readable_run \
+#  tensorflow/lite/micro/tools/make/arm_gcc_download.sh \
+#  ${TEST_OUTPUT_DIR_CMSIS}
+
 pushd ${TEST_OUTPUT_DIR_CMSIS} > /dev/null
 
-readable_run PATH=${PATH}:${ROOT_DIR}/tensorflow/lite/micro/tools/make/downloads/gcc_embedded/bin \
+PATH=${PATH}:${ROOT_DIR}/tensorflow/lite/micro/tools/make/downloads/gcc_embedded/bin \
+  readable_run \
   make -j8 BUILD_TYPE=cmsis_nn
 
 popd > /dev/null
 
-rm -rf ${TEST_OUTPUT_DIR_CMSIS}
+#rm -rf ${TEST_OUTPUT_DIR_CMSIS}

--- a/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
@@ -22,15 +22,14 @@ cd "${ROOT_DIR}"
 
 source tensorflow/lite/micro/tools/ci_build/helper_functions.sh
 
+EXAMPLES="-e hello_world -e magic_wand -e micro_speech -e person_detection"
+
 TEST_OUTPUT_DIR=$(mktemp -d)
 
-readable_run \
+#readable_run \
   python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py \
   ${TEST_OUTPUT_DIR} \
-  -e hello_world \
-  -e magic_wand \
-  -e micro_speech \
-  -e person_detection
+  ${EXAMPLES}
 
 # Confirm that print_src_files and print_dest_files output valid paths (and
 # nothing else).
@@ -52,9 +51,18 @@ rm -rf ${TEST_OUTPUT_DIR}
 
 # Check that we can export a TFLM tree with additional makefile options.
 TEST_OUTPUT_DIR_CMSIS=$(mktemp -d)
-readable_run python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py \
-  --makefile_options="TARGET=cortex_m_generic OPTIMIZED_KERNEL_DIR=cmsis_nn TARGET_ARCH=cortex-m4" \
-  ${TEST_OUTPUT_DIR_CMSIS}
+readable_run \
+  python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py \
+  --makefile_options="TARGET=cortex_m_generic OPTIMIZED_KERNEL_DIR=cmsis_nn TARGET_ARCH=project_generation" \
+  ${TEST_OUTPUT_DIR_CMSIS} \
+  ${EXAMPLES}
+
+readable_run cp tensorflow/lite/micro/tools/project_generation/Makefile ${TEST_OUTPUT_DIR_CMSIS}
+pushd ${TEST_OUTPUT_DIR_CMSIS} > /dev/null
+
+readable_run PATH=${PATH}:${ROOT_DIR}/tensorflow/lite/micro/tools/make/downloads/gcc_embedded/bin \
+  make -j8 BUILD_TYPE=cmsis_nn
+
+popd > /dev/null
 
 rm -rf ${TEST_OUTPUT_DIR_CMSIS}
-

--- a/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
@@ -19,6 +19,9 @@
 FLOAT := soft
 GCC_TARGET_ARCH := $(TARGET_ARCH)
 
+# Explicitly set this to true to include the kissfft symbols.
+INCLUDE_MICRO_SPEECH := false
+
 ifeq ($(TARGET_ARCH), cortex-m0)
   CORE=M0
   ARM_LDFLAGS := -Wl,--cpu=Cortex-M0
@@ -75,6 +78,8 @@ else ifeq ($(TARGET_ARCH), cortex-m7+fp)
   FLOAT=hard
   GCC_TARGET_ARCH := cortex-m7
 
+else ifeq ($(TARGET_ARCH), project_generation)
+ # None of the parameters matter since we are not going to build any code.
 else
   $(error "TARGET_ARCH=$(TARGET_ARCH) is not supported")
 endif
@@ -156,7 +161,12 @@ CCFLAGS += $(PLATFORM_FLAGS)
 MICROLITE_CC_HDRS += \
   tensorflow/lite/micro/cortex_m_generic/debug_log_callback.h
 
-EXCLUDED_EXAMPLE_TESTS := \
-  tensorflow/lite/micro/examples/micro_speech/Makefile.inc
-MICRO_LITE_EXAMPLE_TESTS := $(filter-out $(EXCLUDED_EXAMPLE_TESTS), $(MICRO_LITE_EXAMPLE_TESTS))
-
+# We only include micro_speech for project generation to allow for all the files
+# to be downloaded. We do not include it for an actual build with the
+# cortex_m_generic target to prevent kissfft symbols from getting included in
+# libtensorflow-microlite.a which can result in symbol collision.
+ifneq ($(TARGET_ARCH), project_generation)
+  EXCLUDED_EXAMPLE_TESTS := \
+    tensorflow/lite/micro/examples/micro_speech/Makefile.inc
+  MICRO_LITE_EXAMPLE_TESTS := $(filter-out $(EXCLUDED_EXAMPLE_TESTS), $(MICRO_LITE_EXAMPLE_TESTS))
+endif

--- a/tensorflow/lite/micro/tools/project_generation/Makefile
+++ b/tensorflow/lite/micro/tools/project_generation/Makefile
@@ -19,13 +19,18 @@
 # TFLM tree created with the project generation script:
 # make -j8 examples
 
-CXX := clang++
-CXXFLAGS := \
-  -std=c++11
+BUILD_TYPE :=
 
+COMMON_FLAGS := \
+  -DTF_LITE_STATIC_MEMORY \
+  -fno-unwind-tables \
+  -ffunction-sections \
+  -fdata-sections \
+  -fmessage-length=0
+
+CXX := clang++
 CC := clang
-CCFLAGS := \
-  -std=c11
+AR := ar
 
 INCLUDES := \
   -I. \
@@ -35,7 +40,39 @@ INCLUDES := \
   -I./third_party/kissfft/tools \
   -I./third_party/ruy
 
-AR := ar
+ifeq ($(BUILD_TYPE), cmsis_nn)
+  CXX := arm-none-eabi-g++
+  CC := arm-none-eabi-gcc
+  AR := arm-none-eabi-ar
+
+  INCLUDES += \
+  	-I./third_party/cmsis \
+    -I./third_party/cmsis/CMSIS/Core/Include \
+    -I./third_party/cmsis/CMSIS/DSP/Include \
+    -I./third_party/cmsis/CMSIS/NN/Include
+
+  COMMON_FLAGS += \
+    -DTF_LITE_MCU_DEBUG_LOG \
+    -mthumb \
+    -mlittle-endian \
+    -funsigned-char \
+    -fomit-frame-pointer \
+    -MD \
+    -DCMSIS_NN
+
+endif
+
+CXXFLAGS := \
+  -std=c++11 \
+  -fno-rtti \
+  -fno-exceptions \
+  -fno-threadsafe-statics \
+  $(COMMON_FLAGS)
+
+CCFLAGS := \
+  -std=c11 \
+  $(COMMON_FLAGS)
+
 ARFLAGS := -r
 
 GENDIR := gen


### PR DESCRIPTION
 * This enables use to use the create_tflm_tree.py script correctly for all the examples.

 * The special behavior for `TARGET=cortex_m_generic TARGET_ARCH=project_generation` is to not exclude the micro_speech example (and its dependencies) is the list of sources.

 * We do not want to have micro_speech dependencies as part of a non-project generation build because it means that libtensorflow-microlite.a will have kissfft symbols which can lead to symbol collisions.

Also, improved the CI for project generation with cortex_m_generic, which needed some of the TF_LITE_REMOVE_VIRTUAL_DELETE calls to be moved from private to public sections.

BUG=http://b/193823889
