### PR TITLE
xtensa downloads:

### DIFF
--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
@@ -64,9 +64,10 @@ LIBRARY_INSTALL_PATH=${DOWNLOADS_DIR}/${LIBRARY_DIRNAME}
 if [ -d ${LIBRARY_INSTALL_PATH} ]; then
   echo >&2 "${LIBRARY_INSTALL_PATH} already exists, skipping the download."
 else
-  TMP_ZIP_ARCHIVE_NAME="${LIBRARY_DIRNAME}.zip"
-  wget ${LIBRARY_URL} -O /tmp/${TMP_ZIP_ARCHIVE_NAME} >&2
-  MD5=`md5sum /tmp/${TMP_ZIP_ARCHIVE_NAME} | awk '{print $1}'`
+  TEMPDIR="$(mktemp -d)"
+  TEMPFILE="${TEMPDIR}/${LIBRARY_DIRNAME}.zip"
+  wget ${LIBRARY_URL} -O "$TEMPFILE" >&2
+  MD5=`md5sum "$TEMPFILE" | awk '{print $1}'`
 
   if [[ ${MD5} != ${LIBRARY_MD5} ]]
   then
@@ -74,8 +75,9 @@ else
     exit 1
   fi
 
-  unzip -qo /tmp/${TMP_ZIP_ARCHIVE_NAME} -d ${DOWNLOADS_DIR} >&2
+  unzip -qo "$TEMPFILE" -d ${DOWNLOADS_DIR} >&2
 
+  rm -rf "${TEMPDIR}"
 fi
 
 echo "SUCCESS"


### PR DESCRIPTION
Currently script uses /tmp directory for the the xtensa downloads.
Modifying sciprt to resolve the issue, mktemp creates unique folder.

BUG=usage of /tmp directory for the xtensa downloads.