### PR TITLE
Fix tensor data loading on big-endian targets 

### DIFF
--- a/tensorflow/lite/micro/examples/hello_world/main_functions.cc
+++ b/tensorflow/lite/micro/examples/hello_world/main_functions.cc
@@ -33,7 +33,7 @@ TfLiteTensor* input = nullptr;
 TfLiteTensor* output = nullptr;
 int inference_count = 0;
 
-constexpr int kTensorArenaSize = 2000;
+constexpr int kTensorArenaSize = 3000;
 uint8_t tensor_arena[kTensorArenaSize];
 }  // namespace
 


### PR DESCRIPTION
This is a proof of concept of how a solution for #455 might look like. 

We make `InitializeTfLiteTensorFromFlatbuffer` and `InitializeTfLiteEvalTensorFromFlatbuffer` use `FlatBufferVectorToTfLiteTypeArray` instead of directly assigning a pointer into FlatBuffer data to the tensor's data field. 

This does not fully solve the problem, because it only handles `int32`s (so, as it stands, big-endian targets will be able to correctly read all 8-bit types and `int32`), but it's enough to get the `hello_world` example to run and give correct outputs on SPARC (leon3).