### PR TITLE
Add Unused() for MicroPrintf to avoid #if on TF_LITE_STRIP_ERROR_STRINGS on different files

### DIFF
--- a/tensorflow/lite/micro/kernels/depthwise_conv_test.cc
+++ b/tensorflow/lite/micro/kernels/depthwise_conv_test.cc
@@ -579,7 +579,7 @@ TF_LITE_MICRO_TEST(FilterDimsNotMatchingAffineQuantization) {
   int8_t input_quantized[input_size];
   int8_t filter_quantized[filter_size];
   int32_t bias_quantized[bias_size];
-  int8_t golden_quantized[output_size];
+  int8_t golden_quantized[output_size] = {0};
   int zero_points[bias_size + 1];
   float scales[bias_size + 1];
   int8_t output_data[output_size];

--- a/tensorflow/lite/micro/memory_planner/greedy_memory_planner.cc
+++ b/tensorflow/lite/micro/memory_planner/greedy_memory_planner.cc
@@ -366,9 +366,7 @@ void GreedyMemoryPlanner::PrintMemoryPlan() {
     for (int c = 0; c < kLineWidth; ++c) {
       line[c] = '.';
     }
-#if !defined(TF_LITE_STRIP_ERROR_STRINGS)
     int memory_use = 0;
-#endif
     for (int i = 0; i < buffer_count_; ++i) {
       BufferRequirements* requirements = &requirements_[i];
       if ((t < requirements->first_time_used) ||
@@ -380,9 +378,7 @@ void GreedyMemoryPlanner::PrintMemoryPlan() {
         continue;
       }
       const int size = requirements->size;
-#if !defined(TF_LITE_STRIP_ERROR_STRINGS)
       memory_use += size;
-#endif
       const int line_start = (offset * kLineWidth) / max_size;
       const int line_end = ((offset + size) * kLineWidth) / max_size;
       for (int n = line_start; n < line_end; ++n) {

--- a/tensorflow/lite/micro/micro_error_reporter.h
+++ b/tensorflow/lite/micro/micro_error_reporter.h
@@ -27,10 +27,15 @@ void MicroPrintf(const char* format, ...);
 #else
 // We use a #define to ensure that the strings are completely stripped, to
 // prevent an unnecessary increase in the binary size.
-#define MicroPrintf(format, ...)
+#define MicroPrintf(...) tflite::Unused(__VA_ARGS__)
 #endif
 
 namespace tflite {
+
+template <typename... Args>
+void Unused(Args&&... args) {
+  (void)(sizeof...(args));
+}
 
 // Get a pointer to a singleton global error reporter.
 ErrorReporter* GetMicroErrorReporter();

--- a/tensorflow/lite/micro/micro_error_reporter.h
+++ b/tensorflow/lite/micro/micro_error_reporter.h
@@ -32,6 +32,8 @@ void MicroPrintf(const char* format, ...);
 
 namespace tflite {
 
+// From
+// https://stackoverflow.com/questions/23235910/variadic-unused-function-macro
 template <typename... Args>
 void Unused(Args&&... args) {
   (void)(sizeof...(args));

--- a/tensorflow/lite/micro/micro_graph.cc
+++ b/tensorflow/lite/micro/micro_graph.cc
@@ -27,7 +27,6 @@ limitations under the License.
 namespace tflite {
 namespace {
 
-#ifndef TF_LITE_STRIP_ERROR_STRINGS
 const char* OpNameFromRegistration(const TfLiteRegistration* registration) {
   if (registration->builtin_code == BuiltinOperator_CUSTOM) {
     return registration->custom_name;
@@ -35,7 +34,6 @@ const char* OpNameFromRegistration(const TfLiteRegistration* registration) {
     return EnumNameBuiltinOperator(BuiltinOperator(registration->builtin_code));
   }
 }
-#endif  // !defined(TF_LITE_STRIP_ERROR_STRINGS)
 
 }  // namespace
 


### PR DESCRIPTION
Add Unused() for MicroPrintf to avoid #ifdef TF_LITE_STRIP_ERROR_STRINGS on different files
    
This is a different fix than pr #718 that avoids putting  #ifdef TF_LITE_STRIP_ERROR_STRINGS on different files.
    
Verify that this change does not increase size by adding a bunch of    MicroPrintf in hello_world example and observe the size of binary remain unchanged.

BUG=http://b/208249141
