### PR TITLE
Create a size comparison report when running xtensa fusion_f1 presubmit test

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_size.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_size.sh
@@ -98,7 +98,9 @@ CURRENT_BINARY=${__BINARY_TARGET_PATH}
 size ${CURRENT_BINARY} > ${ROOT_DIR}/ci/size_log.txt
 
 # Get a clone of the main repo as the reference.
-REF_ROOT_DIR="$(mktemp -d ${ROOT_DIR}/../main_ref.XXXXXX)"
+# This is nested in the current repo because in the case that we need to
+# run docker, only the current repo root is mounted.
+REF_ROOT_DIR="$(mktemp -d ${ROOT_DIR}/main_ref.XXXXXX)"
 git clone https://github.com/tensorflow/tflite-micro.git  ${REF_ROOT_DIR}
 
 # Build a binary for the main repo.

--- a/tensorflow/lite/micro/tools/ci_build/test_size.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_size.sh
@@ -38,6 +38,8 @@ __BINARY_TARGET_PATH=
 function build_target() {
   local make_args=$@
   local binary_target=$1
+  # TODO(b/143904317): downloading first to allow for parallel builds.
+  readable_run make -f tensorflow/lite/micro/tools/make/Makefile third_party_downloads
   readable_run make -j8 -f tensorflow/lite/micro/tools/make/Makefile build ${make_args}
 
   # Return the relative binary with path and name.
@@ -79,7 +81,7 @@ done
 
 # Print out the configuration for better on target support
 echo FLAG_ERROR_ON_MEM_INCREASE is ${FLAG_ERROR_ON_MEM_INCREASE}
-echo other makefile flags are ${OTHER_MAKEFLAGS}
+echo makefile flags are ${MAKEFLAGS}
 
 # Pick keyword_benchmark as the target
 BENCHMARK_TARGET=keyword_benchmark
@@ -98,9 +100,7 @@ CURRENT_BINARY=${__BINARY_TARGET_PATH}
 size ${CURRENT_BINARY} > ${ROOT_DIR}/ci/size_log.txt
 
 # Get a clone of the main repo as the reference.
-# This is nested in the current repo because in the case that we need to
-# run docker, only the current repo root is mounted.
-REF_ROOT_DIR="$(mktemp -d ${ROOT_DIR}/main_ref.XXXXXX)"
+REF_ROOT_DIR="$(mktemp -d ${ROOT_DIR}/../main_ref.XXXXXX)"
 git clone https://github.com/tensorflow/tflite-micro.git  ${REF_ROOT_DIR}
 
 # Build a binary for the main repo.

--- a/tensorflow/lite/micro/tools/ci_build/test_xtensa_fusion_f1.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_xtensa_fusion_f1.sh
@@ -41,3 +41,11 @@ readable_run make -f tensorflow/lite/micro/tools/make/Makefile \
   OPTIMIZED_KERNEL_DIR=xtensa \
   XTENSA_CORE=F1_190305_swupgrade \
   test -j$(nproc)
+
+# Generate a size comparison report versus the main repo.
+tensorflow/lite/micro/tools/ci_build/test_size.sh \
+  TARGET=xtensa \
+  TARGET_ARCH=hifi4 \
+  OPTIMIZED_KERNEL_DIR=xtensa \
+  XTENSA_CORE=F1_190305_swupgrade \
+  BUILD_TYPE=release


### PR DESCRIPTION
Call test_size.sh to produce size comparison report in test_xtensafusion_f1.sh and change test_size.sh to take more makefile arguments.
    
The reason to piggy back to test_xtensa_fusion_f1.sh script is to avoid loading the docker again in presubmit.
    
This change will lead to produce a size comparison report at fusion_f1 presubmit test, but will not lead to failure in presubmit yet if the size increase. Presubmit failure on size increase will be only be enabled later after more tests.
    
keyword_benchmark is chosen as the size bench mark target.
    
BUG=http://b/196637015
