### PR TITLE
docs: Fix broken listing in contribution docs

### DIFF
--- a/tensorflow/lite/micro/docs/optimized_kernel_implementations.md
+++ b/tensorflow/lite/micro/docs/optimized_kernel_implementations.md
@@ -131,12 +131,12 @@ currently no fixed recipe for this refactor and we will evaluate on a
 case-by-case basis during the PR review.
 
 For example, to add an optimized implementation for `fully_conntected` for the
-Xtensa Fusion F1 the steps were: *
-[PR 1](https://github.com/tensorflow/tensorflow/pull/45464): refactor for
-reference fallbacks and a baseline latency. *
-[PR 2](https://github.com/tensorflow/tensorflow/pull/46242): refactor to share
-code between reference and optimized kernels. *
-[PR 3](https://github.com/tensorflow/tensorflow/pull/46411): add the code needed
+Xtensa Fusion F1 the steps were: 
+* [PR 1](https://github.com/tensorflow/tensorflow/pull/45464): refactor for
+reference fallbacks and a baseline latency. 
+* [PR 2](https://github.com/tensorflow/tensorflow/pull/46242): refactor to share
+code between reference and optimized kernels. 
+* [PR 3](https://github.com/tensorflow/tensorflow/pull/46411): add the code needed
 to use the optimized NN lib and document the latency improvement.
 
 ## Build System Integration


### PR DESCRIPTION
I was reading the optimized_kernel_implementations.md and I noticed multiply characters inline with the text.  I believe the items were supposed to be shown as an unordered list and not inline.

I fixed the structure so that they now show up as an unordered list

BUG=fix the docs