### PR TITLE
Have the ability to apply multiple patches.

### DIFF
--- a/tensorflow/lite/micro/tools/make/bash_helpers.sh
+++ b/tensorflow/lite/micro/tools/make/bash_helpers.sh
@@ -72,7 +72,7 @@ function apply_patch_to_folder() {
   pushd ${1} > /dev/null
   echo >&2 "Applying ${PWD}/${1}/${2} to ${PWD}/${1}"
   git apply ${2}
-  git commit -a -m ${3} > /dev/null
+  git commit -a -m "${3}" > /dev/null
   popd > /dev/null
 }
 

--- a/tensorflow/lite/micro/tools/make/bash_helpers.sh
+++ b/tensorflow/lite/micro/tools/make/bash_helpers.sh
@@ -58,20 +58,21 @@ create_git_repo() {
   git config user.name "TFLM" --local
   git add . >&2 2> /dev/null
   git commit -a -m "Commit for a temporary repository." > /dev/null
+  git checkout -b tflm
   popd > /dev/null
 }
 
-# Create a git repo in a folder and apply patch.
+# Create a new commit with a patch in a folder that has a git repo.
 #
 # Parameter(s):
 #   $[1} - relative path to folder
 #   ${2} - path to patch file (relative to ${1})
+#   ${3} - commit nessage for the patch
 function apply_patch_to_folder() {
-  create_git_repo ${1}
   pushd ${1} > /dev/null
   echo >&2 "Applying ${PWD}/${1}/${2} to ${PWD}/${1}"
-  git checkout -b tflm-patch
   git apply ${2}
+  git commit -a -m ${3} > /dev/null
   popd > /dev/null
 }
 

--- a/tensorflow/lite/micro/tools/make/bash_helpers.sh
+++ b/tensorflow/lite/micro/tools/make/bash_helpers.sh
@@ -58,7 +58,7 @@ create_git_repo() {
   git config user.name "TFLM" --local
   git add . >&2 2> /dev/null
   git commit -a -m "Commit for a temporary repository." > /dev/null
-  git checkout -b tflm
+  git checkout -b tflm > /dev/null
   popd > /dev/null
 }
 

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
@@ -81,7 +81,8 @@ else
 
   pushd "${LIBRARY_INSTALL_PATH}" > /dev/null
   chmod -R +w ./
-  apply_patch_to_folder ./ "../../ext_libs/xa_nnlib_${2}.patch"
+  create_git_repo ./
+  apply_patch_to_folder ./ "../../ext_libs/xa_nnlib_${2}.patch" "TFLM patch"
 fi
 
 

--- a/tensorflow/lite/micro/tools/make/flatbuffers_download.sh
+++ b/tensorflow/lite/micro/tools/make/flatbuffers_download.sh
@@ -72,7 +72,8 @@ else
 
   pushd ${DOWNLOADED_FLATBUFFERS_PATH} > /dev/null
   delete_build_files ${DOWNLOADED_FLATBUFFERS_PATH}
-  apply_patch_to_folder ./ ../../flatbuffers.patch
+  create_git_repo ./
+  apply_patch_to_folder ./ ../../flatbuffers.patch "TFLM patch"
   popd > /dev/null
 fi
 

--- a/tensorflow/lite/micro/tools/make/kissfft_download.sh
+++ b/tensorflow/lite/micro/tools/make/kissfft_download.sh
@@ -62,7 +62,8 @@ else
   rm -rf "${TEMPDIR}"
 
   pushd ${DOWNLOADED_KISSFFT_PATH} > /dev/null
-  apply_patch_to_folder ./ ../../kissfft.patch
+  create_git_repo ./
+  apply_patch_to_folder ./ ../../kissfft.patch "TFLM patch"
   popd > /dev/null
 fi
 

--- a/tensorflow/lite/micro/tools/make/pigweed_download.sh
+++ b/tensorflow/lite/micro/tools/make/pigweed_download.sh
@@ -55,7 +55,8 @@ else
   rm -rf ${DOWNLOADED_PIGWEED_PATH}/.git
   rm -f `find . -name BUILD`
 
-  apply_patch_to_folder ./ ../../pigweed.patch
+  create_git_repo ./
+  apply_patch_to_folder ./ ../../pigweed.patch "TFLM patch"
 
   popd > /dev/null
 fi

--- a/tensorflow/lite/micro/tools/make/renode_download.sh
+++ b/tensorflow/lite/micro/tools/make/renode_download.sh
@@ -64,7 +64,8 @@ else
   pip3 install -r ${DOWNLOADED_RENODE_PATH}/tests/requirements.txt >&2
 
   pushd ${DOWNLOADED_RENODE_PATH} > /dev/null
-  apply_patch_to_folder ./ ../../renode.patch
+  create_git_repo ./
+  apply_patch_to_folder ./ ../../renode.patch "TFLM patch"
   popd > /dev/null
 fi
 

--- a/tensorflow/lite/micro/tools/make/sifive_sdk_download.sh
+++ b/tensorflow/lite/micro/tools/make/sifive_sdk_download.sh
@@ -62,7 +62,8 @@ else
   rm -rf "${TEMPDIR}"
 
   pushd ${DOWNLOADED_SIFIVE_SDK_PATH} > /dev/null
-  apply_patch_to_folder ./ ../../sifive_sdk.patch
+  create_git_repo ./
+  apply_patch_to_folder ./ ../../sifive_sdk.patch "TFLM patch"
   popd > /dev/null
 fi
 


### PR DESCRIPTION
We have a need to apply two types of patches to our third party dependencies:

 1. TFLM-specific changes that can not be upstreamed.
 2. changes that can be upstreamed

With this PR, we can separate the two types of patches into their own individual patch files which will make it easier to remove the patches in the second category once the changes are indeed upstreamed and TFLM updates to use the newer verison of the third party library.

https://github.com/tensorflow/tflite-micro/pull/818 uses the ability to apply multiple patches for flatbuffers.

BUG=groundwork to address http://b/211811553
