### PR TITLE
Have make fail if C++ array generation fails

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
@@ -49,9 +49,10 @@ popd > /dev/null
 
 rm -rf ${TEST_OUTPUT_DIR}
 
-# Check that we can export a TFLM tree with additional makefile options.
-TEST_OUTPUT_DIR_CMSIS=$(mktemp -d)
+# Remove existing state prior to testing project generation for cortex-m target.
+make -f tensorflow/lite/micro/tools/make/Makefile clean clean_downloads
 
+TEST_OUTPUT_DIR_CMSIS=$(mktemp -d)
 
 readable_run \
   python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py \
@@ -60,10 +61,6 @@ readable_run \
   ${EXAMPLES}
 
 readable_run cp tensorflow/lite/micro/tools/project_generation/Makefile ${TEST_OUTPUT_DIR_CMSIS}
-
-#readable_run \
-#  tensorflow/lite/micro/tools/make/arm_gcc_download.sh \
-#  ${TEST_OUTPUT_DIR_CMSIS}
 
 pushd ${TEST_OUTPUT_DIR_CMSIS} > /dev/null
 

--- a/tensorflow/lite/micro/tools/make/helper_functions.inc
+++ b/tensorflow/lite/micro/tools/make/helper_functions.inc
@@ -493,9 +493,16 @@ $(1)_LOCAL_SRCS := $(2)
 ifneq ($(4),)
   # Generate cc files and headers for all models and bitmaps in the test.
   GEN_RESULT := $$(shell python3 tensorflow/lite/micro/tools/generate_cc_arrays.py $$(GENERATED_SRCS_DIR) $(4))
-  ifneq ($$(.SHELLSTATUS),0)
-    $$(error Something went wrong: $$(GEN_RESULT))
+
+  # The first ifneq is needed to be compatible with make versions prior to 4.2
+  # which do not support .SHELLSTATUS. While make 4.2 was released in 2016,
+  # Ubuntu 18.04 only has version 4.1
+  ifneq ($(.SHELLSTATUS),)
+    ifneq ($$(.SHELLSTATUS),0)
+      $$(error Something went wrong: $$(GEN_RESULT))
+    endif
   endif
+
   $(1)_LOCAL_SRCS += $$(GEN_RESULT)
 endif
 

--- a/tensorflow/lite/micro/tools/make/helper_functions.inc
+++ b/tensorflow/lite/micro/tools/make/helper_functions.inc
@@ -492,7 +492,11 @@ $(1)_LOCAL_SRCS := $(2)
 
 ifneq ($(4),)
   # Generate cc files and headers for all models and bitmaps in the test.
-  $(1)_LOCAL_SRCS += $$(shell python3 tensorflow/lite/micro/tools/generate_cc_arrays.py $$(GENERATED_SRCS_DIR) $(4))
+  GEN_RESULT := $$(shell python3 tensorflow/lite/micro/tools/generate_cc_arrays.py $$(GENERATED_SRCS_DIR) $(4))
+  ifneq ($$(.SHELLSTATUS),0)
+    $$(error Something went wrong: $$(GEN_RESULT))
+  endif
+  $(1)_LOCAL_SRCS += $$(GEN_RESULT)
 endif
 
 $(1)_LOCAL_SRCS := $$(call specialize,$$($(1)_LOCAL_SRCS))


### PR DESCRIPTION
Prior to this change, the generate_cc_arrays.py script could fail (for example because PIL not being installed) but the error would be silently ignored. Instead, the build would fail much later because of missing header files and the root cause would be hard to debug.

Follow-up PR will also use this error handling approach for other places where we call into Python and bash scripts from the make.

Manually tested by introducing an error in the Python script and confirming that the make command fails:
```
make -f tensorflow/lite/micro/tools/make/Makefile build
find: ‘../google/’: No such file or directory
tensorflow/lite/micro/tools/make/downloads/flatbuffers already exists, skipping the download.
tensorflow/lite/micro/tools/make/downloads/pigweed already exists, skipping the download.
tensorflow/lite/micro/tools/make/downloads/person_model_int8 already exists, skipping the download.
Traceback (most recent call last):
  File "/home/advaitjain/github/tflite-micro/tensorflow/lite/micro/tools/generate_cc_arrays.py", line 22, in <module>
    from PIL import Ima
ImportError: cannot import name 'Ima' from 'PIL' (/usr/lib/python3/dist-packages/PIL/__init__.py)
tensorflow/lite/micro/examples/person_detection/Makefile.inc:58: *** Something went wrong: .  Stop.
```

BUG=http://b/196630709