### PR TITLE
Sync Python flatbuffer bindings, tools and utils from TF.

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -29,6 +29,10 @@ jobs:
         with:
           token: ${{ secrets.TFLM_BOT_REPO_TOKEN }}
 
+      - name: Install dependencies for sync
+        run: |
+          ./ci/install_bazel.sh
+
       - name: Sync the code
         run: |
           ./ci/sync_from_upstream_tf.sh

--- a/ci/sync_from_upstream_tf.sh
+++ b/ci/sync_from_upstream_tf.sh
@@ -31,6 +31,13 @@ rm -rf /tmp/tensorflow
 
 git clone https://github.com/tensorflow/tensorflow.git --depth=1 /tmp/tensorflow
 
+# As part of the import from upstream TF, we generate the Python bindings for
+# the TfLite flatbuffer schema.
+cd /tmp/tensorflow
+bazel build tensorflow/lite/python:schema_py
+/bin/cp bazel-bin/tensorflow/lite/python/schema_py_generated.py tensorflow/lite/python
+cd -
+
 SHARED_TFL_CODE=$(<ci/tflite_files.txt)
 
 for filepath in ${SHARED_TFL_CODE}

--- a/ci/tflite_files.txt
+++ b/ci/tflite_files.txt
@@ -89,5 +89,9 @@ tensorflow/lite/kernels/internal/types.h
 tensorflow/lite/kernels/kernel_util.h
 tensorflow/lite/kernels/padding.h
 tensorflow/lite/portable_type_to_tflitetype.h
+tensorflow/lite/python/schema_py_generated.py
 tensorflow/lite/schema/schema_generated.h
 tensorflow/lite/schema/schema_utils.h
+tensorflow/lite/tools/flatbuffer_utils.py
+tensorflow/lite/tools/flatbuffer_utils_test.py
+tensorflow/lite/tools/test_utils.py


### PR DESCRIPTION
This is a first step towards enabling flatbuffer manipulation from Python.

As part of this change:
  * we generate the python flatbuffer bindings from the tensorflow repository and copy the schema\_py\_generated into the TFLM repo.

  * sync common python flatbuffer manipulation code from upstream TF.

Manually tested that the sync script runs as expected:
```
./ci/sync_from_upstream_tf.sh
```

BUG=http://b/204109200
