### PR TITLE
Allow custom cflags on the command line for Xtensa

### DIFF
--- a/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
@@ -68,6 +68,9 @@ endif
 CXXFLAGS += $(PLATFORM_FLAGS)
 CCFLAGS += $(PLATFORM_FLAGS)
 
+CCFLAGS += $(XA_EXTRA_CFLAGS)
+CXXFLAGS += $(XA_EXTRA_CFLAGS)
+
 TEST_SCRIPT := tensorflow/lite/micro/testing/test_xtensa_binary.sh
 
 # TODO(b/158651472): Fix the memory_arena_threshold_test

--- a/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
@@ -11,6 +11,9 @@
 TARGET_ARCH :=
 XTENSA_USE_LIBC :=
 
+# Allow additional flags on the command line for debugging.
+XTENSA_EXTRA_CFLAGS :=
+
 ifndef XTENSA_BASE
   $(error XTENSA_BASE is undefined)
 endif
@@ -68,8 +71,8 @@ endif
 CXXFLAGS += $(PLATFORM_FLAGS)
 CCFLAGS += $(PLATFORM_FLAGS)
 
-CCFLAGS += $(XA_EXTRA_CFLAGS)
-CXXFLAGS += $(XA_EXTRA_CFLAGS)
+CCFLAGS += $(XTENSA_EXTRA_CFLAGS)
+CXXFLAGS += $(XTENSA_EXTRA_CFLAGS)
 
 TEST_SCRIPT := tensorflow/lite/micro/testing/test_xtensa_binary.sh
 


### PR DESCRIPTION
Adding provision to pass extra c flags for build,
now using these extra c flags for debugging purpose.

BUG=small change