### PR TITLE
Add README instructions for generating projects for cortex m generic, ensure include paths are added to cortex_m_generic makefile

### DIFF
--- a/tensorflow/lite/micro/cortex_m_generic/README.md
+++ b/tensorflow/lite/micro/cortex_m_generic/README.md
@@ -63,3 +63,23 @@ providing `CMSIS_PATH` to the Makefile:
 ```
 make -f tensorflow/lite/micro/tools/make/Makefile TARGET=cortex_m_generic TARGET_ARCH=cortex-m4+fp OPTIMIZED_KERNEL_DIR=cmsis_nn CMSIS_PATH=/path/to/own/cmsis microlite
 ```
+
+
+If you want to generate a project for your specific build you can do the following
+
+```
+make -f tensorflow/lite/micro/tools/make/Makefile TARGET=cortex_m_generic TARGET_ARCH=cortex-m4+fp generate_hello_world_make_project
+cd ~/tflite-micro/tensorflow/lite/micro/tools/make/gen/cortex_m_generic_cortex-m4+fp_default/prj/hello_world/make
+make -j
+
+```
+
+If you want to generate a project that includes CMSIS kernel, the make project generator gets some of the paths wrong for the CMSIS kernel. To fix you will need to correct paths doing the following. 
+
+```
+make -f tensorflow/lite/micro/tools/make/Makefile TARGET=cortex_m_generic TARGET_ARCH=cortex-m4+fp OPTIMIZED_KERNEL_DIR=cmsis_nn generate_hello_world_make_project
+cd ~/tflite-micro/tensorflow/lite/micro/tools/make/gen/cortex_m_generic_cortex-m4+fp_default/prj/hello_world/make
+sed -i 's|tensorflow/lite/micro/tools/make/downloads/cmsis/|./|g' Makefile
+mv tensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/ .
+make -j
+```

--- a/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
@@ -157,6 +157,18 @@ PLATFORM_FLAGS = \
 CXXFLAGS += $(PLATFORM_FLAGS)
 CCFLAGS += $(PLATFORM_FLAGS)
 
+ifeq ($(OPTIMIZED_KERNEL_DIR), cmsis_nn)
+  CCFLAGS += \
+    -I./CMSIS/Core/Include/ \
+    -I./CMSIS/DSP/Include/ \
+    -I./CMSIS/NN/Include/ 
+
+  CXXFLAGS += \
+    -I./CMSIS/Core/Include/ \
+    -I./CMSIS/DSP/Include/ \
+    -I./CMSIS/NN/Include/     
+endif
+
 # Needed for the project generation interface.
 MICROLITE_CC_HDRS += \
   tensorflow/lite/micro/cortex_m_generic/debug_log_callback.h


### PR DESCRIPTION
cortex-m-generic and CMSIS, update makefile to ensure Include paths for CMSIS
are added to the project file