### PR TITLE
Fix erroneous write from EXPAND_DIMS to an array that can be in read-only region

### DIFF
--- a/tensorflow/lite/micro/kernels/expand_dims.cc
+++ b/tensorflow/lite/micro/kernels/expand_dims.cc
@@ -26,33 +26,10 @@ constexpr int kInputTensor = 0;
 constexpr int kAxisTensor = 1;
 constexpr int kOutputTensor = 0;
 
-TfLiteStatus ExpandTensorDim(TfLiteContext* context,
-                             const TfLiteEvalTensor* input, int32_t axis,
-                             TfLiteEvalTensor* output) {
-  const TfLiteIntArray* input_dims = input->dims;
-  TfLiteIntArray* output_dims = output->dims;
-  if (axis < 0) {
-    axis = input_dims->size + 1 + axis;
-  }
-  TF_LITE_ENSURE(context, (axis <= input_dims->size));
-
-  output_dims->size = input_dims->size + 1;
-  for (int i = 0; i < output_dims->size; ++i) {
-    if (i < axis) {
-      output_dims->data[i] = input_dims->data[i];
-    } else if (i == axis) {
-      output_dims->data[i] = 1;
-    } else {
-      output_dims->data[i] = input_dims->data[i - 1];
-    }
-  }
-  return kTfLiteOk;
-}
-
 TfLiteStatus GetAxisValueFromTensor(TfLiteContext* context,
-                                    const TfLiteEvalTensor* axis,
+                                    const TfLiteTensor* axis,
                                     int32_t* axis_value) {
-  const int axis_dims = (tflite::micro::GetTensorShape(axis)).DimensionsCount();
+  const int axis_dims = (tflite::GetTensorShape(axis)).DimensionsCount();
   if (axis_dims > 1) {
     TF_LITE_KERNEL_LOG(context, "Axis has only one element for Expand_Dims.",
                        axis_dims);
@@ -60,7 +37,7 @@ TfLiteStatus GetAxisValueFromTensor(TfLiteContext* context,
   }
 
   if (kTfLiteInt32 == (axis->type)) {
-    const int32_t* axis_ptr = tflite::micro::GetTensorData<int32_t>(axis);
+    const int32_t* axis_ptr = tflite::GetTensorData<int32_t>(axis);
     *axis_value = axis_ptr[0];
     return kTfLiteOk;
   } else {
@@ -69,6 +46,41 @@ TfLiteStatus GetAxisValueFromTensor(TfLiteContext* context,
                        TfLiteTypeGetName(axis->type), axis->type);
     return kTfLiteError;
   }
+}
+
+// Verifies that the output tensor's dimension shape is equivalent to inserting
+// a dimension of length 1 at the dimension index axis of input's shape as
+// defined in https://www.tensorflow.org/api_docs/python/tf/expand_dims.
+TfLiteStatus VerifyTensorDim(TfLiteContext* context, const TfLiteTensor* input,
+                             const TfLiteTensor* axis_tensor,
+                             const TfLiteTensor* output) {
+  int32_t axis_value = 0;
+  TF_LITE_ENSURE_OK(context,
+                    GetAxisValueFromTensor(context, axis_tensor, &axis_value));
+
+  tflite::RuntimeShape input_shape = tflite::GetTensorShape(input);
+  if (axis_value < 0) {
+    axis_value = input_shape.DimensionsCount() + 1 + axis_value;
+  }
+  TF_LITE_ENSURE(context, axis_value <= input_shape.DimensionsCount());
+
+  // TFLM only supports fixed dimension tensor and assumes that the output shape
+  // is fully specified in the model. As such, TFLM directly use the pointer to
+  // the dimension array in the model buffer.
+  tflite::RuntimeShape output_shape = tflite::GetTensorShape(output);
+
+  TF_LITE_ENSURE(context, output_shape.DimensionsCount() ==
+                              input_shape.DimensionsCount() + 1);
+  for (int i = 0; i < output_shape.DimensionsCount(); ++i) {
+    if (i < axis_value) {
+      TF_LITE_ENSURE(context, output_shape.Dims(i) == input_shape.Dims(i));
+    } else if (i == axis_value) {
+      TF_LITE_ENSURE(context, output_shape.Dims(i) == 1);
+    } else {
+      TF_LITE_ENSURE(context, output_shape.Dims(i) == input_shape.Dims(i - 1));
+    }
+  }
+  return kTfLiteOk;
 }
 
 TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
@@ -87,7 +99,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
                        "DynamicTensor is not yet supported by Expand_Dims.");
     return kTfLiteError;
   }
-  return kTfLiteOk;
+  return VerifyTensorDim(context, input, axis, output);
 }
 
 template <typename T>
@@ -100,23 +112,9 @@ void memCopyN(T* out, const T* in, const int num_elements) {
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   const TfLiteEvalTensor* input =
       tflite::micro::GetEvalInput(context, node, kInputTensor);
-  const TfLiteEvalTensor* axis =
-      tflite::micro::GetEvalInput(context, node, kAxisTensor);
   TfLiteEvalTensor* output =
       tflite::micro::GetEvalOutput(context, node, kOutputTensor);
   const int flat_size = ElementCount(*input->dims);
-  const int input_dims = input->dims->size;
-
-  int32_t axis_value;
-  TF_LITE_ENSURE_OK(context,
-                    GetAxisValueFromTensor(context, axis, &axis_value));
-  if ((axis_value > static_cast<int32_t>(input_dims)) ||
-      (axis_value < static_cast<int32_t>(-(input_dims + 1)))) {
-    TF_LITE_KERNEL_LOG(context, "Invalid Expand_Dims axis value (%d).",
-                       axis_value);
-    return kTfLiteError;
-  }
-  ExpandTensorDim(context, input, axis_value, output);
 
   switch (input->type) {
     case kTfLiteFloat32: {

--- a/tensorflow/lite/micro/kernels/expand_dims_test.cc
+++ b/tensorflow/lite/micro/kernels/expand_dims_test.cc
@@ -24,45 +24,68 @@ namespace tflite {
 namespace testing {
 namespace {
 
+// The tensor layout is fixed.
+constexpr int kInputsTensorSize = 2;
+constexpr int kOutputsTensorSize = 1;
+constexpr int kTensorsSize = kInputsTensorSize + kOutputsTensorSize;
+
+constexpr int kDimsTensorIndex = 0;
+constexpr int kAxisTensorIndex = 1;
+constexpr int kOutputTensorIndex = 2;
+constexpr int kInputTensors[] = {2, kDimsTensorIndex, kAxisTensorIndex};
+constexpr int kOutputTensors[] = {1, kOutputTensorIndex};
+
+template <typename T>
+micro::KernelRunner CreateExpandDimsKernelRunner(
+    int* input_dims, const T* input_data, int* axis_dims,
+    const int32_t* axis_data, int* output_dims, T* output_data) {
+  // Some targets do not support dynamic memory (i.e., no malloc or new), thus,
+  // the test need to place non-transitent memories in static variables. This is
+  // safe because tests are guarateed to run serially.
+  // Both below structures are trivially destructible.
+  static TfLiteRegistration registration;
+  static TfLiteTensor tensors[kTensorsSize];
+
+  TfLiteIntArray* in_dims = IntArrayFromInts(input_dims);
+  TfLiteIntArray* ax_dims = IntArrayFromInts(axis_dims);
+  TfLiteIntArray* out_dims = IntArrayFromInts(output_dims);
+
+  const int out_dims_size = out_dims->size;
+  const int in_dims_size = in_dims->size;
+  TF_LITE_MICRO_EXPECT_EQ(out_dims_size, (in_dims_size + 1));
+
+  tensors[kDimsTensorIndex] = CreateTensor(input_data, in_dims);
+  tensors[kAxisTensorIndex] = CreateTensor(axis_data, ax_dims);
+  tensors[kOutputTensorIndex] = CreateTensor(output_data, out_dims, true);
+
+  TfLiteIntArray* inputs_array =
+      IntArrayFromInts(const_cast<int*>(kInputTensors));
+
+  TfLiteIntArray* outputs_array =
+      IntArrayFromInts(const_cast<int*>(kOutputTensors));
+
+  registration = Register_EXPAND_DIMS();
+  micro::KernelRunner runner(registration, tensors, kTensorsSize, inputs_array,
+                             outputs_array,
+                             /*builtin_data=*/nullptr);
+  return runner;
+}
+
 template <typename T>
 void TestExpandDims(int* input_dims, const T* input_data, int* axis_dims,
                     const int32_t* axis_data, int* expected_output_dims,
                     int* output_dims, const T* expected_output_data,
                     T* output_data) {
-  TfLiteIntArray* in_dims = IntArrayFromInts(input_dims);
-  TfLiteIntArray* ax_dims = IntArrayFromInts(axis_dims);
-  TfLiteIntArray* out_dims = IntArrayFromInts(output_dims);
-  const int in_dims_size = in_dims->size;
+  micro::KernelRunner runner = CreateExpandDimsKernelRunner(
+      input_dims, input_data, axis_dims, axis_data, output_dims, output_data);
 
-  constexpr int inputs_size = 2;
-  constexpr int outputs_size = 1;
-  constexpr int tensors_size = inputs_size + outputs_size;
-  TfLiteTensor tensors[tensors_size] = {
-      CreateTensor(input_data, in_dims),
-      CreateTensor(axis_data, ax_dims),
-      CreateTensor(output_data, out_dims, true),
-  };
-  int inputs_array_data[] = {2, 0, 1};
-  TfLiteIntArray* inputs_array = IntArrayFromInts(inputs_array_data);
-  int outputs_array_data[] = {1, 2};
-  TfLiteIntArray* outputs_array = IntArrayFromInts(outputs_array_data);
-
-  const TfLiteRegistration registration = Register_EXPAND_DIMS();
-  micro::KernelRunner runner(registration, tensors, tensors_size, inputs_array,
-                             outputs_array,
-                             /*builtin_data=*/nullptr);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.InitAndPrepare());
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.Invoke());
 
-  // The output tensor's data and shape have been updated by the kernel.
-  TfLiteTensor* actual_out_tensor = &tensors[2];
-  TfLiteIntArray* actual_out_dims = actual_out_tensor->dims;
-  const int actual_out_dims_size = actual_out_dims->size;
+  // The output tensor's data have been updated by the kernel.
+  TfLiteIntArray* actual_out_dims = IntArrayFromInts(output_dims);
   const int output_size = ElementCount(*actual_out_dims);
-  TF_LITE_MICRO_EXPECT_EQ(actual_out_dims_size, (in_dims_size + 1));
-  for (int i = 0; i < actual_out_dims_size; ++i) {
-    TF_LITE_MICRO_EXPECT_EQ(expected_output_dims[i], actual_out_dims->data[i]);
-  }
+
   for (int i = 0; i < output_size; ++i) {
     TF_LITE_MICRO_EXPECT_EQ(expected_output_data[i], output_data[i]);
   }
@@ -82,7 +105,7 @@ TF_LITE_MICRO_TEST(ExpandDimsPositiveAxisTest0) {
   int axis_dims[] = {1, 1};
   const int32_t axis_data[] = {0};
   int golden_dims[] = {1, 2, 2};
-  int output_dims[] = {3, 0, 0, 0};
+  int output_dims[] = {3, 1, 2, 2};
   tflite::testing::TestExpandDims<int8_t>(input_dims, input_data, axis_dims,
                                           axis_data, golden_dims, output_dims,
                                           golden_data, output_data);
@@ -96,7 +119,7 @@ TF_LITE_MICRO_TEST(ExpandDimsPositiveAxisTest1) {
   int axis_dims[] = {1, 1};
   const int32_t axis_data[] = {1};
   int golden_dims[] = {2, 1, 2};
-  int output_dims[] = {3, 0, 0, 0};
+  int output_dims[] = {3, 2, 1, 2};
   tflite::testing::TestExpandDims<float>(input_dims, input_data, axis_dims,
                                          axis_data, golden_dims, output_dims,
                                          golden_data, output_data);
@@ -110,7 +133,7 @@ TF_LITE_MICRO_TEST(ExpandDimsPositiveAxisTest2) {
   int axis_dims[] = {1, 1};
   const int32_t axis_data[] = {2};
   int golden_dims[] = {2, 2, 1};
-  int output_dims[] = {3, 0, 0, 0};
+  int output_dims[] = {3, 2, 2, 1};
   tflite::testing::TestExpandDims<int8_t>(input_dims, input_data, axis_dims,
                                           axis_data, golden_dims, output_dims,
                                           golden_data, output_data);
@@ -124,7 +147,7 @@ TF_LITE_MICRO_TEST(ExpandDimsNegativeAxisTest4) {
   int axis_dims[] = {1, 1};
   const int32_t axis_data[] = {-4};
   int golden_dims[] = {1, 3, 1, 2};
-  int output_dims[] = {4, 0, 0, 0, 0};
+  int output_dims[] = {4, 1, 3, 1, 2};
   tflite::testing::TestExpandDims<int8_t>(input_dims, input_data, axis_dims,
                                           axis_data, golden_dims, output_dims,
                                           golden_data, output_data);
@@ -138,7 +161,7 @@ TF_LITE_MICRO_TEST(ExpandDimsNegativeAxisTest3) {
   int axis_dims[] = {1, 1};
   const int32_t axis_data[] = {-3};
   int golden_dims[] = {3, 1, 1, 2};
-  int output_dims[] = {4, 0, 0, 0, 0};
+  int output_dims[] = {4, 3, 1, 1, 2};
   tflite::testing::TestExpandDims<float>(input_dims, input_data, axis_dims,
                                          axis_data, golden_dims, output_dims,
                                          golden_data, output_data);
@@ -152,7 +175,7 @@ TF_LITE_MICRO_TEST(ExpandDimsNegativeAxisTest2) {
   int axis_dims[] = {1, 1};
   const int32_t axis_data[] = {-2};
   int golden_dims[] = {1, 2, 1, 3};
-  int output_dims[] = {4, 0, 0, 0, 0};
+  int output_dims[] = {4, 1, 2, 1, 3};
   tflite::testing::TestExpandDims<int8_t>(input_dims, input_data, axis_dims,
                                           axis_data, golden_dims, output_dims,
                                           golden_data, output_data);
@@ -166,10 +189,48 @@ TF_LITE_MICRO_TEST(ExpandDimsNegativeAxisTest1) {
   int axis_dims[] = {1, 1};
   const int32_t axis_data[] = {-1};
   int golden_dims[] = {1, 3, 2, 1};
-  int output_dims[] = {4, 0, 0, 0, 0};
+  int output_dims[] = {4, 1, 3, 2, 1};
   tflite::testing::TestExpandDims<float>(input_dims, input_data, axis_dims,
                                          axis_data, golden_dims, output_dims,
                                          golden_data, output_data);
+}
+
+TF_LITE_MICRO_TEST(ExpandDimsInputOutputDimsMismatchShallFail) {
+  float output_data[6];
+  int input_dims[] = {3, 1, 3, 2};
+  const float input_data[] = {0.1, -0.8, -1.2, -0.5, 0.9, 1.3};
+  int axis_dims[] = {1, 1};
+  const int32_t axis_data[] = {-1};
+  // When input dimension is [1, 3, 2] and the axis is -1, the output dimension
+  // should be [1, 3, 2, 1] as in the test case ExpandDimsNegativeAxisTest1.
+  // Shuffle the output dimension to make it incorrect so that the EXPAND_DIMS
+  // op would fail at prepare.
+  int output_dims[] = {4, 1, 3, 1, 2};
+
+  tflite::micro::KernelRunner runner =
+      tflite::testing::CreateExpandDimsKernelRunner(input_dims, input_data,
+                                                    axis_dims, axis_data,
+                                                    output_dims, output_data);
+
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteError, runner.InitAndPrepare());
+}
+
+TF_LITE_MICRO_TEST(ExpandDimsAxisOutOfRangeShallFail) {
+  int8_t output_data[6];
+  int input_dims[] = {3, 1, 3, 2};
+  const int8_t input_data[] = {1, 8, 2, 5, 9, 3};
+  int axis_dims[] = {1, 1};
+  // The input dimension is 3-D, so that axis value should not exceed 3.
+  // The below axis value 4 shall lead to failure at prepare.
+  const int32_t axis_data[] = {4};
+  int output_dims[] = {4, 1, 3, 2, 1};
+
+  tflite::micro::KernelRunner runner =
+      tflite::testing::CreateExpandDimsKernelRunner(input_dims, input_data,
+                                                    axis_dims, axis_data,
+                                                    output_dims, output_data);
+
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteError, runner.InitAndPrepare());
 }
 
 TF_LITE_MICRO_TESTS_END


### PR DESCRIPTION
TFLM actually point to the tflite model buffer for the dimension array of a tensor. However, EXPAND_DIMS also try to
write to this dimension array, which leads to segfault when the model buffer is declared as constant and in RO data section.

This PR fixes https://github.com/tensorflow/tflite-micro/issues/597.

The fix is to avoid writing altogether since TFLM fundamentally assumes fixed dimension for tensors.

This corresponds to internal cl/406285832

BUG=https://b/204237320