### PR TITLE
Update HiFi4 nnlib to v2.5.0 from v2.4.1

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/quantize.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/quantize.cc
@@ -133,7 +133,7 @@ TfLiteStatus EvalXtensa(TfLiteContext* context, TfLiteNode* node) {
     int size = ElementCount(*input->dims);
     TF_LITE_ENSURE_EQ(
         context,
-        xa_nn_elm_quantize_asym16s_asym8s(
+        xa_nn_elm_requantize_asym16s_asym8s(
             tflite::micro::GetTensorData<int8_t>(output),
             tflite::micro::GetTensorData<int16_t>(input),
             op_data->input_zero_point, op_data->quantization_params.zero_point,

--- a/tensorflow/lite/micro/tools/make/ext_libs/xa_nnlib_hifi4.patch
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xa_nnlib_hifi4.patch
@@ -1,5 +1,5 @@
 diff --git a/algo/kernels/fc/hifi4/xa_nn_fully_connected.c b/algo/kernels/fc/hifi4/xa_nn_fully_connected.c
-index 26a2b73..b153274 100644
+index 26a2b73..61f0a64 100644
 --- a/algo/kernels/fc/hifi4/xa_nn_fully_connected.c
 +++ b/algo/kernels/fc/hifi4/xa_nn_fully_connected.c
 @@ -298,7 +298,6 @@ WORD32 xa_nn_fully_connected_sym8sxasym8s_asym8s
@@ -20,18 +20,11 @@ index 26a2b73..b153274 100644
  #endif
    /* Basic Parameter checks */
    XA_NNLIB_ARG_CHK_COND((out_depth <= 0), -1);
-@@ -337,5 +337,6 @@ WORD32 xa_nn_fully_connected_sym8sxasym8s_asym8s
-      ,out_shift
-      ,out_zero_bias
-     );
-+
-   return ret;
- }
 diff --git a/algo/kernels/matXvec/hifi4/xa_nn_matXvec_sym8sxasym8s.c b/algo/kernels/matXvec/hifi4/xa_nn_matXvec_sym8sxasym8s.c
-index 14b7d6f..36d6fab 100644
+index df6779e..d92eaa5 100644
 --- a/algo/kernels/matXvec/hifi4/xa_nn_matXvec_sym8sxasym8s.c
 +++ b/algo/kernels/matXvec/hifi4/xa_nn_matXvec_sym8sxasym8s.c
-@@ -510,9 +510,9 @@ WORD32 xa_nn_matXvec_sym8sxasym8s_asym8s(
+@@ -1033,9 +1033,9 @@ WORD32 xa_nn_matXvec_sym8sxasym8s_asym8s(
    XA_NNLIB_ARG_CHK_PTR(p_out, -1);
    XA_NNLIB_ARG_CHK_PTR(p_mat1, -1);
    XA_NNLIB_ARG_CHK_PTR(p_vec1, -1);

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
@@ -47,9 +47,9 @@ if [ ! -d ${DOWNLOADS_DIR} ]; then
 fi
 
 if [[ ${2} == "hifi4" ]]; then
-  LIBRARY_URL="http://github.com/foss-xtensa/nnlib-hifi4/raw/master/archive/xa_nnlib_hifi4_07_27_2021.zip"
+  LIBRARY_URL="http://github.com/foss-xtensa/nnlib-hifi4/raw/master/archive/xa_nnlib_hifi4_11_09_2021.zip"
   LIBRARY_DIRNAME="xa_nnlib_hifi4"
-  LIBRARY_MD5="24b8844f8e0c53c1ed8561b09968bb98"
+  LIBRARY_MD5="fd6445b3d281220e2f584e2adc10165d"
 elif [[ ${2} == "hifi5" ]]; then
   LIBRARY_URL="http://github.com/foss-xtensa/nnlib-hifi5/raw/master/archive/xa_nnlib_hifi5_06_30.zip"
   LIBRARY_DIRNAME="xa_nnlib_hifi5"


### PR DESCRIPTION
Download HiFi4 nnlib from v2.5.0 instead of v2.4.1.

Minor code change is necessary due to an API change. Patches from https://github.com/tensorflow/tflite-micro/pull/711 was also re-generated.

BUG=#758

TESTED=

`docker run --rm -v "$(pwd)":/opt/tflite-micro ghcr.io/tflm-bot/xtensa:0.1 /opt/tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi3z.sh`