### PR TITLE
Add license statement to integration tests BUILD.

### DIFF
--- a/tensorflow/lite/micro/integration_tests/BUILD
+++ b/tensorflow/lite/micro/integration_tests/BUILD
@@ -1,5 +1,9 @@
 load("@tflm_pip_deps//:requirements.bzl", "requirement")
 
+package(
+    licenses = ["notice"],
+)
+
 py_binary(
     name = "generate_per_layer_tests",
     srcs = ["generate_per_layer_tests.py"],


### PR DESCRIPTION
Mirrors internal change to prevent presubmit failure.

BUG=http://b/205758944