### PR TITLE
Switch kissfft to use a download script + patch.

### DIFF
--- a/tensorflow/lite/micro/examples/micro_speech/Makefile.inc
+++ b/tensorflow/lite/micro/examples/micro_speech/Makefile.inc
@@ -18,8 +18,6 @@ $(MAKEFILE_DIR)/downloads/kissfft/_kiss_fft_guts.h \
 $(MAKEFILE_DIR)/downloads/kissfft/tools/kiss_fftr.c \
 $(MAKEFILE_DIR)/downloads/kissfft/tools/kiss_fftr.h
 
-$(eval $(call add_third_party_download,$(KISSFFT_URL),$(KISSFFT_MD5),kissfft,patch_kissfft))
-
 THIRD_PARTY_CC_HDRS += \
 third_party/kissfft/COPYING \
 third_party/kissfft/kiss_fft.h \

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -476,6 +476,11 @@ ifneq ($(DOWNLOAD_RESULT), SUCCESS)
   $(error Something went wrong with the flatbuffers download: $(DOWNLOAD_RESULT))
 endif
 
+DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/kissfft_download.sh ${MAKEFILE_DIR}/downloads)
+ifneq ($(DOWNLOAD_RESULT), SUCCESS)
+  $(error Something went wrong with the kissfft download: $(DOWNLOAD_RESULT))
+endif
+
 DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/pigweed_download.sh ${MAKEFILE_DIR}/downloads)
 ifneq ($(DOWNLOAD_RESULT), SUCCESS)
   $(error Something went wrong with the pigweed download: $(DOWNLOAD_RESULT))

--- a/tensorflow/lite/micro/tools/make/download_and_extract.sh
+++ b/tensorflow/lite/micro/tools/make/download_and_extract.sh
@@ -68,24 +68,6 @@ patch_am_sdk() {
   echo "Finished preparing Apollo3 files"
 }
 
-# Fixes issues with KissFFT.
-patch_kissfft() {
-  sed -i -E '/^#include <sys\/types.h>/d' tensorflow/lite/micro/tools/make/downloads/kissfft/kiss_fft.h
-  # Fix for https://github.com/mborgerding/kissfft/issues/20
-  sed -i -E $'s@#ifdef FIXED_POINT@#ifdef FIXED_POINT\\\n#include <stdint.h> /* Patched. */@g' tensorflow/lite/micro/tools/make/downloads/kissfft/kiss_fft.h
-  sed -i -E $'s@extern "C"@extern "C++"@g' tensorflow/lite/micro/tools/make/downloads/kissfft/kiss_fft.h
-  sed -i -E $'s@extern "C"@extern "C++"@g' tensorflow/lite/micro/tools/make/downloads/kissfft/tools/kiss_fftr.h
-  sed -i '1 i\#ifndef _KISS_FFT_GUTS_H\n#define _KISS_FFT_GUTS_H\n' tensorflow/lite/micro/tools/make/downloads/kissfft/_kiss_fft_guts.h
-  sed -i '$a\#endif // _KISS_FFT_GUTS_H\n' tensorflow/lite/micro/tools/make/downloads/kissfft/_kiss_fft_guts.h
-  sed -i -E "s@HALF_OF\(x\) \(\(x\)\*\.5\)@HALF_OF(x) ((x)*(kiss_fft_scalar).5)@g" tensorflow/lite/micro/tools/make/downloads/kissfft/_kiss_fft_guts.h
-  sed -i -E "s@#define KISS_FFT_MALLOC malloc@#define KISS_FFT_MALLOC(X) (void*)(0x0) /* Patched. */@g" tensorflow/lite/micro/tools/make/downloads/kissfft/kiss_fft.h
-  sed -i -E "s@#define KISS_FFT_FREE free@#define KISS_FFT_FREE(X) /* Patched. */@g" tensorflow/lite/micro/tools/make/downloads/kissfft/kiss_fft.h
-  sed -ir -E "s@(fprintf.*\);)@/* \1 */@g" tensorflow/lite/micro/tools/make/downloads/kissfft/tools/kiss_fftr.c
-  sed -ir -E "s@(memcpy.*\);)@/* \1 */@g" tensorflow/lite/micro/tools/make/downloads/kissfft/kiss_fft.c
-  sed -ir -E "s@(exit.*\);)@return; /* \1 */@g" tensorflow/lite/micro/tools/make/downloads/kissfft/tools/kiss_fftr.c
-  echo "Finished patching kissfft"
-}
-
 build_embarc_mli() {
   if [[ ${ARC_TAGS} =~ "mli20_experimental" ]]; then
     make -C ${1}/lib/make build TCF_FILE=${2} BUILDLIB_DIR=${BUILD_LIB_DIR} GEN_EXAMPLES=0 JOBS=4
@@ -191,8 +173,6 @@ download_and_extract() {
 
   if [[ ${action} == "patch_am_sdk" ]]; then
     patch_am_sdk ${dir}
-  elif [[ ${action} == "patch_kissfft" ]]; then
-    patch_kissfft ${dir}
   elif [[ ${action} == "patch_cifar10_dataset" ]]; then
     patch_cifar10_dataset ${dir}
   elif [[ ${action} == "build_embarc_mli" ]]; then

--- a/tensorflow/lite/micro/tools/make/kissfft.patch
+++ b/tensorflow/lite/micro/tools/make/kissfft.patch
@@ -1,0 +1,94 @@
+diff --git a/_kiss_fft_guts.h b/_kiss_fft_guts.h
+index ba66144..b7792a7 100644
+--- a/_kiss_fft_guts.h
++++ b/_kiss_fft_guts.h
+@@ -1,3 +1,6 @@
++#ifndef _KISS_FFT_GUTS_H
++#define _KISS_FFT_GUTS_H
++
+ /*
+ Copyright (c) 2003-2010, Mark Borgerding
+ 
+@@ -162,3 +165,4 @@ struct kiss_fft_state{
+ #define  KISS_FFT_TMP_ALLOC(nbytes) KISS_FFT_MALLOC(nbytes)
+ #define  KISS_FFT_TMP_FREE(ptr) KISS_FFT_FREE(ptr)
+ #endif
++#endif // _KISS_FFT_GUTS_H
+diff --git a/kiss_fft.h b/kiss_fft.h
+index 64c50f4..ce88cdf 100644
+--- a/kiss_fft.h
++++ b/kiss_fft.h
+@@ -7,7 +7,7 @@
+ #include <string.h>
+ 
+ #ifdef __cplusplus
+-extern "C" {
++extern "C++" {
+ #endif
+ 
+ /*
+@@ -29,13 +29,13 @@ extern "C" {
+ #define KISS_FFT_MALLOC(nbytes) _mm_malloc(nbytes,16)
+ #define KISS_FFT_FREE _mm_free
+ #else	
+-#define KISS_FFT_MALLOC malloc
+-#define KISS_FFT_FREE free
++#define KISS_FFT_MALLOC(X) (void*)(~0x1) /* Patched. */
++#define KISS_FFT_FREE(X) /* Patched. */
+ #endif	
+ 
+ 
+ #ifdef FIXED_POINT
+-#include <sys/types.h>	
++#include <stdint.h> /* Patched. */
+ # if (FIXED_POINT == 32)
+ #  define kiss_fft_scalar int32_t
+ # else	
+diff --git a/tools/kiss_fftr.c b/tools/kiss_fftr.c
+index b8e238b..0d22a04 100644
+--- a/tools/kiss_fftr.c
++++ b/tools/kiss_fftr.c
+@@ -31,7 +31,7 @@ kiss_fftr_cfg kiss_fftr_alloc(int nfft,int inverse_fft,void * mem,size_t * lenme
+     size_t subsize, memneeded;
+ 
+     if (nfft & 1) {
+-        fprintf(stderr,"Real FFT optimization must be even.\n");
++        /* fprintf(stderr,"Real FFT optimization must be even.\n"); */
+         return NULL;
+     }
+     nfft >>= 1;
+@@ -71,8 +71,8 @@ void kiss_fftr(kiss_fftr_cfg st,const kiss_fft_scalar *timedata,kiss_fft_cpx *fr
+     kiss_fft_cpx fpnk,fpk,f1k,f2k,tw,tdc;
+ 
+     if ( st->substate->inverse) {
+-        fprintf(stderr,"kiss fft usage error: improper alloc\n");
+-        exit(1);
++        /* fprintf(stderr,"kiss fft usage error: improper alloc\n"); */
++        return; /* exit(1); */
+     }
+ 
+     ncfft = st->substate->nfft;
+@@ -126,8 +126,8 @@ void kiss_fftri(kiss_fftr_cfg st,const kiss_fft_cpx *freqdata,kiss_fft_scalar *t
+     int k, ncfft;
+ 
+     if (st->substate->inverse == 0) {
+-        fprintf (stderr, "kiss fft usage error: improper alloc\n");
+-        exit (1);
++        /* fprintf (stderr, "kiss fft usage error: improper alloc\n"); */
++        return; /* exit (1); */
+     }
+ 
+     ncfft = st->substate->nfft;
+diff --git a/tools/kiss_fftr.h b/tools/kiss_fftr.h
+index 72e5a57..b888a28 100644
+--- a/tools/kiss_fftr.h
++++ b/tools/kiss_fftr.h
+@@ -3,7 +3,7 @@
+ 
+ #include "kiss_fft.h"
+ #ifdef __cplusplus
+-extern "C" {
++extern "C++" {
+ #endif
+ 
+     

--- a/tensorflow/lite/micro/tools/make/kissfft_download.sh
+++ b/tensorflow/lite/micro/tools/make/kissfft_download.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Called with following arguments:
+# 1 - Path to the downloads folder which is typically
+#     tensorflow/lite/micro/tools/make/downloads
+#
+# This script is called from the Makefile and uses the following convention to
+# enable determination of sucess/failure:
+#
+#   - If the script is successful, the only output on stdout should be SUCCESS.
+#     The makefile checks for this particular string.
+#
+#   - Any string on stdout that is not SUCCESS will be shown in the makefile as
+#     the cause for the script to have failed.
+#
+#   - Any other informational prints should be on stderr.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR=${SCRIPT_DIR}/../../../../..
+cd "${ROOT_DIR}"
+
+source tensorflow/lite/micro/tools/make/bash_helpers.sh
+
+DOWNLOADS_DIR=${1}
+if [ ! -d ${DOWNLOADS_DIR} ]; then
+  echo "The top-level downloads directory: ${DOWNLOADS_DIR} does not exist."
+  exit 1
+fi
+
+DOWNLOADED_KISSFFT_PATH=${DOWNLOADS_DIR}/kissfft
+
+if [ -d ${DOWNLOADED_KISSFFT_PATH} ]; then
+  echo >&2 "${DOWNLOADED_KISSFFT_PATH} already exists, skipping the download."
+else
+
+  KISSFFT_URL="https://github.com/mborgerding/kissfft/archive/refs/tags/v130.zip"
+  KISSFFT_MD5="438ba1fef5783cc5f5f201395cc477ca"
+
+  TEMPDIR="$(mktemp -d)"
+  TEMPFILE="${TEMPDIR}/v130.zip"
+  wget ${KISSFFT_URL} -O "${TEMPFILE}" >&2
+  check_md5 "${TEMPFILE}" ${KISSFFT_MD5}
+
+  unzip -qo "$TEMPFILE" -d "${TEMPDIR}" >&2
+  mv "${TEMPDIR}/kissfft-130" ${DOWNLOADED_KISSFFT_PATH}
+  rm -rf "${TEMPDIR}"
+
+  pushd ${DOWNLOADED_KISSFFT_PATH} > /dev/null
+  apply_patch_to_folder ./ ../../kissfft.patch
+  popd > /dev/null
+fi
+
+echo "SUCCESS"

--- a/tensorflow/lite/micro/tools/make/third_party_downloads.inc
+++ b/tensorflow/lite/micro/tools/make/third_party_downloads.inc
@@ -25,9 +25,6 @@ endif
 SIFIVE_FE310_LIB_URL := "http://mirror.tensorflow.org/github.com/sifive/freedom-e-sdk/archive/baeeb8fd497a99b3c141d7494309ec2e64f19bdf.zip"
 SIFIVE_FE310_LIB_MD5 := "06ee24c4956f8e21670ab3395861fe64"
 
-KISSFFT_URL="http://mirror.tensorflow.org/github.com/mborgerding/kissfft/archive/v130.zip"
-KISSFFT_MD5="438ba1fef5783cc5f5f201395cc477ca"
-
 RUY_URL="https://github.com/google/ruy/archive/d37128311b445e758136b8602d1bbd2a755e115d.zip"
 RUY_MD5="abf7a91eb90d195f016ebe0be885bb6e"
 


### PR DESCRIPTION
 * Some additional context in http://b/195794602
 * Moved the kissfft download to the top-level makefile. With the download in a shell script, there is no benefit to having it being defined in the micro\_speech example's Makefile since the download will happen independent of the build target.
 * kissfft.patch was created from exactly the changes that are currently made with the sed scripts.

BUG=Fixes #604
