### PR TITLE
Install bazel with sudo.

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install dependencies for sync
         run: |
-          ./ci/install_bazel.sh
+          sudo ./ci/install_bazel.sh
 
       - name: Sync the code
         run: |


### PR DESCRIPTION
This PR should fix the error introduced with https://github.com/tensorflow/tflite-micro/pull/626.

The error from running the sync workflow is:
```
Run ./ci/install_bazel.sh
  ./ci/install_bazel.sh
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.10.0/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.0/x64/lib
mkdir: cannot create directory ‘/bazel’: Permission denied
Error: Process completed with exit code 1.
```


BUG=fix error introduced with earlier change.
