### PR TITLE
Add Support for building Micropython using project generator

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
@@ -17,35 +17,35 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR=${SCRIPT_DIR}/../../../../..
+ROOT_DIR="${SCRIPT_DIR}/../../../../.."
 cd "${ROOT_DIR}"
 
 source tensorflow/lite/micro/tools/ci_build/helper_functions.sh
 
 # First, we test that create_tflm_tree without any examples can be used to build a
 # static library.
-TEST_OUTPUT_DIR=$(mktemp -d)
+TEST_OUTPUT_DIR="$(mktemp -d)"
 
 readable_run \
   python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py \
-  ${TEST_OUTPUT_DIR}
+  "${TEST_OUTPUT_DIR}"
 
-readable_run cp tensorflow/lite/micro/tools/project_generation/Makefile ${TEST_OUTPUT_DIR}
-pushd ${TEST_OUTPUT_DIR} > /dev/null
+readable_run cp tensorflow/lite/micro/tools/project_generation/Makefile "${TEST_OUTPUT_DIR}"
+pushd "${TEST_OUTPUT_DIR}" > /dev/null
 readable_run make -j8 libtflm
 popd > /dev/null
 
-rm -rf ${TEST_OUTPUT_DIR}
+rm -rf "${TEST_OUTPUT_DIR}"
 
 # Next, we test that create_tflm_tree can be used to build example binaries.
 EXAMPLES="-e hello_world -e magic_wand -e micro_speech -e person_detection"
 
-TEST_OUTPUT_DIR=$(mktemp -d)
+TEST_OUTPUT_DIR="$(mktemp -d)"
 
 readable_run \
   python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py \
-  ${TEST_OUTPUT_DIR} \
-  ${EXAMPLES}
+  "${TEST_OUTPUT_DIR}" \
+  "${EXAMPLES}"
 
 # Confirm that print_src_files and print_dest_files output valid paths (and
 # nothing else).
@@ -54,51 +54,52 @@ FILES="$(python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree
            ${TEST_OUTPUT_DIR} \
            --print_src_files --print_dest_files --no_copy)"
 
-readable_run ls ${FILES} > /dev/null
+readable_run ls "${FILES}" > /dev/null
 
 # Next, make sure that the output tree has all the files needed buld the
 # examples.
-readable_run cp tensorflow/lite/micro/tools/project_generation/Makefile ${TEST_OUTPUT_DIR}
-pushd ${TEST_OUTPUT_DIR} > /dev/null
+readable_run cp tensorflow/lite/micro/tools/project_generation/Makefile "${TEST_OUTPUT_DIR}"
+pushd "${TEST_OUTPUT_DIR}" > /dev/null
 readable_run make -j8 examples
 popd > /dev/null
 
-rm -rf ${TEST_OUTPUT_DIR}
+rm -rf "${TEST_OUTPUT_DIR}"
 
 # Remove existing state prior to testing project generation for cortex-m target.
 make -f tensorflow/lite/micro/tools/make/Makefile clean clean_downloads
 
-TEST_OUTPUT_DIR_CMSIS=$(mktemp -d)
+TEST_OUTPUT_DIR_CMSIS="$(mktemp -d)"
 
 readable_run \
   python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py \
   --makefile_options="TARGET=cortex_m_generic OPTIMIZED_KERNEL_DIR=cmsis_nn TARGET_ARCH=project_generation" \
-  ${TEST_OUTPUT_DIR_CMSIS} \
-  ${EXAMPLES}
+  "${TEST_OUTPUT_DIR_CMSIS}" \
+  "${EXAMPLES}"
 
-readable_run cp tensorflow/lite/micro/tools/project_generation/Makefile ${TEST_OUTPUT_DIR_CMSIS}
+readable_run \
+  cp tensorflow/lite/micro/tools/project_generation/Makefile "${TEST_OUTPUT_DIR_CMSIS}"
 
-pushd ${TEST_OUTPUT_DIR_CMSIS} > /dev/null
+pushd "${TEST_OUTPUT_DIR_CMSIS}" > /dev/null
 
-PATH=${PATH}:${ROOT_DIR}/tensorflow/lite/micro/tools/make/downloads/gcc_embedded/bin \
+PATH="${PATH}:${ROOT_DIR}/tensorflow/lite/micro/tools/make/downloads/gcc_embedded/bin" \
   readable_run \
   make -j8 BUILD_TYPE=cmsis_nn
 
 popd > /dev/null
 
-rm -rf ${TEST_OUTPUT_DIR_CMSIS}
+rm -rf "${TEST_OUTPUT_DIR_CMSIS}"
 
 # Test that C++ files are renamed to .cpp
 
-TEST_OUTPUT_DIR_RENAME_CC=$(mktemp -d)
+TEST_OUTPUT_DIR_RENAME_CC="$(mktemp -d)"
 
 readable_run \
   python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py \
-  --rename-cc-to-cpp \
-  ${TEST_OUTPUT_DIR_RENAME_CC}
+  --rename_cc_to_cpp \
+  "${TEST_OUTPUT_DIR_RENAME_CC}"
 
-CC_FILES=$(find ${TEST_OUTPUT_DIR_RENAME_CC} -name "*.cc" | head)
-CPP_FILES=$(find ${TEST_OUTPUT_DIR_RENAME_CC} -name "*.cpp" | head)
+CC_FILES="$(find ${TEST_OUTPUT_DIR_RENAME_CC} -name "*.cc" | head)"
+CPP_FILES="$(find ${TEST_OUTPUT_DIR_RENAME_CC} -name "*.cpp" | head)"
 
 if test -n "${CC_FILES}"; then
   echo "Expected no .cc file to exist"

--- a/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
@@ -54,7 +54,7 @@ FILES="$(python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree
            ${TEST_OUTPUT_DIR} \
            --print_src_files --print_dest_files --no_copy)"
 
-readable_run ls "${FILES}" > /dev/null
+readable_run ls ${FILES} > /dev/null
 
 # Next, make sure that the output tree has all the files needed buld the
 # examples.

--- a/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
@@ -86,4 +86,28 @@ PATH=${PATH}:${ROOT_DIR}/tensorflow/lite/micro/tools/make/downloads/gcc_embedded
 
 popd > /dev/null
 
-#rm -rf ${TEST_OUTPUT_DIR_CMSIS}
+rm -rf ${TEST_OUTPUT_DIR_CMSIS}
+
+# Test that C++ files are renamed to .cpp
+
+TEST_OUTPUT_DIR_RENAME_CC=$(mktemp -d)
+
+readable_run \
+  python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py \
+  --rename-cc-to-cpp \
+  ${TEST_OUTPUT_DIR_RENAME_CC}
+
+CC_FILES=$(find ${TEST_OUTPUT_DIR_RENAME_CC} -name "*.cc" | head)
+CPP_FILES=$(find ${TEST_OUTPUT_DIR_RENAME_CC} -name "*.cpp" | head)
+
+if test -n "${CC_FILES}"; then
+  echo "Expected no .cc file to exist"
+  echo "${CC_FILES}"
+  exit 1;
+fi
+
+if test -z "${CPP_FILES}"; then
+  echo "Expected a .cpp file to exist"
+  echo "${CPP_FILES}}}"
+  exit 1;
+fi

--- a/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
@@ -45,7 +45,7 @@ TEST_OUTPUT_DIR="$(mktemp -d)"
 readable_run \
   python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py \
   "${TEST_OUTPUT_DIR}" \
-  "${EXAMPLES}"
+  ${EXAMPLES}
 
 # Confirm that print_src_files and print_dest_files output valid paths (and
 # nothing else).
@@ -74,7 +74,7 @@ readable_run \
   python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py \
   --makefile_options="TARGET=cortex_m_generic OPTIMIZED_KERNEL_DIR=cmsis_nn TARGET_ARCH=project_generation" \
   "${TEST_OUTPUT_DIR_CMSIS}" \
-  "${EXAMPLES}"
+  ${EXAMPLES}
 
 readable_run \
   cp tensorflow/lite/micro/tools/project_generation/Makefile "${TEST_OUTPUT_DIR_CMSIS}"

--- a/tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py
+++ b/tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py
@@ -36,7 +36,6 @@ import re
 import shutil
 import subprocess
 
-
 def _get_dirs(file_list):
   dirs = set()
   for filepath in file_list:
@@ -99,7 +98,6 @@ def _get_src_and_dest_files(prefix_dir, makefile_options):
   all_src_files = tflm_src_files + third_party_srcs
   all_dest_files = tflm_dest_files + third_party_dests
   return all_src_files, all_dest_files
-
 
 def _copy(src_files, dest_files):
   for dirname in _get_dirs(dest_files):
@@ -179,6 +177,13 @@ def _create_examples_tree(prefix_dir, examples_list):
         # in-place find and replace.
         print(line, end="")
 
+def _rename_cc_to_cpp (output_dir):
+  for path, subdirs, files in os.walk(output_dir):
+    for name in files:
+      if name.endswith (".cc"):
+        baseName, extension = os.path.splitext(name)
+        os.rename (path + '/' + name, path + '/' + baseName + ".cpp")
+
 
 def main():
   parser = argparse.ArgumentParser(
@@ -206,6 +211,9 @@ def main():
                       action="append",
                       help="Examples to add to the output tree. For example: "
                       "-e hello_world -e micro_speech")
+  parser.add_argument("--rename-cc-to-cpp",
+                      action="store_true",
+                      help="Rename all .cc files to .cpp in the destination files location.")
   args = parser.parse_args()
 
   makefile_options = args.makefile_options
@@ -240,6 +248,8 @@ def main():
   if args.examples is not None:
     _create_examples_tree(args.output_dir, args.examples)
 
+  if args.rename_cc_to_cpp:
+    _rename_cc_to_cpp(args.output_dir)
 
 if __name__ == "__main__":
   main()

--- a/tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py
+++ b/tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py
@@ -36,6 +36,7 @@ import re
 import shutil
 import subprocess
 
+
 def _get_dirs(file_list):
   dirs = set()
   for filepath in file_list:
@@ -98,6 +99,7 @@ def _get_src_and_dest_files(prefix_dir, makefile_options):
   all_src_files = tflm_src_files + third_party_srcs
   all_dest_files = tflm_dest_files + third_party_dests
   return all_src_files, all_dest_files
+
 
 def _copy(src_files, dest_files):
   for dirname in _get_dirs(dest_files):
@@ -177,12 +179,13 @@ def _create_examples_tree(prefix_dir, examples_list):
         # in-place find and replace.
         print(line, end="")
 
-def _rename_cc_to_cpp (output_dir):
-  for path, subdirs, files in os.walk(output_dir):
+
+def _rename_cc_to_cpp(output_dir):
+  for path, _, files in os.walk(output_dir):
     for name in files:
-      if name.endswith (".cc"):
-        baseName, extension = os.path.splitext(name)
-        os.rename (path + '/' + name, path + '/' + baseName + ".cpp")
+      if name.endswith(".cc"):
+        base_name_with_path = os.path.join(path, os.path.splitext(name)[0])
+        os.rename(base_name_with_path + ".cc", base_name_with_path + ".cpp")
 
 
 def main():
@@ -211,9 +214,10 @@ def main():
                       action="append",
                       help="Examples to add to the output tree. For example: "
                       "-e hello_world -e micro_speech")
-  parser.add_argument("--rename-cc-to-cpp",
-                      action="store_true",
-                      help="Rename all .cc files to .cpp in the destination files location.")
+  parser.add_argument(
+      "--rename_cc_to_cpp",
+      action="store_true",
+      help="Rename all .cc files to .cpp in the destination files location.")
   args = parser.parse_args()
 
   makefile_options = args.makefile_options
@@ -250,6 +254,7 @@ def main():
 
   if args.rename_cc_to_cpp:
     _rename_cc_to_cpp(args.output_dir)
+
 
 if __name__ == "__main__":
   main()

--- a/third_party/xtensa/examples/micro_speech_lstm/Makefile.inc
+++ b/third_party/xtensa/examples/micro_speech_lstm/Makefile.inc
@@ -22,7 +22,8 @@ ifeq ($(OPTIMIZED_KERNEL_DIR), xtensa)
    third_party/xtensa/examples/micro_speech_lstm/no_micro_features_data.h \
    third_party/xtensa/examples/micro_speech_lstm/yes_micro_features_data.h
 
-   # Tests loading and running a speech model.
-   $(eval $(call microlite_test,micro_speech_lstm_test,\
-   $(MICRO_SPEECH_LSTM_TEST_SRCS),$(MICRO_SPEECH_LSTM_HDRS),$(MICRO_SPEECH_LSTM_GENERATOR_INPUTS)))
+   # TODO(#802): Disbaling test that takes a long time to run.
+   ## Tests loading and running a speech model.
+   #$(eval $(call microlite_test,micro_speech_lstm_test,\
+   #$(MICRO_SPEECH_LSTM_TEST_SRCS),$(MICRO_SPEECH_LSTM_HDRS),$(MICRO_SPEECH_LSTM_GENERATOR_INPUTS)))
 endif


### PR DESCRIPTION
Add a new option **--rename-cc-to-cpp** to the create_tflm_tree.py script that is needed for building tflm within a Micropython build.

This is upstreaming of some changes I made to switch my Microlite Micropython firmware over to the new generator files approach from building separately and linking the static library in at firrmware build time.

My microlite Micropython module is built using the USER_C_MODULE micropython extension point so I am not able to easily change the core makefiles to support .cc files instead or in addition to .cpp files.

Since tflm has switched to generating the project files for incorporation into projects adding this switch on the tflm side makes sense. 

@advaitjain made some style changes to conform to the Google Python style as well as the shell style (https://google.github.io/styleguide/shellguide.html#s5.7-quoting)

BUG=#702