### PR TITLE
Make code format check work again (and fix some formatting errors).

### DIFF
--- a/tensorflow/lite/micro/integration_tests/seanet/conv/integration_tests.cc
+++ b/tensorflow/lite/micro/integration_tests/seanet/conv/integration_tests.cc
@@ -133,63 +133,73 @@ void RunModel(const uint8_t* model, const int16_t* input,
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(conv0_test) {
-  tflite::micro::RunModel(
-      g_conv0_model_data, g_conv0_input_int16_test_data, g_conv0_input_int16_test_data_size,
-      g_conv0_golden_int16_test_data, g_conv0_golden_int16_test_data_size, "conv0 test");
+  tflite::micro::RunModel(g_conv0_model_data, g_conv0_input_int16_test_data,
+                          g_conv0_input_int16_test_data_size,
+                          g_conv0_golden_int16_test_data,
+                          g_conv0_golden_int16_test_data_size, "conv0 test");
 }
 
 TF_LITE_MICRO_TEST(conv1_test) {
-  tflite::micro::RunModel(
-      g_conv1_model_data, g_conv1_input_int16_test_data, g_conv1_input_int16_test_data_size,
-      g_conv1_golden_int16_test_data, g_conv1_golden_int16_test_data_size, "conv1 test");
+  tflite::micro::RunModel(g_conv1_model_data, g_conv1_input_int16_test_data,
+                          g_conv1_input_int16_test_data_size,
+                          g_conv1_golden_int16_test_data,
+                          g_conv1_golden_int16_test_data_size, "conv1 test");
 }
 
 TF_LITE_MICRO_TEST(conv2_test) {
-  tflite::micro::RunModel(
-      g_conv2_model_data, g_conv2_input_int16_test_data, g_conv2_input_int16_test_data_size,
-      g_conv2_golden_int16_test_data, g_conv2_golden_int16_test_data_size, "conv2 test");
+  tflite::micro::RunModel(g_conv2_model_data, g_conv2_input_int16_test_data,
+                          g_conv2_input_int16_test_data_size,
+                          g_conv2_golden_int16_test_data,
+                          g_conv2_golden_int16_test_data_size, "conv2 test");
 }
 
 TF_LITE_MICRO_TEST(conv3_test) {
-  tflite::micro::RunModel(
-      g_conv3_model_data, g_conv3_input_int16_test_data, g_conv3_input_int16_test_data_size,
-      g_conv3_golden_int16_test_data, g_conv3_golden_int16_test_data_size, "conv3 test");
+  tflite::micro::RunModel(g_conv3_model_data, g_conv3_input_int16_test_data,
+                          g_conv3_input_int16_test_data_size,
+                          g_conv3_golden_int16_test_data,
+                          g_conv3_golden_int16_test_data_size, "conv3 test");
 }
 
 TF_LITE_MICRO_TEST(conv4_test) {
-  tflite::micro::RunModel(
-      g_conv4_model_data, g_conv4_input_int16_test_data, g_conv4_input_int16_test_data_size,
-      g_conv4_golden_int16_test_data, g_conv4_golden_int16_test_data_size, "conv4 test");
+  tflite::micro::RunModel(g_conv4_model_data, g_conv4_input_int16_test_data,
+                          g_conv4_input_int16_test_data_size,
+                          g_conv4_golden_int16_test_data,
+                          g_conv4_golden_int16_test_data_size, "conv4 test");
 }
 
 TF_LITE_MICRO_TEST(conv5_test) {
-  tflite::micro::RunModel(
-      g_conv5_model_data, g_conv5_input_int16_test_data, g_conv5_input_int16_test_data_size,
-      g_conv5_golden_int16_test_data, g_conv5_golden_int16_test_data_size, "conv5 test");
+  tflite::micro::RunModel(g_conv5_model_data, g_conv5_input_int16_test_data,
+                          g_conv5_input_int16_test_data_size,
+                          g_conv5_golden_int16_test_data,
+                          g_conv5_golden_int16_test_data_size, "conv5 test");
 }
 
 TF_LITE_MICRO_TEST(conv6_test) {
-  tflite::micro::RunModel(
-      g_conv6_model_data, g_conv6_input_int16_test_data, g_conv6_input_int16_test_data_size,
-      g_conv6_golden_int16_test_data, g_conv6_golden_int16_test_data_size, "conv6 test");
+  tflite::micro::RunModel(g_conv6_model_data, g_conv6_input_int16_test_data,
+                          g_conv6_input_int16_test_data_size,
+                          g_conv6_golden_int16_test_data,
+                          g_conv6_golden_int16_test_data_size, "conv6 test");
 }
 
 TF_LITE_MICRO_TEST(conv7_test) {
-  tflite::micro::RunModel(
-      g_conv7_model_data, g_conv7_input_int16_test_data, g_conv7_input_int16_test_data_size,
-      g_conv7_golden_int16_test_data, g_conv7_golden_int16_test_data_size, "conv7 test");
+  tflite::micro::RunModel(g_conv7_model_data, g_conv7_input_int16_test_data,
+                          g_conv7_input_int16_test_data_size,
+                          g_conv7_golden_int16_test_data,
+                          g_conv7_golden_int16_test_data_size, "conv7 test");
 }
 
 TF_LITE_MICRO_TEST(conv8_test) {
-  tflite::micro::RunModel(
-      g_conv8_model_data, g_conv8_input_int16_test_data, g_conv8_input_int16_test_data_size,
-      g_conv8_golden_int16_test_data, g_conv8_golden_int16_test_data_size, "conv8 test");
+  tflite::micro::RunModel(g_conv8_model_data, g_conv8_input_int16_test_data,
+                          g_conv8_input_int16_test_data_size,
+                          g_conv8_golden_int16_test_data,
+                          g_conv8_golden_int16_test_data_size, "conv8 test");
 }
 
 TF_LITE_MICRO_TEST(conv9_test) {
-  tflite::micro::RunModel(
-      g_conv9_model_data, g_conv9_input_int16_test_data, g_conv9_input_int16_test_data_size,
-      g_conv9_golden_int16_test_data, g_conv9_golden_int16_test_data_size, "conv9 test");
+  tflite::micro::RunModel(g_conv9_model_data, g_conv9_input_int16_test_data,
+                          g_conv9_input_int16_test_data_size,
+                          g_conv9_golden_int16_test_data,
+                          g_conv9_golden_int16_test_data_size, "conv9 test");
 }
 
 TF_LITE_MICRO_TEST(conv10_test) {

--- a/tensorflow/lite/micro/tools/ci_build/test_code_style.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_code_style.sh
@@ -78,7 +78,7 @@ fi
 
 tensorflow/lite/micro/tools/make/downloads/pigweed/pw_presubmit/py/pw_presubmit/format_code.py \
   ${FIX_FORMAT_OPTIONS} \
-  -e .github \
+  -e "\.github" \
   -e third_party/hexagon \
   -e third_party/xtensa \
   -e ci \


### PR DESCRIPTION
Prior to this change, none of the files were getting tested.

i.e. the following command:
```
tensorflow/lite/micro/tools/ci_build/test_code_style.sh
```

Would have the output:
```
Formatting files in the tflite_micro repo that do not match 16 patterns (.github, third_party/hexagon, third_party/xtensa, ci, c/common.c, core/api/error_reporter.cc, kernels/internal/reference/integer_ops/, kernels/internal/reference/reference_ops.h, kernels/internal/types.h, lite/python, lite/tools, experimental, schema/schema_generated.h, schema/schema_utils.h, \.inc, \.md)
Checking formatting for 0 files
```

With this change, the output is now:
```
Formatting files in the tflite_micro repo that do not match 16 patterns (\.github, third_party/hexagon, third_party/xtensa, ci, c/common.c, core/api/error_reporter.cc, kernels/internal/reference/integer_ops/, kernels/internal/reference/reference_ops.h, kernels/internal/types.h, lite/python, lite/tools, experimental, schema/schema_generated.h, schema/schema_utils.h, \.inc, \.md)
Checking formatting for 773 files
./            7 files
tensorflow/   752 files (344 .cc, 186 .h, 44 .csv, 178 other)
third_party/  14 files (5 .bzl, 2 .bazel, 1 .system, 6 other)
```

This regression was likely introduced with #629.

 * #629 was manually patched to exclude lite/python and a few additional folders from the Python style check.
 * For some (currently unknown) reason, adding `-e .github` meant that all the paths were getting excluded.
 * `-e "\.github"` fixes the issue.

BUG=fix regression in CI checks.
