### PR TITLE
refactor mergify setup

### DIFF
--- a/.github/workflows/apply_cirun.yml
+++ b/.github/workflows/apply_cirun.yml
@@ -1,0 +1,18 @@
+on:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  apply-label:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'ci:ready_to_merge')
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['ci:run']
+            })

--- a/.github/workflows/check_tflite_files.yml
+++ b/.github/workflows/check_tflite_files.yml
@@ -7,8 +7,7 @@ jobs:
   check_tflite_files:
     runs-on: ubuntu-latest
     if: |
-      contains(github.event.pull_request.labels.*.name, 'ci:run') ||
-      contains(github.event.pull_request.labels.*.name, 'ci:ready_to_merge')
+      contains(github.event.pull_request.labels.*.name, 'ci:run')
     name: Check PR Modifies TfLite Files
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:run')) ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:ready_to_merge')) ||
       (github.event_name == 'schedule' && github.repository == 'tensorflow/tflite-micro')
 
     name: Bazel (presubmit)
@@ -50,7 +49,6 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:run')) ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:ready_to_merge')) ||
       (github.event_name == 'schedule' && github.repository == 'tensorflow/tflite-micro')
 
     name: Cortex-M (presubmit)
@@ -71,7 +69,6 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:run')) ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:ready_to_merge')) ||
       (github.event_name == 'schedule' && github.repository == 'tensorflow/tflite-micro')
 
     name: Code Style (presubmit)
@@ -88,7 +85,6 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:run')) ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:ready_to_merge')) ||
       (github.event_name == 'schedule' && github.repository == 'tensorflow/tflite-micro')
 
     name: Project Generation (presubmit)

--- a/.github/workflows/hexagon.yml
+++ b/.github/workflows/hexagon.yml
@@ -27,7 +27,6 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ci:run')) ||
-      (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ci:ready_to_merge')) ||
       (github.event_name == 'schedule' && github.repository == 'tensorflow/tflite-micro')
 
     name: Hexagon Build Test (presubmit)

--- a/.github/workflows/xtensa.yml
+++ b/.github/workflows/xtensa.yml
@@ -27,7 +27,6 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ci:run')) ||
-      (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ci:ready_to_merge')) ||
       (github.event_name == 'schedule' && github.repository == 'tensorflow/tflite-micro')
 
     name: Fusion F1 Unit Tests (presubmit)


### PR DESCRIPTION
Adds script apply_cirun.yml that triggers on PULL_REQUEST_TARGET[synchronize] and adds the ci:run label to the PR if it already has the ci:ready_to_merge label. 

Note this has to be PULL_REQUEST_TARGET instead of PULL_REQUEST in order to add the label to PRs coming from unprivileged forks. Since no code from the repo is being executed as a result of the workflow, there is no security issue with this usage.

Also note that we are using an external action github-script to handle the labeling. This action is one of the github staff maintained actions, so the risks there are reasonably minimal.

This PR also removes test conditionals related to ci:ready_to_merge from the five workflow files involved.

BUG= #791 