### PR TITLE
Enable person_detection_test on stm32f4 + Renode

### DIFF
--- a/tensorflow/lite/micro/examples/person_detection/Makefile.inc
+++ b/tensorflow/lite/micro/examples/person_detection/Makefile.inc
@@ -55,34 +55,19 @@ $(GENERATED_SRCS_DIR)tensorflow/lite/micro/models/person_detect_model_data.h
 include $(wildcard tensorflow/lite/micro/examples/person_detection/*/Makefile.inc)
 
 # Tests loading and running a vision model.
-$(eval $(call microlite_test,person_detection_test_int8,\
+$(eval $(call microlite_test,person_detection_test,\
 $(person_detection_TEST_SRCS),$(person_detection_TEST_HDRS),$(person_detection_GENERATOR_INPUTS)))
 
-# Three conflicting issues here:
-# 1. The image_provider_test fails on Sparkfun Edge we do not have a way to
-#    filter out individual tests within and example.
-# 2. We do not want to completely remove person_detection from the sparkfun_edge
-#    build.
-# 3. We do want to keep as many targets as possible be part of the sparkfun_edge
-#    CI build to avoid getting into similar situations where some parts of the
-#    code are supported on a platform while other parts are not.
-#
-# The current nasty workaround is to explicitly exclude the offending test for
-# the sparkfun_edge target. Note that we are not exluding it for
-# TARGET=apollo3evb becuase that is not part of our CI builds (and the two are
-# basically equivalent).
-ifneq ($(TARGET),sparkfun_edge)
 # Tests the image provider module.
-$(eval $(call microlite_test,image_provider_test_int8,\
+$(eval $(call microlite_test,image_provider_test,\
 $(IMAGE_PROVIDER_TEST_SRCS),$(IMAGE_PROVIDER_TEST_HDRS)))
-endif
 
 # Tests the detection responder module.
-$(eval $(call microlite_test,detection_responder_test_int8,\
+$(eval $(call microlite_test,detection_responder_test,\
 $(DETECTION_RESPONDER_TEST_SRCS),$(DETECTION_RESPONDER_TEST_HDRS)))
 
 # Builds a standalone object recognition binary.
-$(eval $(call microlite_test,person_detection_int8,\
+$(eval $(call microlite_test,person_detection,\
 $(person_detection_SRCS),$(person_detection_HDRS),$(person_detection_GENERATOR_INPUTS)))
 
 # Add sources and headers generated from $(person_detection_GENERATOR_INPUTS).

--- a/tensorflow/lite/micro/testing/robot.resource.txt
+++ b/tensorflow/lite/micro/testing/robot.resource.txt
@@ -16,7 +16,7 @@ Test Binary
     Requires                  ready-platform
     Execute Command           sysbus LoadELF ${BIN}
 
-    Create Terminal Tester    ${UART}  timeout=2
+    Create Terminal Tester    ${UART}  timeout=30
     Start Emulation
 
     Wait For Line On Uart     ${UART_LINE_ON_SUCCESS}

--- a/tensorflow/lite/micro/tools/make/targets/bluepill_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/bluepill_makefile.inc
@@ -75,7 +75,6 @@ MICROLITE_TEST_SRCS := $(filter-out $(EXCLUDED_TESTS), $(MICROLITE_TEST_SRCS))
 EXCLUDED_EXAMPLE_TESTS := \
   tensorflow/lite/micro/examples/magic_wand/Makefile.inc \
   tensorflow/lite/micro/examples/micro_speech/Makefile.inc \
-  tensorflow/lite/micro/examples/person_detection/Makefile.inc \
   $(shell find ../google/ -name Makefile_internal.inc)
 MICRO_LITE_EXAMPLE_TESTS := $(filter-out $(EXCLUDED_EXAMPLE_TESTS), $(MICRO_LITE_EXAMPLE_TESTS))
 

--- a/tensorflow/lite/micro/tools/make/targets/bluepill_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/bluepill_makefile.inc
@@ -75,7 +75,7 @@ MICROLITE_TEST_SRCS := $(filter-out $(EXCLUDED_TESTS), $(MICROLITE_TEST_SRCS))
 EXCLUDED_EXAMPLE_TESTS := \
   tensorflow/lite/micro/examples/magic_wand/Makefile.inc \
   tensorflow/lite/micro/examples/micro_speech/Makefile.inc \
-  tensorflow/lite/micro/examples/image_recognition_experimental/Makefile.inc \
+  tensorflow/lite/micro/examples/person_detection/Makefile.inc \
   $(shell find ../google/ -name Makefile_internal.inc)
 MICRO_LITE_EXAMPLE_TESTS := $(filter-out $(EXCLUDED_EXAMPLE_TESTS), $(MICRO_LITE_EXAMPLE_TESTS))
 

--- a/tensorflow/lite/micro/tools/make/targets/stm32f4_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/stm32f4_makefile.inc
@@ -96,7 +96,6 @@ MICROLITE_TEST_SRCS := $(filter-out $(EXCLUDED_TESTS), $(MICROLITE_TEST_SRCS))
 EXCLUDED_EXAMPLE_TESTS := \
   tensorflow/lite/micro/examples/magic_wand/Makefile.inc \
   tensorflow/lite/micro/examples/micro_speech/Makefile.inc \
-  tensorflow/lite/micro/examples/person_detection/Makefile.inc \
   tensorflow/lite/micro/examples/image_recognition_experimental/Makefile.inc
 MICRO_LITE_EXAMPLE_TESTS := $(filter-out $(EXCLUDED_EXAMPLE_TESTS), $(MICRO_LITE_EXAMPLE_TESTS))
 

--- a/tensorflow/lite/micro/tools/make/targets/stm32f4_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/stm32f4_makefile.inc
@@ -95,8 +95,7 @@ MICROLITE_TEST_SRCS := $(filter-out $(EXCLUDED_TESTS), $(MICROLITE_TEST_SRCS))
 
 EXCLUDED_EXAMPLE_TESTS := \
   tensorflow/lite/micro/examples/magic_wand/Makefile.inc \
-  tensorflow/lite/micro/examples/micro_speech/Makefile.inc \
-  tensorflow/lite/micro/examples/image_recognition_experimental/Makefile.inc
+  tensorflow/lite/micro/examples/micro_speech/Makefile.inc
 MICRO_LITE_EXAMPLE_TESTS := $(filter-out $(EXCLUDED_EXAMPLE_TESTS), $(MICRO_LITE_EXAMPLE_TESTS))
 
 TEST_SCRIPT := tensorflow/lite/micro/testing/test_with_renode.sh


### PR DESCRIPTION
Manually tested the following command:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=stm32f4 OPTIMIZED_KERNEL_DIR=cmsis_nn test_person_detection_test
```

From this PR on, the person_detection_test will be part of our CI.

The key point here is that removing the _int8 suffix means that it will be run as part of the bluepill and stm32f4 tests. This is also the reason for needing to increase the timeout for bluepill in the current PR (even though it was not previously excluded).

Also, a little bit of cleanup in the name of the tests and binaries and remove mentions to sparkfun_edge.

BUG=http://b/209700478
