### PR TITLE
Add dilation support for CMSIS-NN optimized kernels

### DIFF
--- a/tensorflow/lite/micro/kernels/cmsis_nn/conv.cc
+++ b/tensorflow/lite/micro/kernels/cmsis_nn/conv.cc
@@ -1,4 +1,4 @@
-/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -133,109 +133,93 @@ TfLiteStatus EvalQuantizedPerChannel(
   cmsis_nn_conv_params conv_params;
   conv_params.dilation.h = params.dilation_height_factor;
   conv_params.dilation.w = params.dilation_width_factor;
-  // TODO(#43557) Remove checks for dilation and call to reference
-  // implementation when dilation is supported in the optimized implementation
-  // by CMSIS-NN.
-  if (conv_params.dilation.h == 1 && conv_params.dilation.w == 1) {
-    // Initialize cmsis_nn convolution parameters
-    conv_params.input_offset = -data.reference_op_data.input_zero_point;
-    conv_params.output_offset = data.reference_op_data.output_zero_point;
-    conv_params.stride.h = params.stride_height;
-    conv_params.stride.w = params.stride_width;
-    conv_params.padding.h = data.reference_op_data.padding.height;
-    conv_params.padding.w = data.reference_op_data.padding.width;
-    conv_params.activation.min = data.reference_op_data.output_activation_min;
-    conv_params.activation.max = data.reference_op_data.output_activation_max;
 
-    // Initialize cmsis_nn per channel quantization parameters
-    cmsis_nn_per_channel_quant_params quant_params;
-    quant_params.multiplier = const_cast<int32_t*>(
-        data.reference_op_data.per_channel_output_multiplier);
-    quant_params.shift =
-        const_cast<int32_t*>(data.reference_op_data.per_channel_output_shift);
+  // Initialize cmsis_nn convolution parameters
+  conv_params.input_offset = -data.reference_op_data.input_zero_point;
+  conv_params.output_offset = data.reference_op_data.output_zero_point;
+  conv_params.stride.h = params.stride_height;
+  conv_params.stride.w = params.stride_width;
+  conv_params.padding.h = data.reference_op_data.padding.height;
+  conv_params.padding.w = data.reference_op_data.padding.width;
+  conv_params.activation.min = data.reference_op_data.output_activation_min;
+  conv_params.activation.max = data.reference_op_data.output_activation_max;
 
-    RuntimeShape filter_shape = tflite::micro::GetTensorShape(filter);
-    RuntimeShape input_shape = tflite::micro::GetTensorShape(input);
-    RuntimeShape output_shape = tflite::micro::GetTensorShape(output);
-    RuntimeShape bias_shape = tflite::micro::GetTensorShape(bias);
+  // Initialize cmsis_nn per channel quantization parameters
+  cmsis_nn_per_channel_quant_params quant_params;
+  quant_params.multiplier = const_cast<int32_t*>(
+      data.reference_op_data.per_channel_output_multiplier);
+  quant_params.shift =
+      const_cast<int32_t*>(data.reference_op_data.per_channel_output_shift);
 
-    // Consistency check.
-    TFLITE_DCHECK_LE(conv_params.activation.min, conv_params.activation.max);
-    TFLITE_DCHECK_EQ(input_shape.DimensionsCount(), 4);
-    TFLITE_DCHECK_EQ(filter_shape.DimensionsCount(), 4);
-    TFLITE_DCHECK_EQ(output_shape.DimensionsCount(), 4);
-    const int batch_size = MatchingDim(input_shape, 0, output_shape, 0);
-    const int input_depth = MatchingDim(input_shape, 3, filter_shape, 3);
-    const int output_depth = MatchingDim(filter_shape, 0, output_shape, 3);
-    if (tflite::micro::GetTensorData<int8_t>(bias)) {
-      TFLITE_DCHECK_EQ(bias_shape.FlatSize(), output_depth);
-    }
+  RuntimeShape filter_shape = tflite::micro::GetTensorShape(filter);
+  RuntimeShape input_shape = tflite::micro::GetTensorShape(input);
+  RuntimeShape output_shape = tflite::micro::GetTensorShape(output);
+  RuntimeShape bias_shape = tflite::micro::GetTensorShape(bias);
 
-    // Initialize cmsis_nn dimensions
-    // Input
-    cmsis_nn_dims input_dims;
-    input_dims.n = batch_size;
-    input_dims.h = input_shape.Dims(1);
-    input_dims.w = input_shape.Dims(2);
-    input_dims.c = input_depth;
-
-    // Filter
-    cmsis_nn_dims filter_dims;
-    filter_dims.n = output_depth;
-    filter_dims.h = filter_shape.Dims(1);
-    filter_dims.w = filter_shape.Dims(2);
-    filter_dims.c = input_depth;
-
-    // Bias
-    cmsis_nn_dims bias_dims;
-    bias_dims.n = 1;
-    bias_dims.h = 1;
-    bias_dims.w = 1;
-    bias_dims.c = output_depth;
-
-    // Output
-    cmsis_nn_dims output_dims;
-    output_dims.n = batch_size;
-    output_dims.h = output_shape.Dims(1);
-    output_dims.w = output_shape.Dims(2);
-    output_dims.c = output_depth;
-
-    // Initialize cmsis_nn context
-    cmsis_nn_context ctx;
-    ctx.buf = nullptr;
-    ctx.size = 0;
-
-    if (data.buffer_idx > -1) {
-      ctx.buf = context->GetScratchBuffer(context, data.buffer_idx);
-      // Note: ctx.size is currently not used in cmsis_nn.
-      // The buffer should be allocated in the Prepare function through
-      // arm_convolve_wrapper_s8_get_buffer_size
-    }
-
-    // arm_convolve_wrapper_s8 dispatches the optimized kernel accordingly with
-    // the parameters passed
-    TFLITE_DCHECK_EQ(
-        arm_convolve_wrapper_s8(
-            &ctx, &conv_params, &quant_params, &input_dims,
-            tflite::micro::GetTensorData<int8_t>(input), &filter_dims,
-            tflite::micro::GetTensorData<int8_t>(filter), &bias_dims,
-            tflite::micro::GetTensorData<int32_t>(bias), &output_dims,
-            tflite::micro::GetTensorData<int8_t>(output)),
-        ARM_MATH_SUCCESS);
-  } else {
-    reference_integer_ops::ConvPerChannel(
-        ConvParamsQuantized(params, data.reference_op_data),
-        data.reference_op_data.per_channel_output_multiplier,
-        data.reference_op_data.per_channel_output_shift,
-        tflite::micro::GetTensorShape(input),
-        tflite::micro::GetTensorData<int8_t>(input),
-        tflite::micro::GetTensorShape(filter),
-        tflite::micro::GetTensorData<int8_t>(filter),
-        tflite::micro::GetTensorShape(bias),
-        tflite::micro::GetTensorData<int32_t>(bias),
-        tflite::micro::GetTensorShape(output),
-        tflite::micro::GetTensorData<int8_t>(output));
+  // Consistency check.
+  TFLITE_DCHECK_LE(conv_params.activation.min, conv_params.activation.max);
+  TFLITE_DCHECK_EQ(input_shape.DimensionsCount(), 4);
+  TFLITE_DCHECK_EQ(filter_shape.DimensionsCount(), 4);
+  TFLITE_DCHECK_EQ(output_shape.DimensionsCount(), 4);
+  const int batch_size = MatchingDim(input_shape, 0, output_shape, 0);
+  const int input_depth = MatchingDim(input_shape, 3, filter_shape, 3);
+  const int output_depth = MatchingDim(filter_shape, 0, output_shape, 3);
+  if (tflite::micro::GetTensorData<int8_t>(bias)) {
+    TFLITE_DCHECK_EQ(bias_shape.FlatSize(), output_depth);
   }
+
+  // Initialize cmsis_nn dimensions
+  // Input
+  cmsis_nn_dims input_dims;
+  input_dims.n = batch_size;
+  input_dims.h = input_shape.Dims(1);
+  input_dims.w = input_shape.Dims(2);
+  input_dims.c = input_depth;
+
+  // Filter
+  cmsis_nn_dims filter_dims;
+  filter_dims.n = output_depth;
+  filter_dims.h = filter_shape.Dims(1);
+  filter_dims.w = filter_shape.Dims(2);
+  filter_dims.c = input_depth;
+
+  // Bias
+  cmsis_nn_dims bias_dims;
+  bias_dims.n = 1;
+  bias_dims.h = 1;
+  bias_dims.w = 1;
+  bias_dims.c = output_depth;
+
+  // Output
+  cmsis_nn_dims output_dims;
+  output_dims.n = batch_size;
+  output_dims.h = output_shape.Dims(1);
+  output_dims.w = output_shape.Dims(2);
+  output_dims.c = output_depth;
+
+  // Initialize cmsis_nn context
+  cmsis_nn_context ctx;
+  ctx.buf = nullptr;
+  ctx.size = 0;
+
+  if (data.buffer_idx > -1) {
+    ctx.buf = context->GetScratchBuffer(context, data.buffer_idx);
+    // Note: ctx.size is currently not used in cmsis_nn.
+    // The buffer should be allocated in the Prepare function through
+    // arm_convolve_wrapper_s8_get_buffer_size
+  }
+
+  // arm_convolve_wrapper_s8 dispatches the optimized kernel accordingly with
+  // the parameters passed
+  TFLITE_DCHECK_EQ(
+      arm_convolve_wrapper_s8(
+          &ctx, &conv_params, &quant_params, &input_dims,
+          tflite::micro::GetTensorData<int8_t>(input), &filter_dims,
+          tflite::micro::GetTensorData<int8_t>(filter), &bias_dims,
+          tflite::micro::GetTensorData<int32_t>(bias), &output_dims,
+          tflite::micro::GetTensorData<int8_t>(output)),
+      ARM_MATH_SUCCESS);
+
   return kTfLiteOk;
 }
 

--- a/tensorflow/lite/micro/tools/make/ext_libs/cmsis_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/cmsis_download.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,9 +49,9 @@ if [ -d ${DOWNLOADED_CMSIS_PATH} ]; then
   echo >&2 "${DOWNLOADED_CMSIS_PATH} already exists, skipping the download."
 else
 
-  ZIP_PREFIX="bff28575f0c96a4ee9008947fea2b018a69b4900"
+  ZIP_PREFIX="977abe9849781a2e788b02282986480ff4e25ea6"
   CMSIS_URL="http://github.com/ARM-software/CMSIS_5/archive/${ZIP_PREFIX}.zip"
-  CMSIS_MD5="5412572a648d7103b311e8b7acd86a01"
+  CMSIS_MD5="7f87371ed9e8ac2749fe49598700a448"
 
   # wget is much faster than git clone of the entire repo. So we wget a specific
   # version and can then apply a patch, as needed.


### PR DESCRIPTION
* Removes calls to reference kernel function in depthwise and conv kernels.
* Updates downloaded CMSIS version.
* Fix bug in prepare for depthwise where dilation was not set in call
  to get buffer size.

BUG=Fixes https://github.com/tensorflow/tflite-micro/issues/831