### PR TITLE
Add flatbuffer_utils and corresponding test to the bazel build.

### DIFF
--- a/ci/sync_from_upstream_tf.sh
+++ b/ci/sync_from_upstream_tf.sh
@@ -46,6 +46,12 @@ do
   /bin/cp /tmp/tensorflow/${filepath} ${filepath}
 done
 
+# The shared TFL/TFLM python code uses a different bazel workspace in the two
+# repositories (TF and tflite-micro) which needs the import statements to be
+# modified.
+PY_FILES=$(find tensorflow/lite/tools tensorflow/lite/python -name "*.py")
+sed -i 's/from tensorflow\.lite/from tflm_bazel\.tensorflow\.lite/' ${PY_FILES}
+
 # Since the TFLM code was deleted from the tensorflow repository, the
 # microfrontend is no longer sync'd from upstream and instead maintaned as a
 # fork.

--- a/tensorflow/lite/python/BUILD
+++ b/tensorflow/lite/python/BUILD
@@ -1,0 +1,20 @@
+load("@tflm_pip_deps//:requirements.bzl", "requirement")
+
+# In upstream Tensorflow, this target is a flatbuffer_py_library which generates
+# the Python bindings from schema.fbs
+#
+# We have made a decision to generate the Python bindings as part of the sync
+# and directly commit schema_py_generated.py in the TFLM repository.
+#
+# The name of this BUILD target is kept the same as the upstream target to allow
+# for fewer source transformations when going between the different
+# repositories.
+py_library(
+    name = "schema_py",
+    srcs = ["schema_py_generated.py"],
+    srcs_version = "PY3",
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("flatbuffers"),
+    ],
+)

--- a/tensorflow/lite/schema/BUILD
+++ b/tensorflow/lite/schema/BUILD
@@ -1,3 +1,5 @@
+load("@tflm_pip_deps//:requirements.bzl", "requirement")
+
 package(
     default_visibility = [
         "//visibility:public",

--- a/tensorflow/lite/tools/BUILD
+++ b/tensorflow/lite/tools/BUILD
@@ -1,0 +1,35 @@
+load("@tflm_pip_deps//:requirements.bzl", "requirement")
+
+py_library(
+    name = "flatbuffer_utils",
+    srcs = ["flatbuffer_utils.py"],
+    srcs_version = "PY3",
+    deps = [
+        requirement("flatbuffers"),
+        requirement("tensorflow"),
+        "//tensorflow/lite/python:schema_py",
+    ],
+)
+
+py_library(
+    name = "test_utils",
+    srcs = ["test_utils.py"],
+    srcs_version = "PY3",
+    deps = [
+        requirement("flatbuffers"),
+        requirement("tensorflow"),
+        "//tensorflow/lite/python:schema_py",
+    ],
+)
+
+py_test(
+    name = "flatbuffer_utils_test",
+    srcs = ["flatbuffer_utils_test.py"],
+    python_version = "PY3",
+    srcs_version = "PY3",
+    deps = [
+        ":flatbuffer_utils",
+        ":test_utils",
+        requirement("tensorflow"),
+    ],
+)

--- a/tensorflow/lite/tools/flatbuffer_utils.py
+++ b/tensorflow/lite/tools/flatbuffer_utils.py
@@ -26,7 +26,7 @@ import random
 import re
 
 import flatbuffers
-from tensorflow.lite.python import schema_py_generated as schema_fb
+from tflm_bazel.tensorflow.lite.python import schema_py_generated as schema_fb
 from tensorflow.python.platform import gfile
 
 _TFLITE_FILE_IDENTIFIER = b'TFL3'

--- a/tensorflow/lite/tools/flatbuffer_utils_test.py
+++ b/tensorflow/lite/tools/flatbuffer_utils_test.py
@@ -17,8 +17,8 @@ import copy
 import os
 import subprocess
 
-from tensorflow.lite.tools import flatbuffer_utils
-from tensorflow.lite.tools import test_utils
+from tflm_bazel.tensorflow.lite.tools import flatbuffer_utils
+from tflm_bazel.tensorflow.lite.tools import test_utils
 from tensorflow.python.framework import test_util
 from tensorflow.python.platform import test
 

--- a/tensorflow/lite/tools/test_utils.py
+++ b/tensorflow/lite/tools/test_utils.py
@@ -18,7 +18,7 @@ All functions that can be commonly used by various tests.
 """
 
 import flatbuffers
-from tensorflow.lite.python import schema_py_generated as schema_fb
+from tflm_bazel.tensorflow.lite.python import schema_py_generated as schema_fb
 
 TFLITE_SCHEMA_VERSION = 3
 

--- a/third_party/bazel_requirements.txt
+++ b/third_party/bazel_requirements.txt
@@ -1,1 +1,2 @@
+flatbuffers
 tensorflow


### PR DESCRIPTION
This is the first step towards being able to manipulate flatbuffers from Python from the TFLM github repository.

Manually confirmed that the following command works:
```
bazel test tensorflow/lite/tools:flatbuffer_utils_test
```

These python tests will also be run as part of the bazel CI.

Note that the code that is sync'd from TF needs to have an updated import path and we have changed the sync script to perform this transformation. The changes to the shared TFL/TFLM Python code were made by manually running the sync script:
```
./ci/sync_from_upstream_tf.sh
```

BUG=http://b/204109200
NO_CHECK_TFLITE_FILES=shared code modified by manually running the sync script.