### PR TITLE
Remove `-DTF_LITE_STATIC_MEMORY` from bazel CI.

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_bazel.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_bazel.sh
@@ -48,10 +48,3 @@ CC=clang readable_run bazel test tensorflow/lite/micro/... \
 
 # TODO(b/178621680): enable ubsan once bazel + clang + ubsan errors are fixed.
 #CC=clang readable_run bazel test tensorflow/lite/micro/... --config=ubsan --test_tag_filters=-no_oss,-noubsan --build_tag_filters=-no_oss,-noubsan
-
-CC=clang readable_run bazel build tensorflow/lite/micro/... \
-  --build_tag_filters=-no_oss --copt=-DTF_LITE_STATIC_MEMORY
-CC=clang readable_run bazel test tensorflow/lite/micro/... \
-  --test_tag_filters=-no_oss --build_tag_filters=-no_oss \
-  --copt=-DTF_LITE_STATIC_MEMORY \
-  --test_output=errors


### PR DESCRIPTION
We do not use the bazel build with `-DTF_LITE_STATIC_MEMORY` and having that be part of the CI can cause confusion.

BUG=cleanup