### PR TITLE
Make size check workflow error out if memory footprint increase

### DIFF
--- a/.github/workflows/size_check.yml
+++ b/.github/workflows/size_check.yml
@@ -20,9 +20,16 @@ jobs:
 
     name: Binary Size Estimation
     steps:
+      - name: Get build with PR
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Get build from main
+        uses: actions/checkout@v2
+        with:
+          path: main_ref
+
 
       - name: Install dependencies
         run: |
@@ -31,17 +38,22 @@ jobs:
       - name: Build binary
         run: |
           tensorflow/lite/micro/tools/ci_build/test_size.sh
+          main_ref/tensorflow/lite/micro/tools/ci_build/test_size.sh
 
-      - name: Update size history and commit
+      # If PR has MEM_CHANGE_OK tag, then does not error out on memory footprint
+      # increase and simply produce a report for reviewer to check.
+      # Example tag format:
+      # MEM_CHANGE_OK=why_the_change_is_ok
+      # Comparison of size before and after that change: (A copy from the below step output)
+      #  data: old xxxx, new xxx
+      - name: Compare size between main and PR build
+        if: ${{ contains(github.event.pull_request.body, 'MEM_CHANGE_OK=') }}
         run: |
-          # Live debug inconsistency between manual trigger and ci:test label.
-          git status
-          rm -rf tensorflow/lite/micro/tools/ci_build/binary_size_history/binary_size.json
-          ci/size_comp.py -t ci/size_log.txt tensorflow/lite/micro/tools/ci_build/binary_size_history/binary_size.json
-          git config user.name tflm_bot
-          git config user.email tflm_bot@github.com
-          git add tensorflow/lite/micro/tools/ci_build/binary_size_history/*
-          # Live debug inconsistency between manual trigger and ci:test label.
-          git status
-          git commit --allow-empty  -m "Update binary size history by CI bot"
-          git push origin HEAD:${GITHUB_HEAD_REF} 
+          ci/size_comp.py -a main_ref/ci/size_log.txt ci/size_log.txt
+
+      # If PR does not have MEM_CHANGE_OK tag, then error out on memory footprint
+      # increase.
+      - name: Check size does not increase between main and PR build
+        if: ${{ contains(github.event.pull_request.body, 'MEM_CHANGE_OK=') }}
+        run: |
+          ci/size_comp.py -a main_ref/ci/size_log.txt ci/size_log.txt --error_on_mem_increase

--- a/ci/size_comp.py
+++ b/ci/size_comp.py
@@ -43,6 +43,28 @@ def compare_val_in_files(old_file, new_file, val='bss'):
 
     return()
 
+def compare_all_val_in_files(old_file, new_file, error_on_mem_increase):
+    old_dict = file_to_dict(old_file)
+    new_dict = file_to_dict(new_file)
+    any_mem_increase = False
+    for section, val in old_dict.items():
+        if int(new_dict[section]) > int(old_dict[section]):
+            print(section, " larger than previous value")
+            print("old: ", old_dict[section])
+            print("new: ", new_dict[section])
+            any_mem_increase = True
+        else:
+            print(section)
+            print("old: ", old_dict[section])
+            print("new: ", new_dict[section])
+
+    if any_mem_increase:
+        print("Warning: memory foot print increases!")
+        if error_on_mem_increase:
+            sys.exit(1)
+
+    return()
+
 def berkeley_size_format_to_json_file(input_file, output_file):
     output_dict = file_to_dict(input_file)
     with open(output_file, 'w') as outfile:
@@ -55,6 +77,8 @@ if __name__=="__main__":
     parser.add_argument("-t","--transform", help="transform a berkeley size format file to a json file", nargs=2)
     parser.add_argument("-c","--compare", help="compare value in old file to new file", nargs=2)
     parser.add_argument("-v","--value", default="bss", help="value to be compared")
+    parser.add_argument("-a","--compare_all", help="compare all value in old file to new file", nargs=2)
+    parser.add_argument("-e","--error_on_mem_increase", default=False, action="store_true", help="error exit on memory footprint increase")
     args = parser.parse_args()
 
     if args.transform:
@@ -62,5 +86,7 @@ if __name__=="__main__":
 
     if args.compare:
         compare_val_in_files(args.compare[0], args.compare[1], args.value)
-              
+
+    if args.compare_all:
+        compare_all_val_in_files(args.compare_all[0], args.compare_all[1], args.error_on_mem_increase)
 


### PR DESCRIPTION
between head of main and this PR.

This error can be disabled by putting MEM_CHANGE_OK= tag.
In either case, a memory footprint comparison report will be produced
as part of this workflow action.

The plan is for the code reviewer to audit the report when the
PR increase memory footprint and only
allow the PR that increase memory footprint to be merged with
MEM_CHANGE_OK=what_is_the_reason_for_this_increase_and_why_this_is_ok

The PR shall be up to date for the comparison to be accurate.
So before applying MEM_CHANGE_OK=, please make the PR branch up to date.

BUG=http://b/196637015