### PR TITLE
Fix Unused Operator Output Buffer Sharing

### DIFF
--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -250,8 +250,6 @@ TfLiteStatus CreatePlan(ErrorReporter* error_reporter,
       size_t aligned_bytes_required =
           AlignSizeUp(current->bytes, MicroArenaBufferAlignment());
       if (current->offline_offset == kOnlinePlannedBuffer) {
-        printf("tensor %d first created %d last used %d\n", (int)i,
-               current->first_created, current->last_used);
         TF_LITE_ENSURE_STATUS(
             planner->AddBuffer(error_reporter, aligned_bytes_required,
                                current->first_created, current->last_used));

--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -178,6 +178,7 @@ TfLiteStatus AllocationInfoBuilder::AddTensors(const SubGraph* subgraph,
       if ((current->first_created == -1) || (current->first_created > i)) {
         current->first_created = i;
       }
+      // Since operator outputs are written to, they must be marked as used.
       if ((current->last_used == -1) || (current->last_used < i)) {
         current->last_used = i;
       }

--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -247,9 +247,15 @@ TfLiteStatus CreatePlan(ErrorReporter* error_reporter,
       size_t aligned_bytes_required =
           AlignSizeUp(current->bytes, MicroArenaBufferAlignment());
       if (current->offline_offset == kOnlinePlannedBuffer) {
+        // Ensure unused operator outputs do not overlap other buffers used in
+        // that operator.
+        int last_used = current->last_used;
+        if (last_used == -1) {
+          last_used = current->first_created;
+        }
         TF_LITE_ENSURE_STATUS(
             planner->AddBuffer(error_reporter, aligned_bytes_required,
-                               current->first_created, current->last_used));
+                               current->first_created, last_used));
       } else {
         TF_LITE_ENSURE_STATUS(planner->AddBuffer(
             error_reporter, aligned_bytes_required, current->first_created,

--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -178,6 +178,9 @@ TfLiteStatus AllocationInfoBuilder::AddTensors(const SubGraph* subgraph,
       if ((current->first_created == -1) || (current->first_created > i)) {
         current->first_created = i;
       }
+      if ((current->last_used == -1) || (current->last_used < i)) {
+        current->last_used = i;
+      }
     }
   }
   return kTfLiteOk;
@@ -247,15 +250,11 @@ TfLiteStatus CreatePlan(ErrorReporter* error_reporter,
       size_t aligned_bytes_required =
           AlignSizeUp(current->bytes, MicroArenaBufferAlignment());
       if (current->offline_offset == kOnlinePlannedBuffer) {
-        // Ensure unused operator outputs do not overlap other buffers used in
-        // that operator.
-        int last_used = current->last_used;
-        if (last_used == -1) {
-          last_used = current->first_created;
-        }
+        printf("tensor %d first created %d last used %d\n", (int)i,
+               current->first_created, current->last_used);
         TF_LITE_ENSURE_STATUS(
             planner->AddBuffer(error_reporter, aligned_bytes_required,
-                               current->first_created, last_used));
+                               current->first_created, current->last_used));
       } else {
         TF_LITE_ENSURE_STATUS(planner->AddBuffer(
             error_reporter, aligned_bytes_required, current->first_created,

--- a/tensorflow/lite/micro/test_helpers.h
+++ b/tensorflow/lite/micro/test_helpers.h
@@ -141,6 +141,10 @@ const Model* GetModelWithOfflinePlanning(int num_tensors,
 // output.
 const Model* GetModelWithUnusedInputs();
 
+// Returns a flatbuffer with a single operator, zero inputs and two outputs
+// (one unused).
+const Model* GetModelWithUnusedOperatorOutputs();
+
 // Returns a flatbuffer model with `simple_stateful_op`
 const Model* GetSimpleStatefulModel();
 


### PR DESCRIPTION
Handle case where operator outputs are unused, but written to from within the op.

TESTED=Ran various end-to-end tests and verified audio artifacts were gone.

BUG=http://b/205145012#comment15