### PR TITLE
Updated build badge for Espressif chipsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ additional documentation.
 Platform      |    Status     |
 -----------     | --------------|
 Arduino         | [![Arduino](https://github.com/tensorflow/tflite-micro-arduino-examples/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/tensorflow/tflite-micro-arduino-examples/actions/workflows/ci.yml) [![Antmicro](https://github.com/antmicro/tensorflow-arduino-examples/actions/workflows/test_examples.yml/badge.svg)](https://github.com/antmicro/tensorflow-arduino-examples/actions/workflows/test_examples.yml) |
-ESP32           | [![ESP32](https://github.com/tensorflow/tflite-micro/actions/workflows/esp32.yml/badge.svg)](https://github.com/tensorflow/tflite-micro/actions/workflows/esp32.yml) |
+ESP32           | [![ESP32](https://github.com/espressif/tflite-micro-esp-examples/actions/workflows/build.yml/badge.svg)](https://github.com/espressif/tflite-micro-esp-examples/actions/workflows/build.yml) |
 Sparkfun Edge   | [![Sparkfun Edge](https://github.com/advaitjain/tflite-micro-sparkfun-edge-examples/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/advaitjain/tflite-micro-sparkfun-edge-examples/actions/workflows/ci.yml)
 
 


### PR DESCRIPTION
Updated build badge to repo hosting examples for Espressif chipsets:
https://github.com/espressif/tflite-micro-esp-examples

BUG=#407