### PR TITLE
Progress towards a working project generation with Xtensa.

### DIFF
--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -522,6 +522,10 @@ ifneq ($(OPTIMIZED_KERNEL_DIR),)
     endif
   endif
 
+  # Optimized kernel directories can have their own header files which need to
+  # be included in MICROLITE_CC_HDRS for project generation to have a complete
+  # list of headers.
+  MICROLITE_CC_HDRS += $(wildcard $(PATH_TO_OPTIMIZED_KERNELS)/*.h)
 endif
 
 # If a co-processor is specified on the command line with

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -37,6 +37,8 @@ ifeq ($(TARGET_ARCH), hifi5)
 
   THIRD_PARTY_CC_SRCS := $(filter-out $(EXCLUDED_NNLIB_SRCS), $(THIRD_PARTY_CC_SRCS))
 
+  THIRD_PARTY_CC_HDRS += \
+    $(shell find $(NNLIB_PATH) -name "*.h")
 
   INCLUDES += \
     -I$(NNLIB_PATH)/ \
@@ -75,6 +77,9 @@ else ifeq ($(TARGET_ARCH), hifi4)
     $(NNLIB_PATH)/algo/layers/lstm/src/xa_nn_lstm_api.c
 
   THIRD_PARTY_CC_SRCS := $(filter-out $(EXCLUDED_NNLIB_SRCS), $(THIRD_PARTY_CC_SRCS))
+
+  THIRD_PARTY_CC_HDRS += \
+    $(shell find $(NNLIB_PATH) -name "*.h")
 
   INCLUDES += \
     -I$(NNLIB_PATH)/ \


### PR DESCRIPTION
Manually tested that the following command:
```
python tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py --makefile_options="TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=hifi4 XTENSA_CORE=F1_190305_swupgrade" /tmp/tflm-xtensa
```

results in an output tree that has the header files for xa\_nnlib as well as the headers in tensorflow/micro/kernels/xtensa.

We are currently in the prototyping stage for http://b/194200306 so this change does not include any CI for Xtensa + project generation.

BUG=http://b/194200306
