### PR TITLE
Refactor MicroAllocator such that a MemoryPlanner can be injected int…

### DIFF
--- a/tensorflow/lite/micro/memory_planner/greedy_memory_planner.cc
+++ b/tensorflow/lite/micro/memory_planner/greedy_memory_planner.cc
@@ -58,9 +58,14 @@ void ReverseSortInPlace(int* values, int* ids, int size) {
   } while (any_swapped);
 }
 
-GreedyMemoryPlanner::GreedyMemoryPlanner(unsigned char* scratch_buffer,
-                                         int scratch_buffer_size)
-    : buffer_count_(0), need_to_calculate_offsets_(true) {
+GreedyMemoryPlanner::GreedyMemoryPlanner() {}
+
+TfLiteStatus GreedyMemoryPlanner::Init(unsigned char* scratch_buffer,
+                                       int scratch_buffer_size) {
+  // Reset internal states
+  buffer_count_ = 0;
+  need_to_calculate_offsets_ = true;
+
   // Allocate the arrays we need within the scratch buffer arena.
   max_buffer_count_ = scratch_buffer_size / per_buffer_size();
 
@@ -78,6 +83,7 @@ GreedyMemoryPlanner::GreedyMemoryPlanner(unsigned char* scratch_buffer,
   next_free += sizeof(ListEntry) * max_buffer_count_;
 
   buffer_offsets_ = reinterpret_cast<int*>(next_free);
+  return kTfLiteOk;
 }
 
 GreedyMemoryPlanner::~GreedyMemoryPlanner() {

--- a/tensorflow/lite/micro/memory_planner/greedy_memory_planner.h
+++ b/tensorflow/lite/micro/memory_planner/greedy_memory_planner.h
@@ -58,7 +58,7 @@ class GreedyMemoryPlanner : public MicroMemoryPlanner {
   // reused once you're done with the planner, as long as you copy the
   // calculated offsets to another location. Each buffer requires about 36 bytes
   // of scratch.
-  TfLiteStatus Init(unsigned char* scratch_buffer, int scratch_buffer_size);
+  TfLiteStatus Init(unsigned char* scratch_buffer, int scratch_buffer_size) override;
 
   // Record details of a buffer we want to place.
   TfLiteStatus AddBuffer(ErrorReporter* error_reporter, int size,

--- a/tensorflow/lite/micro/memory_planner/greedy_memory_planner.h
+++ b/tensorflow/lite/micro/memory_planner/greedy_memory_planner.h
@@ -58,7 +58,8 @@ class GreedyMemoryPlanner : public MicroMemoryPlanner {
   // reused once you're done with the planner, as long as you copy the
   // calculated offsets to another location. Each buffer requires about 36 bytes
   // of scratch.
-  TfLiteStatus Init(unsigned char* scratch_buffer, int scratch_buffer_size) override;
+  TfLiteStatus Init(unsigned char* scratch_buffer,
+                    int scratch_buffer_size) override;
 
   // Record details of a buffer we want to place.
   TfLiteStatus AddBuffer(ErrorReporter* error_reporter, int size,

--- a/tensorflow/lite/micro/memory_planner/greedy_memory_planner.h
+++ b/tensorflow/lite/micro/memory_planner/greedy_memory_planner.h
@@ -45,17 +45,20 @@ constexpr int kOnlinePlannedBuffer = -1;
 // NP-Complete problem, but in practice it should produce one that's decent.
 class GreedyMemoryPlanner : public MicroMemoryPlanner {
  public:
-  // You need to pass in an area of memory to be used for planning. This memory
-  // needs to have a lifetime as long as the planner, but isn't owned by this
-  // object, so management should be handled by the client. This is so it can be
-  // stack or globally allocated if necessary on devices without dynamic memory
-  // allocation. How many buffers can be planned for will depend on the size of
-  // this scratch memory, so you should enlarge it if you see an error when
-  // calling AddBuffer(). The memory can be reused once you're done with the
-  // planner, as long as you copy the calculated offsets to another location.
-  // Each buffer requires about 36 bytes of scratch.
-  GreedyMemoryPlanner(unsigned char* scratch_buffer, int scratch_buffer_size);
+  GreedyMemoryPlanner();
   ~GreedyMemoryPlanner() override;
+
+  // You need to pass in an area of memory to be used for planning. The client
+  // should ensure the validity of the memory when it needs to use this object.
+  // This memory isn't owned by this object, so management should be handled by
+  // the client. This is so it can be stack or globally allocated if necessary
+  // on devices without dynamic memory allocation. How many buffers can be
+  // planned for will depend on the size of this scratch memory, so you should
+  // enlarge it if you see an error when calling AddBuffer(). The memory can be
+  // reused once you're done with the planner, as long as you copy the
+  // calculated offsets to another location. Each buffer requires about 36 bytes
+  // of scratch.
+  TfLiteStatus Init(unsigned char* scratch_buffer, int scratch_buffer_size);
 
   // Record details of a buffer we want to place.
   TfLiteStatus AddBuffer(ErrorReporter* error_reporter, int size,
@@ -65,7 +68,7 @@ class GreedyMemoryPlanner : public MicroMemoryPlanner {
   // offline_offset is the buffer offset from the start of the arena.
   TfLiteStatus AddBuffer(ErrorReporter* error_reporter, int size,
                          int first_time_used, int last_time_used,
-                         int offline_offset);
+                         int offline_offset) override;
 
   // Returns the high-water mark of used memory. This is the minimum size of a
   // memory arena you'd need to allocate to hold these buffers.

--- a/tensorflow/lite/micro/memory_planner/greedy_memory_planner_test.cc
+++ b/tensorflow/lite/micro/memory_planner/greedy_memory_planner_test.cc
@@ -93,7 +93,8 @@ TF_LITE_MICRO_TEST(TestReverseSortInPlace) {
 TF_LITE_MICRO_TEST(TestGreedyBasics) {
   tflite::MicroErrorReporter micro_error_reporter;
 
-  tflite::GreedyMemoryPlanner planner(g_scratch_buffer, kScratchBufferSize);
+  tflite::GreedyMemoryPlanner planner;
+  planner.Init(g_scratch_buffer, kScratchBufferSize);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
                           planner.AddBuffer(&micro_error_reporter, 10, 0, 1));
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
@@ -118,7 +119,8 @@ TF_LITE_MICRO_TEST(TestGreedyBasics) {
 TF_LITE_MICRO_TEST(TestGreedyMedium) {
   tflite::MicroErrorReporter micro_error_reporter;
 
-  tflite::GreedyMemoryPlanner planner(g_scratch_buffer, kScratchBufferSize);
+  tflite::GreedyMemoryPlanner planner;
+  planner.Init(g_scratch_buffer, kScratchBufferSize);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
                           planner.AddBuffer(&micro_error_reporter, 10, 0, 1));
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
@@ -163,7 +165,8 @@ TF_LITE_MICRO_TEST(TestGreedyMedium) {
 TF_LITE_MICRO_TEST(TestPersonDetectionModel) {
   tflite::MicroErrorReporter micro_error_reporter;
 
-  tflite::GreedyMemoryPlanner planner(g_scratch_buffer, kScratchBufferSize);
+  tflite::GreedyMemoryPlanner planner;
+  planner.Init(g_scratch_buffer, kScratchBufferSize);
   // These buffer sizes and time ranges are taken from the 250KB MobileNet model
   // used in the person detection example.
   TF_LITE_MICRO_EXPECT_EQ(
@@ -241,7 +244,8 @@ TF_LITE_MICRO_TEST(TestPersonDetectionModel) {
 TF_LITE_MICRO_TEST(TestOverlapCase) {
   tflite::MicroErrorReporter micro_error_reporter;
 
-  tflite::GreedyMemoryPlanner planner(g_scratch_buffer, kScratchBufferSize);
+  tflite::GreedyMemoryPlanner planner;
+  planner.Init(g_scratch_buffer, kScratchBufferSize);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
                           planner.AddBuffer(&micro_error_reporter, 100, 0, 1));
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
@@ -263,7 +267,8 @@ TF_LITE_MICRO_TEST(TestSmallScratch) {
 
   constexpr int scratch_buffer_size = 40;
   unsigned char scratch_buffer[scratch_buffer_size];
-  tflite::GreedyMemoryPlanner planner(scratch_buffer, scratch_buffer_size);
+  tflite::GreedyMemoryPlanner planner;
+  planner.Init(scratch_buffer, scratch_buffer_size);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
                           planner.AddBuffer(&micro_error_reporter, 100, 0, 1));
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteError,

--- a/tensorflow/lite/micro/memory_planner/micro_memory_planner.h
+++ b/tensorflow/lite/micro/memory_planner/micro_memory_planner.h
@@ -57,6 +57,16 @@ class MicroMemoryPlanner {
                                  int size, int first_time_used,
                                  int last_time_used) = 0;
 
+  // Record details of an offline planned buffer offset we want to place.
+  // offline_offset is the buffer offset from the start of the arena.
+  // This is to support offline memory planning from the flatbuffer metadata.
+  // By default, it returns an error.
+  virtual TfLiteStatus AddBuffer(ErrorReporter* error_reporter, int size,
+                                 int first_time_used, int last_time_used,
+                                 int offline_offset) {
+    return kTfLiteError;
+  }
+
   // The largest contiguous block of memory that's needed to hold the layout.
   virtual size_t GetMaximumMemorySize() = 0;
   // How many buffers have been added to the planner.
@@ -64,6 +74,16 @@ class MicroMemoryPlanner {
   // Calculated layout offset for the N-th buffer added to the planner.
   virtual TfLiteStatus GetOffsetForBuffer(tflite::ErrorReporter* error_reporter,
                                           int buffer_index, int* offset) = 0;
+
+  // Provides the scratch buffer in case that the memory planner needs it.
+  // The lifetime of scratch buffers lifetime lasts until the static memory plan
+  // is committed.
+  // The default implementation is for the memory planner that does not need
+  // scratch buffer and simply returns ok.
+  virtual TfLiteStatus Init(unsigned char* scratch_buffer,
+                            int scratch_buffer_size) {
+    return kTfLiteOk;
+  }
 };
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -301,7 +301,7 @@ TfLiteStatus AllocationInfoBuilder::AddScratchBuffers(
 }
 
 TfLiteStatus CreatePlan(ErrorReporter* error_reporter,
-                        GreedyMemoryPlanner* planner,
+                        MicroMemoryPlanner* planner,
                         const AllocationInfo* allocation_info,
                         size_t allocation_info_size) {
   // Add the tensors to our allocation plan.
@@ -562,31 +562,54 @@ TfLiteStatus InitializeTfLiteEvalTensorFromFlatbuffer(
 }  // namespace internal
 
 MicroAllocator::MicroAllocator(SimpleMemoryAllocator* memory_allocator,
+                               MicroMemoryPlanner* memory_planner,
                                ErrorReporter* error_reporter)
     : memory_allocator_(memory_allocator),
+      memory_planner_(memory_planner),
       error_reporter_(error_reporter),
       model_is_allocating_(false) {}
 
 MicroAllocator::~MicroAllocator() {}
 
 MicroAllocator* MicroAllocator::Create(uint8_t* tensor_arena, size_t arena_size,
+                                       MicroMemoryPlanner* memory_planner,
                                        ErrorReporter* error_reporter) {
   uint8_t* aligned_arena = AlignPointerUp(tensor_arena, kBufferAlignment);
   size_t aligned_arena_size = tensor_arena + arena_size - aligned_arena;
-  return Create(SimpleMemoryAllocator::Create(error_reporter, aligned_arena,
-                                              aligned_arena_size),
-                error_reporter);
+  SimpleMemoryAllocator* memory_allocator = SimpleMemoryAllocator::Create(
+      error_reporter, aligned_arena, aligned_arena_size);
+
+  return Create(memory_allocator, memory_planner, error_reporter);
+}
+
+MicroAllocator* MicroAllocator::Create(uint8_t* tensor_arena, size_t arena_size,
+                                       ErrorReporter* error_reporter) {
+  uint8_t* aligned_arena = AlignPointerUp(tensor_arena, kBufferAlignment);
+  size_t aligned_arena_size = tensor_arena + arena_size - aligned_arena;
+  SimpleMemoryAllocator* memory_allocator = SimpleMemoryAllocator::Create(
+      error_reporter, aligned_arena, aligned_arena_size);
+
+  // By default create GreedyMemoryPlanner.
+  // If a different MemoryPlanner is needed, use the other api.
+  uint8_t* memory_planner_buffer = memory_allocator->AllocateFromTail(
+      sizeof(GreedyMemoryPlanner), alignof(GreedyMemoryPlanner));
+  GreedyMemoryPlanner* memory_planner =
+      new (memory_planner_buffer) GreedyMemoryPlanner();
+
+  return Create(memory_allocator, memory_planner, error_reporter);
 }
 
 MicroAllocator* MicroAllocator::Create(SimpleMemoryAllocator* memory_allocator,
+                                       MicroMemoryPlanner* memory_planner,
                                        ErrorReporter* error_reporter) {
   TFLITE_DCHECK(memory_allocator != nullptr);
   TFLITE_DCHECK(error_reporter != nullptr);
+  TFLITE_DCHECK(memory_planner != nullptr);
 
   uint8_t* allocator_buffer = memory_allocator->AllocateFromTail(
       sizeof(MicroAllocator), alignof(MicroAllocator));
-  MicroAllocator* allocator =
-      new (allocator_buffer) MicroAllocator(memory_allocator, error_reporter);
+  MicroAllocator* allocator = new (allocator_buffer)
+      MicroAllocator(memory_allocator, memory_planner, error_reporter);
   return allocator;
 }
 
@@ -976,9 +999,9 @@ TfLiteStatus MicroAllocator::CommitStaticMemoryPlan(
   uint8_t* planner_arena =
       memory_allocator_->AllocateTemp(remaining_arena_size, kBufferAlignment);
   TF_LITE_ENSURE(error_reporter_, planner_arena != nullptr);
-  GreedyMemoryPlanner planner(planner_arena, remaining_arena_size);
-  TF_LITE_ENSURE_STATUS(CreatePlan(error_reporter_, &planner, allocation_info,
-                                   allocation_info_count));
+  memory_planner_->Init(planner_arena, remaining_arena_size);
+  TF_LITE_ENSURE_STATUS(CreatePlan(error_reporter_, memory_planner_,
+                                   allocation_info, allocation_info_count));
 
   // Reset all temp allocations used above:
   memory_allocator_->ResetTempAllocations();
@@ -987,22 +1010,22 @@ TfLiteStatus MicroAllocator::CommitStaticMemoryPlan(
       memory_allocator_->GetAvailableMemory(kBufferAlignment);
 
   // Make sure we have enough arena size.
-  if (planner.GetMaximumMemorySize() > actual_available_arena_size) {
+  if (memory_planner_->GetMaximumMemorySize() > actual_available_arena_size) {
     TF_LITE_REPORT_ERROR(
         error_reporter_,
         "Arena size is too small for all buffers. Needed %u but only "
         "%u was available.",
-        planner.GetMaximumMemorySize(), actual_available_arena_size);
+        memory_planner_->GetMaximumMemorySize(), actual_available_arena_size);
     return kTfLiteError;
   }
   // Commit the plan.
-  TF_LITE_ENSURE_STATUS(CommitPlan(error_reporter_, &planner,
+  TF_LITE_ENSURE_STATUS(CommitPlan(error_reporter_, memory_planner_,
                                    memory_allocator_->GetHeadBuffer(),
                                    allocation_info, allocation_info_count));
 #ifdef TF_LITE_SHOW_MEMORY_USE
-  planner.PrintMemoryPlan();
+  memory_planner_->PrintMemoryPlan();
 #endif
-  head_usage = planner.GetMaximumMemorySize();
+  head_usage = memory_planner_->GetMaximumMemorySize();
 
   // The head is used to store memory plans for one model at a time during the
   // model preparation stage, and is re-purposed to store scratch buffer handles

--- a/tensorflow/lite/micro/recording_micro_allocator.h
+++ b/tensorflow/lite/micro/recording_micro_allocator.h
@@ -92,6 +92,7 @@ class RecordingMicroAllocator : public MicroAllocator {
 
  private:
   RecordingMicroAllocator(RecordingSimpleMemoryAllocator* memory_allocator,
+                          MicroMemoryPlanner* memory_planner,
                           ErrorReporter* error_reporter);
 
   void PrintRecordedAllocation(RecordedAllocationType allocation_type,


### PR DESCRIPTION
…o the MicroAllocator

This is the first step to allow offline memory planner.

When a MemoryPlanner is not injected at creation time for
a MicroAllocator, a default GreedyMemoryPlanner is created
from the arena. This change is hence backward compatible
at the MicroAllocator api level. The arena usage slightly increase
by 80 bytes on linux x86 due to the GreedyMemoryPlanner is moved from
stack to the arena in such case.

This corresponds to internal cl/395749105

BUG=http://b/199230276