### PR TITLE
adding full mergify queueing

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,11 +1,16 @@
-pull_request_rules:
-  - name: Automatic merge on approval
+queue_rules:
+  - name: default
     conditions:
-      - check-success=Bazel (presubmit)
-      - check-success=Cortex-M (presubmit)
-      - check-success=Project Generation (presubmit)
-      - check-success=Makefile x86 (presubmit)
+      - label=ci:mergify
+    
+   
+pull_request_rules:
+  - name: push to default merge queue
+    conditions:
+      - base=main
       - label=ci:mergify
     actions:
-      merge:
+      queue:
+        name: default
+        require_branch_protection: true
         method: squash


### PR DESCRIPTION
This adds a full queue to the mergify setup. It also removes the various explicit test checks from this file in favor of requiring all branch protection checks to pass, making that the source of truth. 

After we see this work with our own eyes, will add deleting the pr branch after merge function in a later pr.

BUG=add merge queue support.