### PR TITLE
Experimental pull request for review of use of ExternalContext to share network context between application and operators.

### DIFF
--- a/tensorflow/lite/c/common.h
+++ b/tensorflow/lite/c/common.h
@@ -55,7 +55,8 @@ typedef enum TfLiteExternalContextType {
   kTfLiteGemmLowpContext = 1,    // include gemm_support.h to use.
   kTfLiteEdgeTpuContext = 2,     // Placeholder for Edge TPU support.
   kTfLiteCpuBackendContext = 3,  // include cpu_backend_context.h to use.
-  kTfLiteMaxExternalContexts = 4
+  kTfLiteTnneNetworkContext = 4, // include xa_tnne_nw_context.h to use.
+  kTfLiteMaxExternalContexts = 5
 } TfLiteExternalContextType;
 
 // Forward declare so dependent structs and methods can reference these types

--- a/tensorflow/lite/micro/examples/person_detection/person_detection_test.cc
+++ b/tensorflow/lite/micro/examples/person_detection/person_detection_test.cc
@@ -23,10 +23,13 @@ limitations under the License.
 #include "tensorflow/lite/micro/models/person_detect_model_data.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
 #include "tensorflow/lite/schema/schema_generated.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xa_tnne_nw_context.h"
 
 // Create an area of memory to use for input, output, and intermediate arrays.
 constexpr int tensor_arena_size = 136 * 1024;
 uint8_t tensor_arena[tensor_arena_size];
+
+XaTnneNetworkContext foo;
 
 TF_LITE_MICRO_TESTS_BEGIN
 
@@ -60,6 +63,11 @@ TF_LITE_MICRO_TEST(TestInvoke) {
   tflite::MicroInterpreter interpreter(model, micro_op_resolver, tensor_arena,
                                        tensor_arena_size,
                                        &micro_error_reporter);
+  
+  memset(&foo.nw_ctx, 0, sizeof(xa_tnne_nw_context));
+  foo.type = kTfLiteTnneNetworkContext; 
+  interpreter.SetExternalContext(kTfLiteTnneNetworkContext, &foo);
+
   interpreter.AllocateTensors();
 
   // Get information about the memory area to use for the model's input.

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/xtensa/fixedpoint_utils.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xa_tnne_nw_context.h"
 
 namespace tflite {
 namespace {
@@ -40,6 +41,16 @@ void* Init(TfLiteContext* context, const char* buffer, size_t length) {
 }
 
 TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  
+  XaTnneNetworkContext *foo;
+  foo = reinterpret_cast<XaTnneNetworkContext*>(
+            context->GetExternalContext(context, kTfLiteTnneNetworkContext));
+  if (foo->nw_ctx.init_done == 0) {
+    fprintf(stderr, "init_done = %d, foo: %p \n", foo->nw_ctx.init_done, foo);
+    foo->nw_ctx.init_done = 1;
+  }
+  fprintf(stderr, "init_done = %d, foo: %p \n", foo->nw_ctx.init_done, foo);
+    
   TF_LITE_ENSURE_OK(context, DepthwiseConvPrepare(context, node));
 
 #if defined(HIFI4) || defined(HIFI5)

--- a/tensorflow/lite/micro/kernels/xtensa/xa_tnne_nw_context.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xa_tnne_nw_context.h
@@ -1,0 +1,16 @@
+#ifndef __XA_TNNE_NW_CONTEXT_H__
+#define __XA_TNNE_NW_CONTEXT_H__
+
+typedef struct xa_tnne_nw_context_s {
+  int init_done;
+  int net_id;
+  void *blob_ptr;
+  void *instance_id;
+
+} xa_tnne_nw_context;
+
+struct XaTnneNetworkContext : public TfLiteExternalContext {
+ xa_tnne_nw_context nw_ctx;
+};
+
+#endif /* __XA_TNNE_NW_CONTEXT_H__ */

--- a/tensorflow/lite/micro/micro_interpreter.cc
+++ b/tensorflow/lite/micro/micro_interpreter.cc
@@ -187,6 +187,14 @@ TfLiteStatus MicroInterpreter::PrepareNodeAndRegistrationDataFromFlatbuffer() {
   return kTfLiteOk;
 }
 
+TfLiteStatus MicroInterpreter::SetExternalContext(TfLiteExternalContextType type, 
+                                                  TfLiteExternalContext *ext_ctx) {
+  if (static_cast<int>(type) >= 0 && type < kTfLiteMaxExternalContexts) {
+    external_contexts_[type] = ext_ctx;
+  }
+  return kTfLiteOk;
+}
+
 TfLiteStatus MicroInterpreter::AllocateTensors() {
   SubgraphAllocations* allocations = allocator_.StartModelAllocation(model_);
 
@@ -206,6 +214,7 @@ TfLiteStatus MicroInterpreter::AllocateTensors() {
   context_.RequestScratchBufferInArena = nullptr;
   context_.GetScratchBuffer = nullptr;
   context_.GetExecutionPlan = GetGraph;
+  context_.GetExternalContext = GetExternalContext;
   graph_.InitSubgraphs();
 
   // Both AllocatePersistentBuffer and RequestScratchBufferInArena is
@@ -377,6 +386,19 @@ TfLiteStatus MicroInterpreter::GetGraph(struct TfLiteContext* context,
       reinterpret_cast<MicroInterpreter*>(context->impl_);
   *args = reinterpret_cast<TfLiteIntArray*>(&interpreter->graph_);
   return kTfLiteOk;
+}
+
+
+TfLiteExternalContext* MicroInterpreter::GetExternalContext(TfLiteContext* context,
+                                          TfLiteExternalContextType type)
+{
+  MicroInterpreter* interpreter =
+      reinterpret_cast<MicroInterpreter*>(context->impl_);
+
+  if (static_cast<int>(type) >= 0 && type < kTfLiteMaxExternalContexts) {
+    return interpreter->external_contexts_[type];
+  }
+  return nullptr;
 }
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/micro_interpreter.h
+++ b/tensorflow/lite/micro/micro_interpreter.h
@@ -69,6 +69,9 @@ class MicroInterpreter {
   // TODO(b/149795762): Add this to the TfLiteStatus enum.
   TfLiteStatus Invoke();
 
+  TfLiteStatus SetExternalContext(TfLiteExternalContextType type, 
+                                  TfLiteExternalContext *ext_ctx);
+
   TfLiteTensor* input(size_t index);
   size_t inputs_size() const {
     return model_->subgraphs()->Get(0)->inputs()->size();
@@ -124,6 +127,9 @@ class MicroInterpreter {
   // arena_used_bytes() + 16.
   size_t arena_used_bytes() const { return allocator_.used_bytes(); }
 
+  // List of active external contexts.
+  TfLiteExternalContext* external_contexts_[kTfLiteMaxExternalContexts];
+
  protected:
   const MicroAllocator& allocator() const { return allocator_; }
   const TfLiteContext& context() const { return context_; }
@@ -150,6 +156,8 @@ class MicroInterpreter {
                                          int tensor_idx);
   static TfLiteStatus GetGraph(struct TfLiteContext* context,
                                TfLiteIntArray** args);
+  static TfLiteExternalContext* GetExternalContext(TfLiteContext* context,
+                                                   TfLiteExternalContextType type);
 
   const Model* model_;
   const MicroOpResolver& op_resolver_;


### PR DESCRIPTION
@petewarden , @advaitjain 

Could you please review this experimental PR which tries to add and use Get/SetExternalContext interface to share network context from application to operators?
Note, this is a dirty implementation, only for review of flow and use of interface.
(For e.g. TfLiteExternalContext* external_contexts_[kTfLiteMaxExternalContexts] is not a private array currently).
