### PR TITLE
Install numpy for the bazel build during the sync.

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Install dependencies for sync
         run: |
           sudo ./ci/install_bazel.sh
+          pip3 install numpy
 
       - name: Sync the code
         run: |


### PR DESCRIPTION
This PR should fix the error introduced with #626.

Manually tested in a docker container that the bazel build passes once numpy is installed.

BUG=fix error introduced with earlier change.