### PR TITLE
Fix golden_quantized may be used uninitialized error in depthwise_conv_test.cc

### DIFF
--- a/tensorflow/lite/micro/kernels/depthwise_conv_test.cc
+++ b/tensorflow/lite/micro/kernels/depthwise_conv_test.cc
@@ -579,7 +579,7 @@ TF_LITE_MICRO_TEST(FilterDimsNotMatchingAffineQuantization) {
   int8_t input_quantized[input_size];
   int8_t filter_quantized[filter_size];
   int32_t bias_quantized[bias_size];
-  int8_t golden_quantized[output_size] = {0};
+  int8_t golden_quantized[output_size] = {};
   int zero_points[bias_size + 1];
   float scales[bias_size + 1];
   int8_t output_data[output_size];

--- a/tensorflow/lite/micro/kernels/depthwise_conv_test.cc
+++ b/tensorflow/lite/micro/kernels/depthwise_conv_test.cc
@@ -579,7 +579,7 @@ TF_LITE_MICRO_TEST(FilterDimsNotMatchingAffineQuantization) {
   int8_t input_quantized[input_size];
   int8_t filter_quantized[filter_size];
   int32_t bias_quantized[bias_size];
-  int8_t golden_quantized[output_size];
+  int8_t golden_quantized[output_size] = {0};
   int zero_points[bias_size + 1];
   float scales[bias_size + 1];
   int8_t output_data[output_size];


### PR DESCRIPTION
Fix golden_quantized may be used uninitialized error in depthwise_conv_test.cc

In some local machine, release build  is failing with the following
error:
make -j8 -f tensorflow/lite/micro/tools/make/Makefile BUILD_TYPE=release build

tensorflow/lite/micro/kernels/depthwise_conv_test.cc: In function ‘int
main(int, char**)’:
tensorflow/lite/micro/kernels/depthwise_conv_test.cc:643:72: error:
‘golden_quantized’ may be used uninitialized
[-Werror=maybe-uninitialized]

This error message is only seen in some local machine, but looks legit warning turning into error.

BUG=http://b/210134938