### PR TITLE
Workaround for fpu-related bug in gcc

### DIFF
--- a/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
@@ -139,7 +139,14 @@ else ifeq ($(TOOLCHAIN), gcc)
 
   TARGET_TOOLCHAIN_PREFIX := arm-none-eabi-
 
-  FLAGS_GCC = -mcpu=$(GCC_TARGET_ARCH) -mfpu=auto
+  FLAGS_GCC = -mcpu=$(GCC_TARGET_ARCH)
+  ifeq ($(TARGET_ARCH), cortex-m4)
+    FLAGS_GCC += -mfpu=fpv4-sp-d16
+  else ifeq ($(TARGET_ARCH), cortex-m7)
+    FLAGS_GCC += -mfpu=fpv4-sp-d16
+  else
+    FLAGS_GCC += -mfpu=auto
+  endif
   CXXFLAGS += $(FLAGS_GCC)
   CCFLAGS += $(FLAGS_GCC)
 


### PR DESCRIPTION
Applications would fail for some combination of Cortex-M targets and compilers due to this bug:
https://gcc.gnu.org/bugzilla//show_bug.cgi?id=83206

This PR works around that.

BUG=Fixes #571