### PR TITLE
Disable micro_interpreter_test for FVP target

### DIFF
--- a/tensorflow/lite/micro/tools/make/targets/cortex_m_corstone_300_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/cortex_m_corstone_300_makefile.inc
@@ -195,7 +195,8 @@ INCLUDES += \
 
 # TODO(#47070): Examine why some tests fail here.
 EXCLUDED_TESTS := \
-  tensorflow/lite/micro/memory_arena_threshold_test.cc
+  tensorflow/lite/micro/memory_arena_threshold_test.cc \
+  tensorflow/lite/micro/micro_interpreter_test.cc
 MICROLITE_TEST_SRCS := $(filter-out $(EXCLUDED_TESTS), $(MICROLITE_TEST_SRCS))
 
 TEST_SCRIPT := tensorflow/lite/micro/testing/test_with_arm_corstone_300.sh


### PR DESCRIPTION
We just disable the test for now.

BUG=https://github.com/tensorflow/tflite-micro/issues/809