### PR TITLE
Add int32_t support to strided_slice

### DIFF
--- a/tensorflow/lite/micro/kernels/strided_slice.cc
+++ b/tensorflow/lite/micro/kernels/strided_slice.cc
@@ -167,6 +167,13 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           tflite::micro::GetTensorShape(output),
           tflite::micro::GetTensorData<int16_t>(output));
       break;
+    case kTfLiteInt32:
+      reference_ops::StridedSlice(
+          op_params, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int32_t>(input),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int32_t>(output));
+      break;
     default:
       TF_LITE_KERNEL_LOG(context, "Type %s (%d) not supported.",
                          TfLiteTypeGetName(input->type), input->type);

--- a/tensorflow/lite/micro/kernels/strided_slice_test.cc
+++ b/tensorflow/lite/micro/kernels/strided_slice_test.cc
@@ -1071,4 +1071,46 @@ TF_LITE_MICRO_TEST(In3D_IdentityShrinkAxis1int16) {
       golden, false);
 }
 
+TF_LITE_MICRO_TEST(In3D_IdentityShrinkAxis1int32) {
+  int input_shape[] = {3, 2, 3, 2};
+  int begin_shape[] = {1, 3};
+  int end_shape[] = {1, 3};
+  int strides_shape[] = {1, 3};
+  int output_shape[] = {2, 3, 2};
+  int32_t input_data[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  int32_t begin_data[] = {0, 0, 0};
+  int32_t end_data[] = {1, 3, 2};
+  int32_t strides_data[] = {1, 1, 1};
+  int32_t golden[] = {1, 2, 3, 4, 5, 6};
+  int32_t output_data[12];
+
+  TfLiteStridedSliceParams builtin_data = {0, 0, 0, 0, 1};
+
+  tflite::testing::TestStridedSliceQuantized(
+      input_shape, begin_shape, end_shape, strides_shape, &builtin_data,
+      input_data, begin_data, end_data, strides_data, output_shape, output_data,
+      golden, false);
+}
+
+TF_LITE_MICRO_TEST(In3D_Strided2int32) {
+  int input_shape[] = {3, 2, 3, 2};
+  int begin_shape[] = {1, 3};
+  int end_shape[] = {1, 3};
+  int strides_shape[] = {1, 3};
+  int output_shape[] = {3, 1, 2, 1};
+  int32_t input_data[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  int32_t begin_data[] = {0, 0, 0};
+  int32_t end_data[] = {2, 3, 2};
+  int32_t strides_data[] = {2, 2, 2};
+  int32_t golden[] = {1, 5};
+  int32_t output_data[16];
+
+  TfLiteStridedSliceParams builtin_data = {};
+
+  tflite::testing::TestStridedSliceQuantized(
+      input_shape, begin_shape, end_shape, strides_shape, &builtin_data,
+      input_data, begin_data, end_data, strides_data, output_shape, output_data,
+      golden, false);
+}
+
 TF_LITE_MICRO_TESTS_END


### PR DESCRIPTION
Some TFLite models use an int32 version of STRIDED_SLICE.

This corresponds to internal cl/406286783

BUG=http://b/203816166