### PR TITLE
Add option to provide an external CMSIS-NN lib

### DIFF
--- a/tensorflow/lite/micro/kernels/cmsis_nn/README.md
+++ b/tensorflow/lite/micro/kernels/cmsis_nn/README.md
@@ -8,6 +8,11 @@ processors. To use CMSIS-NN optimized kernels instead of reference kernels, add
 For more information about the optimizations, check out
 [CMSIS-NN documentation](https://github.com/ARM-software/CMSIS_5/blob/develop/CMSIS/NN/README.md)
 
+By default CMSIS-NN is built by code that is downloaded to the TFLM tree.
+It also possible to build CMSIS-NN code from an external path by specifying CMSIS_PATH=<../path>.
+As a third option CMSIS-NN can be provided manually as an external library.
+The examples below will illustrate this.
+
 # Example 1
 
 A simple way to compile a binary with CMSIS-NN optimizations.
@@ -24,7 +29,14 @@ mbed. Here's an example on how to do that. Start by generating an mbed project.
 
 ```
 make -f tensorflow/lite/micro/tools/make/Makefile OPTIMIZED_KERNEL_DIR=cmsis_nn \
-generate_person_detection_int8_mbed_project
+generate_micro_speech_mbed_project
+```
+
+Currently this workaround is needed. See: https://github.com/tensorflow/tflite-micro/issues/475
+
+```
+cp tensorflow/lite/micro/tools/make/gen/linux_x86_64_default/genfiles/tensorflow/lite/micro/examples/micro_speech/micro_speech_model_data.* \
+tensorflow/lite/micro/tools/make/gen/linux_x86_64_default/prj/micro_speech/mbed/tensorflow/lite/micro/examples/micro_speech/
 ```
 
 Go into the generated mbed project folder, currently:
@@ -39,24 +51,6 @@ and setup mbed.
 mbed new .
 ```
 
-Note: Mbed has a dependency to an old version of arm_math.h. Therefore you need
-to copy the newer version as follows:
-
-```
-cp tensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/DSP/Include/\
-arm_math.h mbed-os/cmsis/TARGET_CORTEX_M/arm_math.h
-```
-
-There's also a dependency to an old cmsis_gcc.h, which you can fix with the
-following:
-
-```
-cp tensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/Core/Include/\
-cmsis_gcc.h mbed-os/cmsis/TARGET_CORTEX_M/cmsis_gcc.h
-```
-
-This issue will be resolved soon.
-
 Now type:
 
 ```
@@ -65,3 +59,26 @@ mbed compile -m DISCO_F746NG -t GCC_ARM
 
 and that gives you a binary for the DISCO_F746NG with CMSIS-NN optimized
 kernels.
+
+# Example 3 - FVP based on Arm Corstone-300 software.
+Building the kernel conv unit test.
+See tensorflow/lite/micro/cortex_m_corstone_300/README.md for more info about the target.
+
+Downloaded CMSIS-NN code is built:
+```
+make -f tensorflow/lite/micro/tools/make/Makefile OPTIMIZED_KERNEL_DIR=cmsis_nn TARGET=cortex_m_corstone_300 TARGET_ARCH=cortex-m55 kernel_conv_test
+```
+
+External CMSIS-NN code is built:
+```
+make -f tensorflow/lite/micro/tools/make/Makefile OPTIMIZED_KERNEL_DIR=cmsis_nn CMSIS_PATH=<external/path/to/cmsis/> TARGET=cortex_m_corstone_300 TARGET_ARCH=cortex-m55 kernel_conv_test
+```
+
+External CMSIS-NN library is linked in:
+```
+make -f tensorflow/lite/micro/tools/make/Makefile OPTIMIZED_KERNEL_DIR=cmsis_nn CMSIS_NN_LIBS=<path/to/cmsis-nn.a> CMSIS_PATH=<path/to/cmsis/> TARGET=cortex_m_corstone_300 TARGET_ARCH=cortex-m55 kernel_conv_test
+```
+
+Please note that performance and/or size might be affected when using and external CMSIS-NN library as different compiler options may have been used.
+
+Also please note that if specifying CMSIS_NN_LIBS but not CMSIS_PATH, headers and system/startup code from the default download path of CMSIS would be used. So CMSIS_NN_LIBS and CMSIS_PATH should have the same base path and if not there will be a build error.

--- a/tensorflow/lite/micro/tools/make/ext_libs/cmsis_nn.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/cmsis_nn.inc
@@ -1,6 +1,12 @@
 # Enable u-arch specfic behaviours
 ifneq (,$(filter $(TARGET_ARCH), x86_64))
-    # CMSIS-NN optimizations not supported
+  # CMSIS-NN optimizations not supported
+endif
+
+ifneq (,$(CMSIS_NN_LIBS))
+  ifeq (,$(CMSIS_PATH))
+    $(error CMSIS_NN_LIBS provided but not CMSIS_PATH)
+  endif
 endif
 
 # Unless an external path is provided we force a download during the first
@@ -14,10 +20,12 @@ ifeq ($(CMSIS_PATH), $(CMSIS_DEFAULT_DOWNLOAD_PATH))
   endif
 endif
 
-THIRD_PARTY_CC_SRCS += \
-  $(call recursive_find,$(CMSIS_PATH)/CMSIS/NN/Source,*.c)
-THIRD_PARTY_CC_HDRS += \
-  $(call recursive_find,$(CMSIS_PATH)/CMSIS/NN/Include,*.h)
+ifeq (,$(CMSIS_NN_LIBS))
+  THIRD_PARTY_CC_SRCS += $(call recursive_find,$(CMSIS_PATH)/CMSIS/NN/Source,*.c)
+else
+  MICROLITE_LIBS += $(CMSIS_NN_LIBS)
+endif
+THIRD_PARTY_CC_HDRS += $(call recursive_find,$(CMSIS_PATH)/CMSIS/NN/Include,*.h)
 
 # Note all the headers from CMSIS/Core/Include are needed to ensure that the
 # project generation scripts copy over the compiler specific implementations of


### PR DESCRIPTION
Add new build option for when building with OPTIMIZED_KERNEL_DIR=cmsis_nn and also update the CMSIS-NN README.

This is a fix for: https://github.com/tensorflow/tflite-micro/issues/486