### PR TITLE
Fix "set but unused" warning when using armclang 6.17

### DIFF
--- a/tensorflow/lite/micro/memory_planner/greedy_memory_planner.cc
+++ b/tensorflow/lite/micro/memory_planner/greedy_memory_planner.cc
@@ -366,7 +366,9 @@ void GreedyMemoryPlanner::PrintMemoryPlan() {
     for (int c = 0; c < kLineWidth; ++c) {
       line[c] = '.';
     }
+#if !defined(TF_LITE_STRIP_ERROR_STRINGS)
     int memory_use = 0;
+#endif
     for (int i = 0; i < buffer_count_; ++i) {
       BufferRequirements* requirements = &requirements_[i];
       if ((t < requirements->first_time_used) ||
@@ -378,7 +380,9 @@ void GreedyMemoryPlanner::PrintMemoryPlan() {
         continue;
       }
       const int size = requirements->size;
+#if !defined(TF_LITE_STRIP_ERROR_STRINGS)
       memory_use += size;
+#endif
       const int line_start = (offset * kLineWidth) / max_size;
       const int line_end = ((offset + size) * kLineWidth) / max_size;
       for (int n = line_start; n < line_end; ++n) {


### PR DESCRIPTION
Compiling with armclang 6.17 and BUILD_TYPE=release causes compilation error.

BUG=Fixes #717 