### PR TITLE
Made Xtensa kernels available via bazel.

### DIFF
--- a/tensorflow/lite/micro/BUILD
+++ b/tensorflow/lite/micro/BUILD
@@ -39,8 +39,8 @@ cc_library(
         ":micro_allocator",
         ":micro_error_reporter",
         ":micro_graph",
+        ":micro_op_resolvers",
         ":micro_profiler",
-        ":op_resolvers",
         "//tensorflow/lite:type_to_tflitetype",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/core/api",
@@ -158,12 +158,8 @@ cc_library(
 )
 
 cc_library(
-    name = "op_resolvers",
-    srcs = [
-        "all_ops_resolver.cc",
-    ],
+    name = "micro_op_resolvers",
     hdrs = [
-        "all_ops_resolver.h",
         "micro_mutable_op_resolver.h",
         "micro_op_resolver.h",
     ],
@@ -174,10 +170,50 @@ cc_library(
         "//tensorflow/lite/core/api",
         "//tensorflow/lite/kernels:op_macros",
         "//tensorflow/lite/kernels/internal:compatibility",
-        "//tensorflow/lite/micro/kernels:micro_ops",
         "//tensorflow/lite/schema:schema_fbs",
+        "//tensorflow/lite/micro/kernels:micro_ops_headers",
     ],
 )
+
+micro_ops = [
+    (
+      "",
+      "//tensorflow/lite/micro/kernels:micro_ops",
+      []
+    ),
+    (
+        "xtensa_hifi4_",
+        "//tensorflow/lite/micro/kernels:xtensa_hifi4_micro_ops",
+        ["nobuilder"],  # Disable builder for xtensa builds.
+    ),
+    (
+        "xtensa_hifi5_",
+        "//tensorflow/lite/micro/kernels:xtensa_hifi5_micro_ops",
+        ["nobuilder"],  # Disable builder for xtensa builds.
+    ),
+]
+
+[cc_library(
+    name = "{}op_resolvers".format(micro_op[0]),
+    srcs = [
+        "all_ops_resolver.cc",
+    ],
+    hdrs = [
+        "all_ops_resolver.h",
+    ],
+    copts = micro_copts(),
+    tags = micro_op[2],
+    deps = [
+        ":micro_op_resolvers",
+        ":micro_compatibility",
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/core/api",
+        "//tensorflow/lite/kernels:op_macros",
+        "//tensorflow/lite/kernels/internal:compatibility",
+        "//tensorflow/lite/schema:schema_fbs",
+        micro_op[1],
+    ],
+) for micro_op in micro_ops]
 
 cc_library(
     name = "debug_log",

--- a/tensorflow/lite/micro/build_def.bzl
+++ b/tensorflow/lite/micro/build_def.bzl
@@ -18,3 +18,41 @@ def generate_cc_arrays(name, src, out, visibility = None):
         tools = ["//tensorflow/lite/micro/tools:generate_cc_arrays"],
         visibility = visibility,
     )
+
+def tflm_kernel_accelerated_cc_library(
+        name,
+        default_srcs = [],
+        accelerated_srcs = [],
+        accelerated_hdrs = [],
+        deps = [],
+        **kwargs):
+    """Creates a cc_library with the accelerated target sources.
+
+    This resembles the behavior of the Makefile where specialize_files.py will
+    filter out all reference ops sources in favor of their accelerated
+    counterpart.
+
+    Args:
+      name: The name of the target.
+      default_srcs: The non-accelerated TFLM kernel source files.
+      accelerated_srcs: The platform accelerated TFLM kerenel source files.
+      accelerated_hdrs: The platform accelerated TFLM kernel headers.
+      deps: The library's dependencies.
+      **kwargs: Arguments passed into the cc_library.
+    """
+
+    accelerated_srcs_filenames = [src.split("/")[-1] for src in accelerated_srcs]
+    srcs = accelerated_srcs
+
+    # Filter out all reference ops that have accelerated implementations.
+    for src in default_srcs:
+        if src not in accelerated_srcs_filenames:
+            srcs.append(src)
+
+    native.cc_library(
+        name = name,
+        srcs = srcs,
+        hdrs = accelerated_hdrs,
+        deps = deps,
+        **kwargs
+    )

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -1,4 +1,4 @@
-load("//tensorflow/lite/micro:build_def.bzl", "micro_copts")
+load("//tensorflow/lite/micro:build_def.bzl", "micro_copts", "tflm_kernel_accelerated_cc_library")
 load("//tensorflow:extra_rules.bzl", "tflm_kernel_friends")
 
 package(
@@ -109,9 +109,7 @@ cc_library(
     ],
 )
 
-cc_library(
-    name = "micro_ops",
-    srcs = [
+KERNEL_SRCS = [
         "activations.cc",
         "activations_common.cc",
         "add.cc",
@@ -193,7 +191,10 @@ cc_library(
         "unpack.cc",
         "var_handle.cc",
         "zeros_like.cc",
-    ],
+    ]
+
+cc_library(
+    name = "micro_ops_headers",
     hdrs = [
         "activations.h",
         "circular_buffer.h",
@@ -212,6 +213,17 @@ cc_library(
         "svdf.h",
     ],
     copts = micro_copts(),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/kernels/internal:types",
+    ],
+)
+
+cc_library(
+    name = "micro_ops",
+    srcs = KERNEL_SRCS,
+    copts = micro_copts(),
     visibility = [
         # Public visibility to allow application code to select kernel variants.
         "//visibility:public",
@@ -220,6 +232,7 @@ cc_library(
         ":activation_utils",
         ":kernel_util",
         ":micro_utils",
+        ":micro_ops_headers",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/kernels:kernel_util",
         "//tensorflow/lite/kernels:op_macros",
@@ -237,6 +250,86 @@ cc_library(
         "//tensorflow/lite/micro:micro_utils",
         "//tensorflow/lite/schema:schema_fbs",
         "@flatbuffers//:runtime_cc",
+    ],
+)
+
+tflm_kernel_accelerated_cc_library(
+    name = "xtensa_hifi4_micro_ops",
+    accelerated_hdrs = glob(["xtensa/**/*.h"]),
+    accelerated_srcs = glob(["xtensa/**/*.cc"]),
+    copts = micro_copts() + [
+        "-DXTENSA=1",
+        "-DHIFI4=1",
+    ],
+    default_srcs = KERNEL_SRCS,
+    tags = ["nobuilder"],
+    visibility = [
+        # Public visibility to allow application code to select kernel variants.
+        "//visibility:public",
+    ],
+    deps = [
+        ":micro_ops_headers",
+        ":activation_utils",
+        ":kernel_util",
+        ":micro_utils",
+        "@flatbuffers//:runtime_cc",
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/kernels:kernel_util",
+        "//tensorflow/lite/kernels:op_macros",
+        "//tensorflow/lite/kernels:padding",
+        "//tensorflow/lite/kernels/internal:common",
+        "//tensorflow/lite/kernels/internal:compatibility",
+        "//tensorflow/lite/kernels/internal:cppmath",
+        "//tensorflow/lite/kernels/internal:quantization_util",
+        "//tensorflow/lite/kernels/internal:reference_base",
+        "//tensorflow/lite/kernels/internal:tensor",
+        "//tensorflow/lite/kernels/internal:types",
+        "//tensorflow/lite/schema:schema_fbs",
+        "//tflite_micro/tensorflow/lite/micro:flatbuffer_utils",
+        "//tflite_micro/tensorflow/lite/micro:memory_helpers",
+        "//tflite_micro/tensorflow/lite/micro:micro_graph",
+        "//tflite_micro/tensorflow/lite/micro:micro_utils",
+        "@xtensa//nnlib_hifi4:nnlib_hifi4_lib",
+    ],
+)
+
+tflm_kernel_accelerated_cc_library(
+    name = "xtensa_hifi5_micro_ops",
+    accelerated_hdrs = glob(["xtensa/**/*.h"]),
+    accelerated_srcs = glob(["xtensa/**/*.cc"]),
+    copts = micro_copts() + [
+        "-DXTENSA=1",
+        "-DHIFI5=1",
+    ],
+    default_srcs = KERNEL_SRCS,
+    tags = ["nobuilder"],
+    visibility = [
+        # Public visibility to allow application code to select kernel variants.
+        "//visibility:public",
+    ],
+    deps = [
+        ":micro_ops_headers",
+        ":activation_utils",
+        ":kernel_util",
+        ":micro_utils",
+        "@flatbuffers//:runtime_cc",
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/kernels:kernel_util",
+        "//tensorflow/lite/kernels:op_macros",
+        "//tensorflow/lite/kernels:padding",
+        "//tensorflow/lite/kernels/internal:common",
+        "//tensorflow/lite/kernels/internal:compatibility",
+        "//tensorflow/lite/kernels/internal:cppmath",
+        "//tensorflow/lite/kernels/internal:quantization_util",
+        "//tensorflow/lite/kernels/internal:reference_base",
+        "//tensorflow/lite/kernels/internal:tensor",
+        "//tensorflow/lite/kernels/internal:types",
+        "//tensorflow/lite/schema:schema_fbs",
+        "//tflite_micro/tensorflow/lite/micro:flatbuffer_utils",
+        "//tflite_micro/tensorflow/lite/micro:memory_helpers",
+        "//tflite_micro/tensorflow/lite/micro:micro_graph",
+        "//tflite_micro/tensorflow/lite/micro:micro_utils",
+        "@xtensa//nnlib_hifi5:nnlib_hifi5_lib",
     ],
 )
 


### PR DESCRIPTION
Creates a micro_ops implementation for each of the target kernel implementations. i.e. `micro_ops` for the reference ops, `xtensa_hif4_micro_ops` for the Xtensa HiFi4 ops, etc.

This resembles how the Makefile works, but using Bazel macros instead. This paradigm should extend to all target implementations, not just Xtensa.