### PR TITLE
Add build format check on test_code_style.sh   

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_code_style.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_code_style.sh
@@ -99,7 +99,7 @@ if [[ ${FIX_FORMAT_FLAG} == "--fix_formatting" ]]
 then
   FIX_BUILD_FORMAT_OPTIONS="-mode=fix"
 else
-  FIX_BUILD_FORMAT_OPTIONS="-mode=diff -diff_command=diff"
+  FIX_BUILD_FORMAT_OPTIONS="-d"
 fi
 
 BUILD_FILES=$(find . \( -name BUILD -o -name "*.bzl" \) )


### PR DESCRIPTION
Add build format check on test_code_style.sh   

Pass --fix_formatting to test_code_style.sh will now enalbe format fix for both
code and build file.

After this change, presubmit will check build file format on top of
existing code style format check.

BUG=http://b/203803273