### PR TITLE
__restrict__ is an unnecessary optimization in the reference code.

### DIFF
--- a/tensorflow/lite/micro/kernels/svdf_common.cc
+++ b/tensorflow/lite/micro/kernels/svdf_common.cc
@@ -227,10 +227,9 @@ void EvalInt8SvdfReference(TfLiteContext* context, TfLiteNode* node,
 
 static inline void ApplyTimeWeightsBiasAndActivation(
     int batch_size, int memory_size, int num_filters, int num_units, int rank,
-    const float* const __restrict__ weights_time_ptr,
-    const float* const __restrict__ bias_ptr, TfLiteFusedActivation activation,
-    float* const __restrict__ state_ptr, float* const __restrict__ scratch_ptr,
-    float* const __restrict__ output_ptr) {
+    const float* const weights_time_ptr, const float* const bias_ptr,
+    TfLiteFusedActivation activation, float* const state_ptr,
+    float* const scratch_ptr, float* const output_ptr) {
   // Compute matmul(activation_state, weights_time).
   for (int b = 0; b < batch_size; ++b) {
     // Perform batched vector dot product:


### PR DESCRIPTION
If needed, we will need to add an ifdef similar to https://github.com/tensorflow/tflite-micro/blob/180de4b73b28bde0d39dc9f2a0bad68d6a9e0fc0/tensorflow/lite/kernels/internal/portable_tensor_utils.h#L26-L28

BUG=cleanup and http://b/189926408#comment28
