### PR TITLE
Reenabled xtensa ops for bazel build

### DIFF
--- a/tensorflow/extra_rules.bzl
+++ b/tensorflow/extra_rules.bzl
@@ -9,7 +9,9 @@ def xtensa_fusion_f1_config():
     return "//tensorflow/lite/micro/kernels:xtensa_fusion_f1_default"
 
 def xtensa_hifi_3z_config():
+    """Config setting for all HiFi 3z based cores."""
     return "//tensorflow/lite/micro/kernels:xtensa_hifi_3z_default"
 
 def xtensa_hifi_5_config():
+    """Config setting for all HiFi 5 based cores."""
     return "//tensorflow/lite/micro/kernels:xtensa_hifi_5_default"

--- a/tensorflow/extra_rules.bzl
+++ b/tensorflow/extra_rules.bzl
@@ -4,11 +4,12 @@ def tflm_kernel_friends():
 def tflm_audio_frontend_friends():
     return []
 
-def xtensa_fusion_f1_cpu():
-    return "F1_190305_swupgrade"
+def xtensa_fusion_f1_config():
+    """Config setting for all Fusion F1 based cores."""
+    return "//tensorflow/lite/micro/kernels:xtensa_fusion_f1_default"
 
-def xtensa_hifi_3z_cpu():
-    return "HIFI_190304_swupgrade"
+def xtensa_hifi_3z_config():
+    return "//tensorflow/lite/micro/kernels:xtensa_hifi_3z_default"
 
-def xtensa_hifi_5_cpu():
-    return "AE_HiFi5_LE5_AO_FP_XC"
+def xtensa_hifi_5_config():
+    return "//tensorflow/lite/micro/kernels:xtensa_hifi_5_default"

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -2,9 +2,9 @@ load("//tensorflow/lite/micro:build_def.bzl", "micro_copts", "tflm_kernel_cc_lib
 load(
     "//tensorflow:extra_rules.bzl",
     "tflm_kernel_friends",
-    "xtensa_fusion_f1_cpu",
-    "xtensa_hifi_3z_cpu",
-    "xtensa_hifi_5_cpu",
+    "xtensa_fusion_f1_config",
+    "xtensa_hifi_3z_config",
+    "xtensa_hifi_5_config",
 )
 
 package(
@@ -238,20 +238,20 @@ tflm_kernel_cc_library(
         "sub.h",
         "svdf.h",
     ] + select({
-        ":xtensa_fusion_f1": glob(["xtensa/**/*.h"]),
-        ":xtensa_hifi_3z": glob(["xtensa/**/*.h"]),
-        ":xtensa_hifi_5": glob(["xtensa/**/*.h"]),
+        xtensa_fusion_f1_config(): glob(["xtensa/**/*.h"]),
+        xtensa_hifi_3z_config(): glob(["xtensa/**/*.h"]),
+        xtensa_hifi_5_config(): glob(["xtensa/**/*.h"]),
         "//conditions:default": [],
     }),
     accelerated_srcs = {
-        ":xtensa_fusion_f1": glob(["xtensa/**/*.cc"]),
-        ":xtensa_hifi_3z": glob(["xtensa/**/*.cc"]),
-        ":xtensa_hifi_5": glob(["xtensa/**/*.cc"]),
+        xtensa_fusion_f1_config(): glob(["xtensa/**/*.cc"]),
+        xtensa_hifi_3z_config(): glob(["xtensa/**/*.cc"]),
+        xtensa_hifi_5_config(): glob(["xtensa/**/*.cc"]),
     },
     copts = micro_copts() + select({
-        ":xtensa_fusion_f1": HIFI4_COPTS,
-        ":xtensa_hifi_3z": HIFI4_COPTS,
-        ":xtensa_hifi_5": HIFI5_COPTS,
+        xtensa_fusion_f1_config(): HIFI4_COPTS,
+        xtensa_hifi_3z_config(): HIFI4_COPTS,
+        xtensa_hifi_5_config(): HIFI5_COPTS,
         "//conditions:default": [],
     }),
     visibility = [
@@ -280,11 +280,9 @@ tflm_kernel_cc_library(
         "//tensorflow/lite/schema:schema_fbs",
         "@flatbuffers//:runtime_cc",
     ] + select({
-        # Temporarily comment out these dependencies while sync is resolved.
-        # See http://cl/400799461 for additional context.
-        # ":xtensa_fusion_f1": ["//third_party/xtensa/nnlib_hifi4:nnlib_hifi4_lib"],
-        # ":xtensa_hifi_3z": ["//third_party/xtensa/nnlib_hifi4:nnlib_hifi4_lib"],
-        # ":xtensa_hifi_5": ["//third_party/xtensa/nnlib_hifi5:nnlib_hifi5_lib"],
+        xtensa_fusion_f1_config(): ["//third_party/xtensa/nnlib_hifi4:nnlib_hifi4_lib"],
+        xtensa_hifi_3z_config(): ["//third_party/xtensa/nnlib_hifi4:nnlib_hifi4_lib"],
+        xtensa_hifi_5_config(): ["//third_party/xtensa/nnlib_hifi5:nnlib_hifi5_lib"],
         "//conditions:default": [],
     }),
 )
@@ -1219,22 +1217,22 @@ cc_test(
 ####################################
 
 config_setting(
-    name = "xtensa_fusion_f1",
+    name = "xtensa_fusion_f1_default",
     values = {
-        "cpu": xtensa_fusion_f1_cpu(),
+        "cpu": "F1_190305_swupgrade",
     },
 )
 
 config_setting(
-    name = "xtensa_hifi_3z",
+    name = "xtensa_hifi_3z_default",
     values = {
-        "cpu": xtensa_hifi_3z_cpu(),
+        "cpu": "HIFI_190304_swupgrade",
     },
 )
 
 config_setting(
-    name = "xtensa_hifi_5",
+    name = "xtensa_hifi_5_default",
     values = {
-        "cpu": xtensa_hifi_5_cpu(),
+        "cpu": "AE_HiFi5_LE5_AO_FP_XC",
     },
 )


### PR DESCRIPTION
Modified the `config_setting` to be more extensible to more complex selects outside of CPU type.

BUG=194200306