### PR TITLE
Remove unused function.

### DIFF
--- a/tensorflow/lite/micro/benchmarks/BUILD
+++ b/tensorflow/lite/micro/benchmarks/BUILD
@@ -1,7 +1,5 @@
 # Description:
 #   TensorFlow Lite microcontroller benchmarks.
-load("//tensorflow/lite/micro:build_def.bzl","generate_cc_arrays")
-
 package(
     # Disabling layering_check because of http://b/177257332
     features = ["-layering_check"],


### PR DESCRIPTION
This causes internal checks to fail when importing from github.

BUG=cleanup
