### PR TITLE
Added xtensa kernels to be bazel compatible

### DIFF
--- a/tensorflow/extra_rules.bzl
+++ b/tensorflow/extra_rules.bzl
@@ -3,3 +3,12 @@ def tflm_kernel_friends():
 
 def tflm_audio_frontend_friends():
     return []
+
+def xtensa_fusion_f1_cpu():
+    return "F1_190305_swupgrade"
+
+def xtensa_hifi_3z_cpu():
+    return "HIFI_190304_swupgrade"
+
+def xtensa_hifi_5_cpu():
+    return "AE_HiFi5_LE5_AO_FP_XC"

--- a/tensorflow/lite/micro/build_def.bzl
+++ b/tensorflow/lite/micro/build_def.bzl
@@ -18,3 +18,64 @@ def generate_cc_arrays(name, src, out, visibility = None):
         tools = ["//tensorflow/lite/micro/tools:generate_cc_arrays"],
         visibility = visibility,
     )
+
+def tflm_kernel_cc_library(
+        name,
+        srcs = [],
+        hdrs = [],
+        accelerated_srcs = {},
+        accelerated_hdrs = {},
+        deps = [],
+        **kwargs):
+    """Creates a cc_library with the optional accelerated target sources.
+
+    Note:
+      Blaze macros cannot evaluate a select() statement. Therefore, the accelerated_srcs and
+      accelerated_hdrs are passed as a dictionary, and the select statement is generated from the
+      supplied dictionary.
+
+    Args:
+      name: The name of the target.
+      srcs: The non-accelerated TFLM kernel source files.
+      hdrs: The non-accelerated TFLM kernel header files.
+      accelerated_srcs: A dictionary organized as {target: accelerated tflm kernel sources}.
+      accelerated_hdrs: A dictionary organized as {target: accelerated tflm kernel headers}.
+      deps: The library's dependencies.
+      **kwargs: Arguments passed into the cc_library.
+    """
+
+    all_srcs = {
+        "//conditions:default": srcs,
+    }
+
+    all_hdrs = {
+        "//conditions:default": hdrs,
+    }
+
+    # Identify all of the sources for each target. This ends up creating a dictionary for both the
+    # sources and headers that looks like the following:
+    # {
+    #   "target1" : [target1_srcs] + [reference_srcs that aren't accelerated],
+    #   "target2" : [target2_srcs] + [reference_srcs that aren't accelerated],
+    #   "//conditions:default": [reference_srcs]
+    # }
+    for target in accelerated_srcs:
+        target_srcs = accelerated_srcs[target]
+        target_src_filenames = [src.split("/")[-1] for src in target_srcs]
+        all_target_srcs = target_srcs
+
+        # Filter out all reference ops that have accelerated implementations.
+        for src in srcs:
+            if src not in target_src_filenames:
+                all_target_srcs.append(src)
+
+        all_srcs[target] = all_target_srcs
+        all_hdrs[target] = hdrs + accelerated_hdrs[target]
+
+    native.cc_library(
+        name = name,
+        srcs = select(all_srcs),
+        hdrs = select(all_hdrs),
+        deps = deps,
+        **kwargs
+    )

--- a/tensorflow/lite/micro/build_def.bzl
+++ b/tensorflow/lite/micro/build_def.bzl
@@ -24,13 +24,12 @@ def tflm_kernel_cc_library(
         srcs = [],
         hdrs = [],
         accelerated_srcs = {},
-        accelerated_hdrs = {},
         deps = [],
         **kwargs):
     """Creates a cc_library with the optional accelerated target sources.
 
     Note:
-      Blaze macros cannot evaluate a select() statement. Therefore, the accelerated_srcs and
+      Bazel macros cannot evaluate a select() statement. Therefore, the accelerated_srcs and
       accelerated_hdrs are passed as a dictionary, and the select statement is generated from the
       supplied dictionary.
 
@@ -70,12 +69,11 @@ def tflm_kernel_cc_library(
                 all_target_srcs.append(src)
 
         all_srcs[target] = all_target_srcs
-        all_hdrs[target] = hdrs + accelerated_hdrs[target]
 
     native.cc_library(
         name = name,
         srcs = select(all_srcs),
-        hdrs = select(all_hdrs),
+        hdrs = hdrs,
         deps = deps,
         **kwargs
     )

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -232,12 +232,12 @@ tflm_kernel_cc_library(
         "softmax.h",
         "sub.h",
         "svdf.h",
-    ],
-    accelerated_hdrs = {
+    ] + select({
         ":xtensa_fusion_f1": glob(["xtensa/**/*.h"]),
         ":xtensa_hifi_3z": glob(["xtensa/**/*.h"]),
         ":xtensa_hifi_5": glob(["xtensa/**/*.h"]),
-    },
+        "//conditions:default": [],
+    }),
     accelerated_srcs = {
         ":xtensa_fusion_f1": glob(["xtensa/**/*.cc"]),
         ":xtensa_hifi_3z": glob(["xtensa/**/*.cc"]),
@@ -1196,7 +1196,7 @@ cc_test(
 )
 
 ####################################
-# Blaze config settings.
+# Bazel config settings.
 ####################################
 
 config_setting(

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -1,5 +1,11 @@
-load("//tensorflow/lite/micro:build_def.bzl", "micro_copts")
-load("//tensorflow:extra_rules.bzl", "tflm_kernel_friends")
+load("//tensorflow/lite/micro:build_def.bzl", "micro_copts", "tflm_kernel_cc_library")
+load(
+    "//tensorflow:extra_rules.bzl",
+    "tflm_kernel_friends",
+    "xtensa_fusion_f1_cpu",
+    "xtensa_hifi_3z_cpu",
+    "xtensa_hifi_5_cpu",
+)
 
 package(
     # Disabling layering_check because of http://b/177257332
@@ -109,7 +115,17 @@ cc_library(
     ],
 )
 
-cc_library(
+HIFI4_COPTS = [
+    "-DXTENSA=1",
+    "-DHIFI4=1",
+]
+
+HIFI5_COPTS = [
+    "-DXTENSA=1",
+    "-DHIFI5=1",
+]
+
+tflm_kernel_cc_library(
     name = "micro_ops",
     srcs = [
         "activations.cc",
@@ -217,7 +233,22 @@ cc_library(
         "sub.h",
         "svdf.h",
     ],
-    copts = micro_copts(),
+    accelerated_hdrs = {
+        ":xtensa_fusion_f1": glob(["xtensa/**/*.h"]),
+        ":xtensa_hifi_3z": glob(["xtensa/**/*.h"]),
+        ":xtensa_hifi_5": glob(["xtensa/**/*.h"]),
+    },
+    accelerated_srcs = {
+        ":xtensa_fusion_f1": glob(["xtensa/**/*.cc"]),
+        ":xtensa_hifi_3z": glob(["xtensa/**/*.cc"]),
+        ":xtensa_hifi_5": glob(["xtensa/**/*.cc"]),
+    },
+    copts = micro_copts() + select({
+        ":xtensa_fusion_f1": HIFI4_COPTS,
+        ":xtensa_hifi_3z": HIFI4_COPTS,
+        ":xtensa_hifi_5": HIFI5_COPTS,
+        "//conditions:default": [],
+    }),
     visibility = [
         # Public visibility to allow application code to select kernel variants.
         "//visibility:public",
@@ -243,7 +274,12 @@ cc_library(
         "//tensorflow/lite/micro:micro_utils",
         "//tensorflow/lite/schema:schema_fbs",
         "@flatbuffers//:runtime_cc",
-    ],
+    ] + select({
+        ":xtensa_fusion_f1": ["//third_party/xtensa/nnlib_hifi4:nnlib_hifi4_lib"],
+        ":xtensa_hifi_3z": ["//third_party/xtensa/nnlib_hifi4:nnlib_hifi4_lib"],
+        ":xtensa_hifi_5": ["//third_party/xtensa/nnlib_hifi5:nnlib_hifi5_lib"],
+        "//conditions:default": [],
+    }),
 )
 
 cc_library(
@@ -1157,4 +1193,29 @@ cc_test(
         "//tensorflow/lite/micro:test_helpers",
         "//tensorflow/lite/micro/testing:micro_test",
     ],
+)
+
+####################################
+# Blaze config settings.
+####################################
+
+config_setting(
+    name = "xtensa_fusion_f1",
+    values = {
+        "cpu": xtensa_fusion_f1_cpu(),
+    },
+)
+
+config_setting(
+    name = "xtensa_hifi_3z",
+    values = {
+        "cpu": xtensa_hifi_3z_cpu(),
+    },
+)
+
+config_setting(
+    name = "xtensa_hifi_5",
+    values = {
+        "cpu": xtensa_hifi_5_cpu(),
+    },
 )


### PR DESCRIPTION
This PR introduces a new bazel macro called `tflm_kernel_cc_library` which generates a `cc_library` based on the target architecture. The macro combines the reference sources and headers with the accelerated implementations ensuring that there's only one implementation per kernel.

The `config_setting` is used to declare the CPU type for each of the xtensa cores. This can be extended to other architectures, but this PR starts with xtensa only.

BUG=Fixes #560 and progress towards http://b/194200306