### PR TITLE
Use TEST_WORKSPACE instead of org_tensorflow.

### DIFF
--- a/tensorflow/lite/micro/examples/hello_world/hello_world_binary_test.sh
+++ b/tensorflow/lite/micro/examples/hello_world/hello_world_binary_test.sh
@@ -20,9 +20,7 @@ set -e
 
 OUTPUT_LOG_FILE=${TEST_TMPDIR}/output_log.txt
 
-# Needed for copybara compatibility.
-SCRIPT_BASE_DIR=/org_"tensor"flow
-${TEST_SRCDIR}${SCRIPT_BASE_DIR}/tensorflow/lite/micro/examples/hello_world/hello_world   2>&1 | head > ${OUTPUT_LOG_FILE}
+${TEST_SRCDIR}/${TEST_WORKSPACE}/tensorflow/lite/micro/examples/hello_world/hello_world   2>&1 | head > ${OUTPUT_LOG_FILE}
 
 if ! grep -q 'x_value:.*y_value:' ${OUTPUT_LOG_FILE}; then
   echo "ERROR: Expected logs not found in output '${OUTPUT_LOG_FILE}'"

--- a/tensorflow/lite/micro/examples/micro_speech/micro_speech_binary_mock_test.sh
+++ b/tensorflow/lite/micro/examples/micro_speech/micro_speech_binary_mock_test.sh
@@ -19,10 +19,7 @@
 set -e
 
 OUTPUT_LOG_FILE=${TEST_TMPDIR}/output_log.txt
-
-# Needed for copybara compatibility.
-SCRIPT_BASE_DIR=/org_"tensor"flow
-${TEST_SRCDIR}${SCRIPT_BASE_DIR}/tensorflow/lite/micro/examples/micro_speech/micro_speech_mock 2>&1 | head > ${OUTPUT_LOG_FILE}
+${TEST_SRCDIR}/${TEST_WORKSPACE}/tensorflow/lite/micro/examples/micro_speech/micro_speech_mock 2>&1 | head > ${OUTPUT_LOG_FILE}
 
 if ! grep -q 'Heard ' ${OUTPUT_LOG_FILE}; then
   echo "ERROR: Expected logs not found in output '${OUTPUT_LOG_FILE}'"

--- a/tensorflow/lite/micro/examples/person_detection/person_detection_binary_test.sh
+++ b/tensorflow/lite/micro/examples/person_detection/person_detection_binary_test.sh
@@ -20,9 +20,7 @@ set -e
 
 OUTPUT_LOG_FILE=${TEST_TMPDIR}/output_log.txt
 
-# Needed for copybara compatibility.
-SCRIPT_BASE_DIR=/org_"tensor"flow
-${TEST_SRCDIR}${SCRIPT_BASE_DIR}/tensorflow/lite/micro/examples/person_detection/person_detection 2>&1 | head > ${OUTPUT_LOG_FILE}
+${TEST_SRCDIR}/${TEST_WORKSPACE}/tensorflow/lite/micro/examples/person_detection/person_detection 2>&1 | head > ${OUTPUT_LOG_FILE}
 
 if ! grep -q 'person score' ${OUTPUT_LOG_FILE}; then
   echo "ERROR: Expected logs not found in output '${OUTPUT_LOG_FILE}'"


### PR DESCRIPTION
`TEST_WORKSPACE`, and `TEST_SRCDIR` are set by bazel and should be used to avoid hard coding the name of the bazel workspace (in the top-level WORKSPACE file) in multiple locations.

See https://docs.bazel.build/versions/main/test-encyclopedia.html for more documentation.

BUG=http://b/186254878
