### PR TITLE
Remove support for big-endian in the TFLM inference code.

### DIFF
--- a/tensorflow/lite/micro/BUILD
+++ b/tensorflow/lite/micro/BUILD
@@ -116,6 +116,7 @@ cc_library(
     srcs = ["flatbuffer_utils.cc"],
     hdrs = ["flatbuffer_utils.h"],
     deps = [
+        "//tensorflow/lite/c:common",
         "//tensorflow/lite/schema:schema_fbs",
         "@flatbuffers//:runtime_cc",
     ],

--- a/tensorflow/lite/micro/flatbuffer_utils.cc
+++ b/tensorflow/lite/micro/flatbuffer_utils.cc
@@ -61,4 +61,24 @@ uint32_t NumSubgraphOperators(const Model* model, int subgraph_idx) {
   return NumSubgraphOperators(subgraph);
 }
 
+TfLiteIntArray* FlatBufferVectorToTfLiteTypeArray(
+    const flatbuffers::Vector<int32_t>* flatbuffer_array) {
+  // On little-endian machines, TfLiteIntArray happens to have the same memory
+  // layout as flatbuffers:Vector<int32_t>, so we can reinterpret_cast the
+  // flatbuffer vector and avoid a copy and malloc.
+  // TODO(b/188459715): audit this usage of const_cast.
+  return const_cast<TfLiteIntArray*>(
+      reinterpret_cast<const TfLiteIntArray*>(flatbuffer_array));
+}
+
+TfLiteFloatArray* FlatBufferVectorToTfLiteTypeArray(
+    const flatbuffers::Vector<float>* flatbuffer_array) {
+  // On little-endian machines, TfLiteFloatArray happens to have the same memory
+  // layout as flatbuffers:Vector<float>, so we can reinterpret_cast the
+  // flatbuffer vector and avoid a copy and malloc.
+  // TODO(b/188459715): audit this usage of const_cast.
+  return const_cast<TfLiteFloatArray*>(
+      reinterpret_cast<const TfLiteFloatArray*>(flatbuffer_array));
+}
+
 }  // namespace tflite

--- a/tensorflow/lite/micro/flatbuffer_utils.h
+++ b/tensorflow/lite/micro/flatbuffer_utils.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/flexbuffers.h"
+#include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/schema/schema_generated.h"
 
 namespace tflite {
@@ -50,6 +51,14 @@ class FlexbufferWrapper : public flexbuffers::Vector {
 // Return the number of operators in a subgraph tflite
 uint32_t NumSubgraphOperators(const SubGraph* subgraph);
 uint32_t NumSubgraphOperators(const Model* model, int subgraph_idx);
+
+// Converts a flatbuffer array to a TfLiteArray.
+// TODO(b/188459715): These function convert a const input to a non-const via a
+// const_cast. It is unclear exactly why this is required.
+TfLiteIntArray* FlatBufferVectorToTfLiteTypeArray(
+    const flatbuffers::Vector<int32_t>* flatbuffer_array);
+TfLiteFloatArray* FlatBufferVectorToTfLiteTypeArray(
+    const flatbuffers::Vector<float>* flatbuffer_array);
 
 }  // namespace tflite
 

--- a/tensorflow/lite/micro/micro_allocator.h
+++ b/tensorflow/lite/micro/micro_allocator.h
@@ -209,12 +209,6 @@ class MicroAllocator {
   // `FinishModelAllocation`. Otherwise, it will return 0.
   size_t used_bytes() const;
 
-  // Converts a flatbuffer int32_t array to a TfLiteIntArray, accounting for
-  // endiannes.
-  TfLiteStatus FlatBufferVectorToTfLiteTypeArray(
-      const flatbuffers::Vector<int32_t>* flatbuffer_array,
-      TfLiteIntArray** result);
-
   BuiltinDataAllocator* GetBuiltinDataAllocator();
 
  protected:

--- a/tensorflow/lite/micro/micro_interpreter.cc
+++ b/tensorflow/lite/micro/micro_interpreter.cc
@@ -162,13 +162,10 @@ TfLiteStatus MicroInterpreter::PrepareNodeAndRegistrationDataFromFlatbuffer() {
                                      (void**)(&builtin_data)));
       }
 
-      TfLiteIntArray* inputs_array;
-      TF_LITE_ENSURE_STATUS(allocator_.FlatBufferVectorToTfLiteTypeArray(
-          op->inputs(), &inputs_array));
-
-      TfLiteIntArray* outputs_array;
-      TF_LITE_ENSURE_STATUS(allocator_.FlatBufferVectorToTfLiteTypeArray(
-          op->outputs(), &outputs_array));
+      TfLiteIntArray* inputs_array =
+          FlatBufferVectorToTfLiteTypeArray(op->inputs());
+      TfLiteIntArray* outputs_array =
+          FlatBufferVectorToTfLiteTypeArray(op->outputs());
 
       TfLiteNode* node = &(
           graph_.GetAllocations()[subgraph_idx].node_and_registrations[i].node);
@@ -180,10 +177,8 @@ TfLiteStatus MicroInterpreter::PrepareNodeAndRegistrationDataFromFlatbuffer() {
       node->custom_initial_data_size = custom_data_size;
 
       if (op->intermediates() && (op->intermediates()->size() > 0)) {
-        TfLiteIntArray* intermediates_array;
-        TF_LITE_ENSURE_STATUS(allocator_.FlatBufferVectorToTfLiteTypeArray(
-            op->intermediates(), &intermediates_array));
-        node->intermediates = intermediates_array;
+        node->intermediates =
+            FlatBufferVectorToTfLiteTypeArray(op->intermediates());
       }
     }
   }


### PR DESCRIPTION
Moving forward, we will require that the endianness of the flatbuffer is the same as the endianness of the system that TFLM is being used for inference on.

BUG=Fixes #304 and http://b/194224890
