### PR TITLE
Have different table for TFLM examples and kernels and unit test builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
    * [TensorFlow Lite for Microcontrollers](#tensorflow-lite-for-microcontrollers)
    * [Build Status](#build-status)
       * [Official Builds](#official-builds)
-      * [Community Supported Builds](#community-supported-builds)
+      * [Community Supported TFLM Examples](#community-supported-tflm-examples)
+      * [Community Supported Kernels and Unit Tests](#community-supported-kernels-and-unit-tests)
    * [Contributing](#contributing)
    * [Getting Help](#getting-help)
    * [Additional Documentation](#additional-documentation)
    * [RFCs](#rfcs)
 
-<!-- Added by: advaitjain, at: Thu 16 Sep 2021 11:43:48 AM PDT -->
+<!-- Added by: advaitjain, at: Mon 04 Oct 2021 11:23:57 AM PDT -->
 
 <!--te-->
 
@@ -33,16 +34,30 @@ Build Type       |    Status     |
 CI (Linux)       | [![CI](https://github.com/tensorflow/tflite-micro/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/tensorflow/tflite-micro/actions/workflows/ci.yml?query=event%3Aschedule) |
 Code Sync        | [![Sync from Upstream TF](https://github.com/tensorflow/tflite-micro/actions/workflows/sync.yml/badge.svg)](https://github.com/tensorflow/tflite-micro/actions/workflows/sync.yml) |
 
-## Community Supported Builds
-Build Type      |    Status     |
+
+## Community Supported TFLM Examples
+This table captures platforms that TFLM has been ported to. Please see
+[New Platform Support](tensorflow/lite/micro/docs/new_platform_support.md) for
+additional documentation.
+
+Platform      |    Status     |
 -----------     | --------------|
 Arduino         | [![Arduino](https://github.com/tensorflow/tflite-micro-arduino-examples/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/tensorflow/tflite-micro-arduino-examples/actions/workflows/ci.yml) [![Antmicro](https://github.com/antmicro/tensorflow-arduino-examples/actions/workflows/test_examples.yml/badge.svg)](https://github.com/antmicro/tensorflow-arduino-examples/actions/workflows/test_examples.yml) |
-Cortex-M        | [![Cortex-M](https://github.com/tensorflow/tflite-micro/actions/workflows/cortex_m.yml/badge.svg)](https://github.com/tensorflow/tflite-micro/actions/workflows/cortex_m.yml) |
 ESP32           | [![ESP32](https://github.com/tensorflow/tflite-micro/actions/workflows/esp32.yml/badge.svg)](https://github.com/tensorflow/tflite-micro/actions/workflows/esp32.yml) |
+Sparkfun Edge   | [![Sparkfun Edge](https://github.com/advaitjain/tflite-micro-sparkfun-edge-examples/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/advaitjain/tflite-micro-sparkfun-edge-examples/actions/workflows/ci.yml)
+
+
+## Community Supported Kernels and Unit Tests
+This is a list of targets that have optimized kernel implementations and/or run
+the TFLM unit tests using software emulation or instruction set simulators.
+
+Build Type      |    Status     |
+-----------     | --------------|
+Cortex-M        | [![Cortex-M](https://github.com/tensorflow/tflite-micro/actions/workflows/cortex_m.yml/badge.svg)](https://github.com/tensorflow/tflite-micro/actions/workflows/cortex_m.yml) |
 Hexagon         | [![Hexagon](https://github.com/tensorflow/tflite-micro/actions/workflows/hexagon.yml/badge.svg?event=schedule)](https://github.com/tensorflow/tflite-micro/actions/workflows/hexagon.yml) |
 RISC-V          | [![RISC-V](https://github.com/tensorflow/tflite-micro/actions/workflows/riscv.yml/badge.svg)](https://github.com/tensorflow/tflite-micro/actions/workflows/riscv.yml) |
-Sparkfun Edge   | [![Sparkfun Edge](https://github.com/advaitjain/tflite-micro-sparkfun-edge-examples/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/advaitjain/tflite-micro-sparkfun-edge-examples/actions/workflows/ci.yml)
 Xtensa          | [![Xtensa](https://github.com/tensorflow/tflite-micro/actions/workflows/xtensa.yml/badge.svg?event=schedule)](https://github.com/tensorflow/tflite-micro/actions/workflows/xtensa.yml?query=event%3Aschedule) [![Xtensa](https://raw.githubusercontent.com/advaitjain/tflite-micro/local-continuous-builds/tensorflow/lite/micro/docs/local_continuous_builds/xtensa-build-status.svg)](https://github.com/advaitjain/tflite-micro/tree/local-continuous-builds/tensorflow/lite/micro/docs/local_continuous_builds/xtensa.md#summary) |
+
 
 # Contributing
 See our [contribution documentation](CONTRIBUTING.md).

--- a/tensorflow/lite/micro/docs/new_platform_support.md
+++ b/tensorflow/lite/micro/docs/new_platform_support.md
@@ -13,7 +13,7 @@ https://github.com/ekalinin/github-markdown-toc#auto-insert-and-update-toc
    * [Advanced Integration Topics](#advanced-integration-topics)
    * [Getting Help](#getting-help)
 
-<!-- Added by: advaitjain, at: Thu 12 Aug 2021 04:48:03 PM PDT -->
+<!-- Added by: advaitjain, at: Mon 04 Oct 2021 11:24:09 AM PDT -->
 
 <!--te-->
 
@@ -140,7 +140,7 @@ that integrated TFLM for the:
 
 Once you are set up with continuous integration and the ability to integrate
 newer versions of TFLM with your platform, feel free to add a build badge to
-TFLM's [Community Supported Builds](https://github.com/tensorflow/tflite-micro#community-supported-builds).
+TFLM's [Community Supported TFLM Examples](https://github.com/tensorflow/tflite-micro#community-supported-tflm-examples).
 
 # Getting Help
 


### PR DESCRIPTION
The kernel and unit test list is going to be smaller (and have all the code and CI be part of the TFLM repo).

The examples list is expected to grow and will be maintained external to the TFLM repository as described in #407.

BUG=#407
