### PR TITLE
Update bazel version in the install script

### DIFF
--- a/ci/install_bazel.sh
+++ b/ci/install_bazel.sh
@@ -15,7 +15,7 @@
 # ==============================================================================
 
 # Select bazel version.
-BAZEL_VERSION="4.2.1"
+BAZEL_VERSION="4.2.2"
 
 set +e
 local_bazel_ver=$(bazel version 2>&1 | grep -i label | awk '{print $3}')


### PR DESCRIPTION
Tensorflow requires 4.2.2 with https://github.com/tensorflow/tensorflow/pull/53363

Without this change, the sync workflow fails with:
```
ERROR: The project you're trying to build requires Bazel 4.2.2 (specified in /tmp/tensorflow/.bazelversion), but it wasn't found in /usr/local/lib/bazel/bin.
```

BUG=fix broken sync from upstream TF
