### PR TITLE
Remove HIFI4_INTERNAL for Fusion F1 builds

### DIFF
--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -116,6 +116,11 @@ cc_library(
     ],
 )
 
+FUSION_F1_COPS = [
+    "-DXTENSA=1",
+    "-DHIFI4=1",
+]
+
 HIFI4_COPTS = [
     "-DXTENSA=1",
     "-DHIFI4_INTERNAL=1",
@@ -250,7 +255,7 @@ tflm_kernel_cc_library(
         xtensa_hifi_5_config(): glob(["xtensa/**/*.cc"]),
     },
     copts = micro_copts() + select({
-        xtensa_fusion_f1_config(): HIFI4_COPTS,
+        xtensa_fusion_f1_config(): FUSION_F1_COPS,
         xtensa_hifi_3z_config(): HIFI4_COPTS,
         xtensa_hifi_5_config(): HIFI5_COPTS,
         "//conditions:default": [],


### PR DESCRIPTION
Revert HIFI4_INTERNAL to HIFI4 for Fusion F1 build to succeed.

BUG=http://b/211515389