### PR TITLE
Fix for third_party srcs not being part of the project generation output tree.

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
@@ -22,6 +22,22 @@ cd "${ROOT_DIR}"
 
 source tensorflow/lite/micro/tools/ci_build/helper_functions.sh
 
+# First, we test that create_tflm_tree without any examples can be used to build a
+# static library.
+TEST_OUTPUT_DIR=$(mktemp -d)
+
+readable_run \
+  python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py \
+  ${TEST_OUTPUT_DIR}
+
+readable_run cp tensorflow/lite/micro/tools/project_generation/Makefile ${TEST_OUTPUT_DIR}
+pushd ${TEST_OUTPUT_DIR} > /dev/null
+readable_run make -j8 libtflm
+popd > /dev/null
+
+rm -rf ${TEST_OUTPUT_DIR}
+
+# Next, we test that create_tflm_tree can be used to build example binaries.
 EXAMPLES="-e hello_world -e magic_wand -e micro_speech -e person_detection"
 
 TEST_OUTPUT_DIR=$(mktemp -d)

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -402,12 +402,6 @@ $(wildcard tensorflow/lite/micro/memory_planner/*.h) \
 LICENSE \
 $(TFL_CC_HDRS)
 
-# Load custom kernels.
-include $(MAKEFILE_DIR)/additional_kernels.inc
-
-MICROLITE_CC_SRCS := $(filter-out $(MICROLITE_TEST_SRCS), $(MICROLITE_CC_BASE_SRCS))
-MICROLITE_CC_SRCS := $(filter-out $(MICROLITE_BENCHMARK_SRCS), $(MICROLITE_CC_SRCS))
-
 # For project generation v1, the headers that are common to all targets need to
 # have a third_party prefix. Other third_party headers (e.g. CMSIS) do not have
 # this requirement and are added to THIRD_PARTY_CC_HDRS with full path from the
@@ -423,6 +417,14 @@ MICROLITE_CC_SRCS := $(filter-out $(MICROLITE_BENCHMARK_SRCS), $(MICROLITE_CC_SR
 # TODO(#47413): remove this additional logic once we are ready to switch over to
 # project generation v2.
 THIRD_PARTY_CC_HDRS :=
+THIRD_PARTY_CC_SRCS :=
+
+# Load custom kernels.
+include $(MAKEFILE_DIR)/additional_kernels.inc
+
+MICROLITE_CC_SRCS := $(filter-out $(MICROLITE_TEST_SRCS), $(MICROLITE_CC_BASE_SRCS))
+MICROLITE_CC_SRCS := $(filter-out $(MICROLITE_BENCHMARK_SRCS), $(MICROLITE_CC_SRCS))
+
 
 # TODO(b/165940489): Figure out how to avoid including fixed point
 # platform-specific headers.


### PR DESCRIPTION
BUG=PR created from http://cl/401602201
