### PR TITLE
Allow zero points to be broadcasted during model initialization

### DIFF
--- a/tensorflow/lite/micro/kernels/conv_common.cc
+++ b/tensorflow/lite/micro/kernels/conv_common.cc
@@ -168,8 +168,6 @@ TfLiteStatus ConvPrepare(TfLiteContext* context, TfLiteNode* node) {
                    affine_quantization->scale->size == 1 ||
                        affine_quantization->scale->size ==
                            filter->dims->data[kConvQuantizedDimension]);
-    TF_LITE_ENSURE_EQ(context, affine_quantization->scale->size,
-                      affine_quantization->zero_point->size);
   }
 
   TF_LITE_ENSURE_STATUS(CalculateOpDataConv(

--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -420,7 +420,12 @@ TfLiteStatus InitializeTfLiteTensorFromFlatbuffer(
     quantization->zero_point->size = channels;
     int* zero_point_data = quantization->zero_point->data;
     for (int i = 0; i < channels; i++) {
-      zero_point_data[i] = src_quantization->zero_point()->Get(i);
+      // As a space-saving optimization, zero point arrays for weights can be
+      // reduced to a single value, since all zero points for weights are 0.
+      zero_point_data[i] = src_quantization->zero_point()->size() ==
+                                   src_quantization->scale()->size()
+                               ? src_quantization->zero_point()->Get(i)
+                               : src_quantization->zero_point()->Get(0);
     }
     // TODO(rocky): Need to add a micro_allocator test case that fails when
     // this is not copied:


### PR DESCRIPTION
Enables the removal of zero points from weights with symmetric quantization. These zero points are int64 values in the flatbuffer, and their value is always guaranteed to be zero.

BUG=https://b.corp.google.com/issues/209831641