### PR TITLE
Add features to cast, add slice, clean up split.

### DIFF
--- a/ci/tflite_files.txt
+++ b/ci/tflite_files.txt
@@ -74,6 +74,7 @@ tensorflow/lite/kernels/internal/reference/space_to_batch_nd.h
 tensorflow/lite/kernels/internal/reference/space_to_depth.h
 tensorflow/lite/kernels/internal/reference/sub.h
 tensorflow/lite/kernels/internal/reference/logistic.h
+tensorflow/lite/kernels/internal/reference/slice.h
 tensorflow/lite/kernels/internal/reference/strided_slice.h
 tensorflow/lite/kernels/internal/reference/tanh.h
 tensorflow/lite/kernels/internal/reference/transpose.h

--- a/tensorflow/lite/kernels/internal/reference/slice.h
+++ b/tensorflow/lite/kernels/internal/reference/slice.h
@@ -1,0 +1,80 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_LITE_KERNELS_INTERNAL_REFERENCE_SLICE_H_
+#define TENSORFLOW_LITE_KERNELS_INTERNAL_REFERENCE_SLICE_H_
+
+#include "tensorflow/lite/kernels/internal/portable_tensor.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+
+namespace tflite {
+
+namespace reference_ops {
+
+template <typename T>
+inline void Slice(const tflite::SliceParams& op_params,
+                  const RuntimeShape& input_shape,
+                  const RuntimeShape& output_shape,
+                  SequentialTensorWriter<T>* writer) {
+  const RuntimeShape ext_shape = RuntimeShape::ExtendedShape(5, input_shape);
+  TFLITE_DCHECK_LE(op_params.begin_count, 5);
+  TFLITE_DCHECK_LE(op_params.size_count, 5);
+  const int begin_count = op_params.begin_count;
+  const int size_count = op_params.size_count;
+  // We front-pad the begin and size vectors.
+  int start[5];
+  int stop[5];
+  for (int i = 0; i < 5; ++i) {
+    int padded_i = 5 - i;
+    start[i] =
+        begin_count < padded_i ? 0 : op_params.begin[begin_count - padded_i];
+    stop[i] =
+        (size_count < padded_i || op_params.size[size_count - padded_i] == -1)
+            ? ext_shape.Dims(i)
+            : start[i] + op_params.size[size_count - padded_i];
+  }
+
+  for (int i0 = start[0]; i0 < stop[0]; ++i0) {
+    for (int i1 = start[1]; i1 < stop[1]; ++i1) {
+      for (int i2 = start[2]; i2 < stop[2]; ++i2) {
+        for (int i3 = start[3]; i3 < stop[3]; ++i3) {
+          for (int i4 = start[4]; i4 < stop[4]; ++i4) {
+            writer->Write(Offset(ext_shape, i0, i1, i2, i3, i4));
+          }
+        }
+      }
+    }
+  }
+}
+
+template <typename T>
+inline void Slice(const tflite::SliceParams& op_params,
+                  const RuntimeShape& input_shape, const T* input_data,
+                  const RuntimeShape& output_shape, T* output_data) {
+  SequentialTensorWriter<T> writer(input_data, output_data);
+  return Slice(op_params, input_shape, output_shape, &writer);
+}
+
+template <typename T>
+inline void Slice(const tflite::SliceParams& op_params,
+                  const RuntimeShape& input_shape, const TfLiteTensor* input,
+                  const RuntimeShape& output_shape, TfLiteTensor* output) {
+  SequentialTensorWriter<T> writer(input, output);
+  return Slice(op_params, input_shape, output_shape, &writer);
+}
+
+}  // namespace reference_ops
+}  // namespace tflite
+
+#endif  // TENSORFLOW_LITE_KERNELS_INTERNAL_REFERENCE_SLICE_H_

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -194,6 +194,7 @@ tflm_kernel_cc_library(
         "resize_nearest_neighbor.cc",
         "round.cc",
         "shape.cc",
+        "slice.cc",
         "softmax.cc",
         "softmax_common.cc",
         "space_to_batch_nd.cc",
@@ -996,6 +997,18 @@ cc_test(
 cc_test(
     name = "shape_test",
     srcs = ["shape_test.cc"],
+    deps = [
+        ":kernel_runner",
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/micro:op_resolvers",
+        "//tensorflow/lite/micro:test_helpers",
+        "//tensorflow/lite/micro/testing:micro_test",
+    ],
+)
+
+cc_test(
+    name = "slice_test",
+    srcs = ["slice_test.cc"],
     deps = [
         ":kernel_runner",
         "//tensorflow/lite/c:common",

--- a/tensorflow/lite/micro/kernels/Makefile.inc
+++ b/tensorflow/lite/micro/kernels/Makefile.inc
@@ -87,6 +87,7 @@ tensorflow/lite/micro/kernels/resize_bilinear_test.cc \
 tensorflow/lite/micro/kernels/resize_nearest_neighbor_test.cc \
 tensorflow/lite/micro/kernels/round_test.cc \
 tensorflow/lite/micro/kernels/shape_test.cc \
+tensorflow/lite/micro/kernels/slice_test.cc \
 tensorflow/lite/micro/kernels/softmax_test.cc \
 tensorflow/lite/micro/kernels/space_to_batch_nd_test.cc \
 tensorflow/lite/micro/kernels/space_to_depth_test.cc \

--- a/tensorflow/lite/micro/kernels/cast.cc
+++ b/tensorflow/lite/micro/kernels/cast.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_error_reporter.h"
 
 namespace tflite {
 namespace {
@@ -48,13 +49,16 @@ TfLiteStatus copyToTensor(TfLiteContext* context, const FromT* in,
     case kTfLiteInt8:
       copyCast(in, out->data.int8, num_elements);
       break;
+    case kTfLiteInt16:
+      copyCast(in, out->data.i16, num_elements);
+      break;
     case kTfLiteFloat32:
       copyCast(in, tflite::micro::GetTensorData<float>(out), num_elements);
       break;
     default:
       // Unsupported type.
-      TF_LITE_KERNEL_LOG(context, "Output type %s (%d) not supported.",
-                         TfLiteTypeGetName(out->type), out->type);
+      MicroPrintf("Output type %s (%d) not supported.",
+                  TfLiteTypeGetName(out->type), out->type);
   }
   return kTfLiteOk;
 }
@@ -70,13 +74,16 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   switch (input->type) {
     case kTfLiteInt8:
       return copyToTensor(context, input->data.int8, output, num_elements);
+    case kTfLiteInt16:
+      return copyToTensor(context, tflite::micro::GetTensorData<int16_t>(input),
+                          output, num_elements);
     case kTfLiteFloat32:
       return copyToTensor(context, tflite::micro::GetTensorData<float>(input),
                           output, num_elements);
     default:
       // Unsupported type.
-      TF_LITE_KERNEL_LOG(context, "Input type %s (%d) not supported.",
-                         TfLiteTypeGetName(input->type), input->type);
+      MicroPrintf("Input type %s (%d) not supported.",
+                  TfLiteTypeGetName(input->type), input->type);
   }
   return kTfLiteOk;
 }

--- a/tensorflow/lite/micro/kernels/micro_ops.h
+++ b/tensorflow/lite/micro/kernels/micro_ops.h
@@ -67,6 +67,7 @@ TfLiteRegistration Register_RELU();
 TfLiteRegistration Register_RELU6();
 TfLiteRegistration Register_RESIZE_BILINEAR();
 TfLiteRegistration Register_SHAPE();
+TfLiteRegistration Register_SLICE();
 TfLiteRegistration Register_SPACE_TO_BATCH_ND();
 TfLiteRegistration Register_SPACE_TO_DEPTH();
 TfLiteRegistration Register_SQUEEZE();

--- a/tensorflow/lite/micro/kernels/slice.cc
+++ b/tensorflow/lite/micro/kernels/slice.cc
@@ -1,0 +1,152 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/kernels/internal/reference/slice.h"
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_error_reporter.h"
+
+namespace tflite {
+
+namespace {
+
+constexpr int kInputTensor = 0;
+constexpr int kBeginTensor = 1;
+constexpr int kSizeTensor = 2;
+constexpr int kOutputTensor = 0;
+
+const int kMaxDim = 5;
+
+template <typename T>
+void GetBeginAndSizeVectors(int dimensions, const TfLiteEvalTensor* begin,
+                            const TfLiteEvalTensor* size, int32_t* begins,
+                            int32_t* sizes) {
+  int offset = kMaxDim - dimensions;
+  for (int idx = 0; idx < dimensions; ++idx) {
+    begins[offset + idx] = tflite::micro::GetTensorData<T>(begin)[idx];
+    sizes[offset + idx] = tflite::micro::GetTensorData<T>(size)[idx];
+  }
+}
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 3);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+
+  const TfLiteTensor* input = GetInput(context, node, kInputTensor);
+  TFLITE_DCHECK(input != nullptr);
+  const TfLiteTensor* begin = GetInput(context, node, kBeginTensor);
+  TFLITE_DCHECK(begin != nullptr);
+  const TfLiteTensor* size = GetInput(context, node, kSizeTensor);
+  TFLITE_DCHECK(size != nullptr);
+  TfLiteTensor* output = GetOutput(context, node, kOutputTensor);
+  TFLITE_DCHECK(output != nullptr);
+
+  // Ensure validity of input tensor and its dimension.
+  TFLITE_DCHECK(input->type == output->type);
+  TFLITE_DCHECK(begin->type == size->type);
+  TFLITE_DCHECK(begin->type == kTfLiteInt32 || begin->type == kTfLiteInt64);
+  TFLITE_DCHECK(size->type == kTfLiteInt32 || size->type == kTfLiteInt64);
+  TFLITE_DCHECK(NumDimensions(begin) == 1);
+  TFLITE_DCHECK(NumDimensions(size) == 1);
+  TFLITE_DCHECK(NumElements(begin) == NumElements(size));
+  TFLITE_DCHECK(NumDimensions(input) <= kMaxDim);
+  return kTfLiteOk;
+}
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kInputTensor);
+  const TfLiteEvalTensor* begin =
+      tflite::micro::GetEvalInput(context, node, kBeginTensor);
+  const TfLiteEvalTensor* size =
+      tflite::micro::GetEvalInput(context, node, kSizeTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+
+  tflite::SliceParams op_params;
+  op_params.begin_count = kMaxDim;
+  op_params.size_count = kMaxDim;
+  for (int i = 0; i < kMaxDim; ++i) {
+    op_params.begin[i] = 0;
+    op_params.size[i] = 1;
+  }
+
+  if (begin->type == kTfLiteInt32) {
+    GetBeginAndSizeVectors<int32_t>(input->dims->size, begin, size,
+                                    op_params.begin, op_params.size);
+  } else if (begin->type == kTfLiteInt64) {
+    GetBeginAndSizeVectors<int64_t>(input->dims->size, begin, size,
+                                    op_params.begin, op_params.size);
+  } else {
+    TF_LITE_KERNEL_LOG(context, "Begin tensor type %s (%d) not supported.",
+                       TfLiteTypeGetName(input->type), input->type);
+    return kTfLiteError;
+  }
+
+  switch (input->type) {
+    case kTfLiteFloat32:
+      reference_ops::Slice<float>(op_params,
+                                  tflite::micro::GetTensorShape(input),
+                                  tflite::micro::GetTensorData<float>(input),
+                                  tflite::micro::GetTensorShape(output),
+                                  tflite::micro::GetTensorData<float>(output));
+      break;
+    case kTfLiteInt32:
+      reference_ops::Slice<int32_t>(
+          op_params, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int32_t>(input),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int32_t>(output));
+      break;
+    case kTfLiteInt8:
+      reference_ops::Slice<int8_t>(
+          op_params, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int8_t>(input),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int8_t>(output));
+      break;
+    case kTfLiteInt16:
+      reference_ops::Slice<int16_t>(
+          op_params, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int16_t>(input),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int16_t>(output));
+      break;
+    default:
+      MicroPrintf("Input tensor type %s (%d) not supported.",
+                  TfLiteTypeGetName(input->type), input->type);
+      return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+}  // namespace
+
+TfLiteRegistration Register_SLICE() {
+  return {/*init=*/nullptr,
+          /*free=*/nullptr,
+          /*prepare=*/Prepare,
+          /*invoke=*/Eval,
+          /*profiling_string=*/nullptr,
+          /*builtin_code=*/0,
+          /*custom_name=*/nullptr,
+          /*version=*/0};
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/slice_test.cc
+++ b/tensorflow/lite/micro/kernels/slice_test.cc
@@ -1,0 +1,323 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/micro/all_ops_resolver.h"
+#include "tensorflow/lite/micro/kernels/kernel_runner.h"
+#include "tensorflow/lite/micro/test_helpers.h"
+#include "tensorflow/lite/micro/testing/micro_test.h"
+
+namespace tflite {
+namespace testing {
+namespace {
+
+template <typename dataT, typename shapeT>
+void TestSlice(int* input_dims_data, const dataT* input_data,
+               int* begin_dims_data, const shapeT* begin_data,
+               int* size_dims_data, const shapeT* size_data,
+               int* output_dims_data, const dataT* expected_output_data,
+               dataT* output_data) {
+  TfLiteIntArray* input_dims = IntArrayFromInts(input_dims_data);
+  TfLiteIntArray* begin_dims = IntArrayFromInts(begin_dims_data);
+  TfLiteIntArray* size_dims = IntArrayFromInts(size_dims_data);
+  TfLiteIntArray* output_dims = IntArrayFromInts(output_dims_data);
+  const int output_dims_count = ElementCount(*output_dims);
+
+  constexpr int inputs_size = 3;
+  constexpr int outputs_size = 1;
+  constexpr int tensors_size = inputs_size + outputs_size;
+  TfLiteTensor tensors[tensors_size] = {
+      CreateTensor(input_data, input_dims),
+      CreateTensor(begin_data, begin_dims),
+      CreateTensor(size_data, size_dims),
+      CreateTensor(output_data, output_dims),
+  };
+
+  int inputs_array_data[] = {3, 0, 1, 2};
+  TfLiteIntArray* inputs_array = IntArrayFromInts(inputs_array_data);
+  int outputs_array_data[] = {1, 3};
+  TfLiteIntArray* outputs_array = IntArrayFromInts(outputs_array_data);
+
+  const TfLiteRegistration registration = tflite::Register_SLICE();
+  micro::KernelRunner runner(registration, tensors, tensors_size, inputs_array,
+                             outputs_array, nullptr);
+
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.InitAndPrepare());
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.Invoke());
+
+  for (int i = 0; i < output_dims_count; ++i) {
+    TF_LITE_MICRO_EXPECT_EQ(expected_output_data[i], output_data[i]);
+  }
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace tflite
+
+TF_LITE_MICRO_TESTS_BEGIN
+
+TF_LITE_MICRO_TEST(In1D) {
+  int input_shape[] = {1, 4};
+  float input_values[] = {1, 2, 3, 4};
+  int begin_shape[] = {1, 1};
+  int32_t begin_values[] = {1};
+  int size_shape[] = {1, 1};
+  int32_t size_values[] = {2};
+  int output_shape[] = {1, 2};
+  float expected_output_data[] = {2, 3};
+  float output_data[2];
+
+  tflite::testing::TestSlice(input_shape, input_values, begin_shape,
+                             begin_values, size_shape, size_values,
+                             output_shape, expected_output_data, output_data);
+}
+
+TF_LITE_MICRO_TEST(In2D) {
+  int input_shape[] = {2, 2, 3};
+  float input_values[] = {1, 2, 3, 4, 5, 6};
+  int begin_shape[] = {1, 2};
+  int32_t begin_values[] = {1, 0};
+  int size_shape[] = {1, 2};
+  int32_t size_values[] = {1, 2};
+  int output_shape[] = {1, 2};
+  float expected_output_data[] = {4, 5};
+  float output_data[2];
+
+  tflite::testing::TestSlice(input_shape, input_values, begin_shape,
+                             begin_values, size_shape, size_values,
+                             output_shape, expected_output_data, output_data);
+}
+
+TF_LITE_MICRO_TEST(In3D) {
+  int input_shape[] = {3, 2, 3, 2};
+  float input_values[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  int begin_shape[] = {1, 3};
+  int32_t begin_values[] = {0, 0, 0};
+  int size_shape[] = {1, 3};
+  int32_t size_values[] = {2, 3, 2};
+  int output_shape[] = {3, 2, 3, 2};
+  float expected_output_data[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  float output_data[12];
+
+  tflite::testing::TestSlice(input_shape, input_values, begin_shape,
+                             begin_values, size_shape, size_values,
+                             output_shape, expected_output_data, output_data);
+}
+
+TF_LITE_MICRO_TEST(In5D) {
+  int input_shape[] = {5, 5, 1, 1, 1, 1};
+  float input_values[] = {1, 2, 3, 4, 5};
+  int begin_shape[] = {1, 5};
+  int32_t begin_values[] = {1, 0, 0, 0, 0};
+  int size_shape[] = {1, 5};
+  int32_t size_values[] = {3, 1, 1, 1, 1};
+  int output_shape[] = {5, 3, 1, 1, 1, 1};
+  float expected_output_data[] = {2, 3, 4};
+  float output_data[3];
+
+  tflite::testing::TestSlice(input_shape, input_values, begin_shape,
+                             begin_values, size_shape, size_values,
+                             output_shape, expected_output_data, output_data);
+}
+
+TF_LITE_MICRO_TEST(InputFloat) {
+  int input_shape[] = {4, 4, 1, 1, 1};
+  float input_values[] = {1, 2, 3, 4};
+  int begin_shape[] = {1, 4};
+  int32_t begin_values[] = {1, 0, 0, 0};
+  int size_shape[] = {1, 4};
+  int32_t size_values[] = {3, 1, 1, 1};
+  int output_shape[] = {4, 3, 1, 1, 1};
+  float expected_output_data[] = {2, 3, 4};
+  float output_data[3];
+
+  tflite::testing::TestSlice(input_shape, input_values, begin_shape,
+                             begin_values, size_shape, size_values,
+                             output_shape, expected_output_data, output_data);
+}
+
+TF_LITE_MICRO_TEST(IndexInt64) {
+  int input_shape[] = {4, 4, 1, 1, 1};
+  float input_values[] = {1, 2, 3, 4};
+  int begin_shape[] = {1, 4};
+  int64_t begin_values[] = {1, 0, 0, 0};
+  int size_shape[] = {1, 4};
+  int64_t size_values[] = {3, 1, 1, 1};
+  int output_shape[] = {4, 3, 1, 1, 1};
+  float expected_output_data[] = {2, 3, 4};
+  float output_data[3];
+
+  tflite::testing::TestSlice(input_shape, input_values, begin_shape,
+                             begin_values, size_shape, size_values,
+                             output_shape, expected_output_data, output_data);
+}
+
+// See these test cases under:
+// https://www.tensorflow.org/versions/master/api_docs/python/tf/slice
+TF_LITE_MICRO_TEST(InputInteger1) {
+  int input_shape[] = {4, 3, 2, 3, 1};
+  int32_t input_values[] = {1, 1, 1, 2, 2, 2, 3, 3, 3,
+                            4, 4, 4, 5, 5, 5, 6, 6, 6};
+  int begin_shape[] = {1, 4};
+  int32_t begin_values[] = {1, 0, 0, 0};
+  int size_shape[] = {1, 4};
+  int32_t size_values[] = {1, 1, 3, 1};
+  int output_shape[] = {4, 1, 1, 3, 1};
+  int32_t expected_output_data[] = {3, 3, 3};
+  int32_t output_data[3];
+
+  tflite::testing::TestSlice(input_shape, input_values, begin_shape,
+                             begin_values, size_shape, size_values,
+                             output_shape, expected_output_data, output_data);
+}
+
+TF_LITE_MICRO_TEST(InputInteger2) {
+  int input_shape[] = {4, 3, 2, 3, 1};
+  int32_t input_values[] = {1, 1, 1, 2, 2, 2, 3, 3, 3,
+                            4, 4, 4, 5, 5, 5, 6, 6, 6};
+  int begin_shape[] = {1, 4};
+  int32_t begin_values[] = {1, 0, 0, 0};
+  int size_shape[] = {1, 4};
+  int32_t size_values[] = {1, 2, 3, 1};
+  int output_shape[] = {4, 1, 2, 3, 1};
+  int32_t expected_output_data[] = {3, 3, 3, 4, 4, 4};
+  int32_t output_data[6];
+
+  tflite::testing::TestSlice(input_shape, input_values, begin_shape,
+                             begin_values, size_shape, size_values,
+                             output_shape, expected_output_data, output_data);
+}
+
+TF_LITE_MICRO_TEST(InputInteger3) {
+  int input_shape[] = {4, 3, 2, 3, 1};
+  int32_t input_values[] = {1, 1, 1, 2, 2, 2, 3, 3, 3,
+                            4, 4, 4, 5, 5, 5, 6, 6, 6};
+  int begin_shape[] = {1, 4};
+  int32_t begin_values[] = {1, 0, 0, 0};
+  int size_shape[] = {1, 4};
+  int32_t size_values[] = {2, 1, 3, 1};
+  int output_shape[] = {4, 2, 1, 3, 1};
+  int32_t expected_output_data[] = {3, 3, 3, 5, 5, 5};
+  int32_t output_data[6];
+
+  tflite::testing::TestSlice(input_shape, input_values, begin_shape,
+                             begin_values, size_shape, size_values,
+                             output_shape, expected_output_data, output_data);
+}
+
+TF_LITE_MICRO_TEST(SizeMinus1) {
+  int input_shape[] = {4, 3, 2, 3, 1};
+  int32_t input_values[] = {1, 1, 1, 2, 2, 2, 3, 3, 3,
+                            4, 4, 4, 5, 5, 5, 6, 6, 6};
+  int begin_shape[] = {1, 4};
+  int32_t begin_values[] = {1, 0, 0, 0};
+  int size_shape[] = {1, 4};
+  int32_t size_values[] = {2, 1, -1, 1};
+  int output_shape[] = {4, 2, 1, 3, 1};
+  int32_t expected_output_data[] = {3, 3, 3, 5, 5, 5};
+  int32_t output_data[6];
+
+  tflite::testing::TestSlice(input_shape, input_values, begin_shape,
+                             begin_values, size_shape, size_values,
+                             output_shape, expected_output_data, output_data);
+}
+
+TF_LITE_MICRO_TEST(BeginNonZeroSizeMinus1Axis1) {
+  int input_shape[] = {4, 3, 3, 2, 1};
+  int32_t input_values[] = {1, 1, 2, 2, 3, 3, 4, 4, 5,
+                            5, 6, 6, 7, 7, 8, 8, 9, 9};
+  int begin_shape[] = {1, 4};
+  int32_t begin_values[] = {1, 1, 0, 0};
+  int size_shape[] = {1, 4};
+  int32_t size_values[] = {2, -1, 1, 1};
+  int output_shape[] = {4, 2, 2, 1, 1};
+  int32_t expected_output_data[] = {5, 6, 8, 9};
+  int32_t output_data[4];
+
+  tflite::testing::TestSlice(input_shape, input_values, begin_shape,
+                             begin_values, size_shape, size_values,
+                             output_shape, expected_output_data, output_data);
+}
+
+TF_LITE_MICRO_TEST(BeginNonZeroSizeMinus1Axis2) {
+  int input_shape[] = {4, 3, 2, 3, 1};
+  int32_t input_values[] = {1, 1, 1, 2, 2, 2, 3, 3, 3,
+                            4, 4, 4, 5, 5, 5, 6, 6, 6};
+  int begin_shape[] = {1, 4};
+  int32_t begin_values[] = {1, 0, 1, 0};
+  int size_shape[] = {1, 4};
+  int32_t size_values[] = {2, 1, -1, 1};
+  int output_shape[] = {4, 2, 1, 2, 1};
+  int32_t expected_output_data[] = {3, 3, 5, 5};
+  int32_t output_data[4];
+
+  tflite::testing::TestSlice(input_shape, input_values, begin_shape,
+                             begin_values, size_shape, size_values,
+                             output_shape, expected_output_data, output_data);
+}
+
+TF_LITE_MICRO_TEST(BeginNonZeroSizeMinus1Axis3) {
+  int input_shape[] = {4, 3, 1, 2, 3};
+  int32_t input_values[] = {1, 1, 1, 2, 2, 2, 3, 3, 3,
+                            4, 4, 4, 5, 5, 5, 6, 6, 6};
+  int begin_shape[] = {1, 4};
+  int32_t begin_values[] = {1, 0, 0, 1};
+  int size_shape[] = {1, 4};
+  int32_t size_values[] = {2, 1, 1, -1};
+  int output_shape[] = {4, 2, 1, 1, 2};
+  int32_t expected_output_data[] = {3, 3, 5, 5};
+  int32_t output_data[4];
+
+  tflite::testing::TestSlice(input_shape, input_values, begin_shape,
+                             begin_values, size_shape, size_values,
+                             output_shape, expected_output_data, output_data);
+}
+
+TF_LITE_MICRO_TEST(SliceInt8) {
+  int input_shape[] = {4, 3, 2, 3, 1};
+  int8_t input_values[] = {1, 1, 1, 2, 2, 2, 3, 3, 3,
+                           4, 4, 4, 5, 5, 5, 6, 6, 6};
+  int begin_shape[] = {1, 4};
+  int32_t begin_values[] = {1, 0, 0, 0};
+  int size_shape[] = {1, 4};
+  int32_t size_values[] = {2, 1, -1, 1};
+  int output_shape[] = {4, 2, 1, 3, 1};
+  int8_t expected_output_data[] = {3, 3, 3, 5, 5, 5};
+  int8_t output_data[6];
+
+  tflite::testing::TestSlice(input_shape, input_values, begin_shape,
+                             begin_values, size_shape, size_values,
+                             output_shape, expected_output_data, output_data);
+}
+
+TF_LITE_MICRO_TEST(SliceInt16) {
+  int input_shape[] = {4, 3, 2, 3, 1};
+  int16_t input_values[] = {1, 1, 1, 2, 2, 2, 3, 3, 3,
+                            4, 4, 4, 5, 5, 5, 6, 6, 6};
+  int begin_shape[] = {1, 4};
+  int32_t begin_values[] = {1, 0, 0, 0};
+  int size_shape[] = {1, 4};
+  int32_t size_values[] = {2, 1, -1, 1};
+  int output_shape[] = {4, 2, 1, 3, 1};
+  int16_t expected_output_data[] = {3, 3, 3, 5, 5, 5};
+  int16_t output_data[6];
+
+  tflite::testing::TestSlice(input_shape, input_values, begin_shape,
+                             begin_values, size_shape, size_values,
+                             output_shape, expected_output_data, output_data);
+}
+
+TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/kernels/split.cc
+++ b/tensorflow/lite/micro/kernels/split.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_error_reporter.h"
 
 namespace tflite {
 namespace ops {
@@ -105,11 +106,10 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       return SplitImpl<int32_t>(context, node, input, axis_value);
     }
     default:
-      TF_LITE_KERNEL_LOG(context, "Type %s currently not supported.",
-                         TfLiteTypeGetName(input->type));
+      MicroPrintf("Type %s currently not supported.",
+                  TfLiteTypeGetName(input->type));
       return kTfLiteError;
   }
-#undef TF_LITE_SPLIT
 
   return kTfLiteOk;
 }

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -352,6 +352,7 @@ tensorflow/lite/micro/kernels/resize_bilinear.cc \
 tensorflow/lite/micro/kernels/resize_nearest_neighbor.cc \
 tensorflow/lite/micro/kernels/round.cc \
 tensorflow/lite/micro/kernels/shape.cc \
+tensorflow/lite/micro/kernels/slice.cc \
 tensorflow/lite/micro/kernels/softmax.cc \
 tensorflow/lite/micro/kernels/softmax_common.cc \
 tensorflow/lite/micro/kernels/space_to_batch_nd.cc \


### PR DESCRIPTION
Add 16-float and float to int16 capabilities to the cast operator. Add slice operator. Remove unused #undef in split.

BUG=http://b/198464541
NO_CHECK_TFLITE_FILES=Adding tesnorflow/lite/kernels/internal/reference/slice.h both in tflite_files.txt and in the TFLM repo.

Mirror of http://cl/396955720