### PR TITLE
adding mergify config for jobs in ci.yml workflow

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,11 @@
+pull_request_rules:
+  - name: Automatic merge on approval
+    conditions:
+      - check-success=Bazel (presubmit)
+      - check-success=Cortex-M (presubmit)
+      - check-success=Project Generation (presubmit)
+      - check-success=Makefile x86 (presubmit)
+      - label=ci:mergify
+    actions:
+      merge:
+        method: merge

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,4 +8,4 @@ pull_request_rules:
       - label=ci:mergify
     actions:
       merge:
-        method: merge
+        method: squash


### PR DESCRIPTION
Basic mergify config for testing. Only includes the jobs in the ci.yml workflow: Bazel, Cortex-M, Code Style, Project Generation and Makefile x86 (all (presubmit)).

Requires a ci:mergify label on the pr to activate for purposes of testing. Also does not include a requirement for at least one approved review, which is likely something we want doing this in anger. 

BUG=none, evaluating a ci internal change