### PR TITLE
Adding tflm bot token to apply_cirun.yml

### DIFF
--- a/.github/workflows/apply_cirun.yml
+++ b/.github/workflows/apply_cirun.yml
@@ -9,6 +9,7 @@ jobs:
     steps:
       - uses: actions/github-script@v5
         with:
+          github-token: ${{ secrets.TFLM_BOT_REPO_TOKEN }} 
           script: |
             github.rest.issues.addLabels({
               issue_number: context.issue.number,


### PR DESCRIPTION
The queue is able to run the apply_cirun.yml workflow, but then appears to stall running the actual tests. This could be a permissions issue from the label being applied by a non-privileged user. Adding the github token for the tflm_bot to the label creation to see if that fixes the issue.

BUG= #792 