### PR TITLE
Revert "Workaround for failing arm-gcc download."

### DIFF
--- a/tensorflow/lite/micro/tools/make/arm_gcc_download.sh
+++ b/tensorflow/lite/micro/tools/make/arm_gcc_download.sh
@@ -77,9 +77,7 @@ else
 
   TEMPDIR=$(mktemp -d)
   TEMPFILE=${TEMPDIR}/temp_file
-  # TODO(b/200052821) and TODO(#508): remove no-check-certificate once it is no
-  # longer required.
-  wget ${GCC_URL} --no-check-certificate -O ${TEMPFILE} >&2
+  wget ${GCC_URL} -O ${TEMPFILE} >&2
   check_md5 ${TEMPFILE} ${EXPECTED_MD5}
 
   mkdir ${DOWNLOADED_GCC_PATH}


### PR DESCRIPTION
Reverts tensorflow/tflite-micro#509

ARM has fixed the issue at their end: https://github.com/tensorflow/tflite-micro/issues/508#issuecomment-921529046

BUG=Fixes #508