### PR TITLE
Fix xtensa build with reference kernels.

### DIFF
--- a/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
@@ -88,8 +88,12 @@ MICRO_LITE_EXAMPLE_TESTS += $(shell find third_party/xtensa/examples/ -name Make
 
 # Needed for LSTM support.
 MICROLITE_CC_KERNEL_SRCS := $(MICROLITE_CC_KERNEL_SRCS) \
-tensorflow/lite/micro/kernels/xtensa/lstm_eval.cc \
-tensorflow/lite/micro/kernels/xtensa/lstm_eval_hifi.cc \
-tensorflow/lite/micro/kernels/xtensa/unidirectional_sequence_lstm.cc \
 tensorflow/lite/kernels/internal/reference/portable_tensor_utils.cc \
 tensorflow/lite/kernels/kernel_util.cc
+
+ifeq ($(OPTIMIZED_KERNEL_DIR), xtensa)
+  MICROLITE_CC_KERNEL_SRCS := $(MICROLITE_CC_KERNEL_SRCS) \
+  tensorflow/lite/micro/kernels/xtensa/lstm_eval.cc \
+  tensorflow/lite/micro/kernels/xtensa/lstm_eval_hifi.cc \
+  tensorflow/lite/micro/kernels/xtensa/unidirectional_sequence_lstm.cc
+endif


### PR DESCRIPTION
Previously, xtensa kernels which depended on nnlib were included by default even when building for reference kernels. This cauesed an include error due to missing nnlib headers.

TESTED=make -f tensorflow/lite/micro/tools/make/Makefile test_integration_tests_seanet_conv TARGET=xtensa TARGET_ARCH=hifi4 XTENSA_CORE=Fusion_F1 -j8

Test ensures that TFLM targets can be built / run on the xtensa ISS with reference kernels.

BUG=http://b/204814982