### PR TITLE
Integrate and demonstrate use of Pigweed's unit test module

### DIFF
--- a/tensorflow/lite/micro/examples/hello_world/Makefile.inc
+++ b/tensorflow/lite/micro/examples/hello_world/Makefile.inc
@@ -3,6 +3,9 @@ EXAMPLE_NAME:=hello_world
 HELLO_WORLD_TEST_SRCS := \
 tensorflow/lite/micro/examples/$(EXAMPLE_NAME)/$(EXAMPLE_NAME)_test.cc
 
+HELLO_WORLD_TEST_PIGWEED_SRCS := \
+tensorflow/lite/micro/examples/$(EXAMPLE_NAME)/$(EXAMPLE_NAME)_test.pigweed.cc
+
 OUTPUT_HANDLER_TEST_SRCS := \
 tensorflow/lite/micro/examples/$(EXAMPLE_NAME)/output_handler_test.cc \
 tensorflow/lite/micro/examples/$(EXAMPLE_NAME)/output_handler.cc
@@ -37,6 +40,10 @@ include $(wildcard tensorflow/lite/micro/examples/$(EXAMPLE_NAME)/*/Makefile.inc
 # Tests loading and running the sine model.
 $(eval $(call microlite_test,$(EXAMPLE_NAME)_test,\
 $(HELLO_WORLD_TEST_SRCS),,$(HELLO_WORLD_GENERATOR_INPUTS)))
+
+# Tests using Pigweed's unit test module.
+$(eval $(call pigweed_unit_test,$(EXAMPLE_NAME)_test_pigweed,\
+$(HELLO_WORLD_TEST_PIGWEED_SRCS),,$(HELLO_WORLD_GENERATOR_INPUTS)))
 
 # Tests producing an output.
 $(eval $(call microlite_test,output_handler_test,\

--- a/tensorflow/lite/micro/examples/hello_world/hello_world_test.pigweed.cc
+++ b/tensorflow/lite/micro/examples/hello_world/hello_world_test.pigweed.cc
@@ -1,0 +1,127 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <math.h>
+
+#include "tensorflow/lite/micro/all_ops_resolver.h"
+#include "tensorflow/lite/micro/examples/hello_world/hello_world_model_data.h"
+#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_interpreter.h"
+#include "tensorflow/lite/micro/testing/pigweed_unit_test.h"
+#include "tensorflow/lite/schema/schema_generated.h"
+
+TEST(HelloWorldExample, LoadModelAndPerformInference) {
+  // Define the input and the expected output
+  float x = 0.0f;
+  float y_true = sin(x);
+
+  // Set up logging
+  tflite::MicroErrorReporter micro_error_reporter;
+
+  // Map the model into a usable data structure. This doesn't involve any
+  // copying or parsing, it's a very lightweight operation.
+  const tflite::Model* model = ::tflite::GetModel(g_hello_world_model_data);
+  if (model->version() != TFLITE_SCHEMA_VERSION) {
+    TF_LITE_REPORT_ERROR(&micro_error_reporter,
+                         "Model provided is schema version %d not equal "
+                         "to supported version %d.\n",
+                         model->version(), TFLITE_SCHEMA_VERSION);
+  }
+
+  // This pulls in all the operation implementations we need
+  tflite::AllOpsResolver resolver;
+
+  constexpr int kTensorArenaSize = 2000;
+  uint8_t tensor_arena[kTensorArenaSize];
+
+  // Build an interpreter to run the model with
+  tflite::MicroInterpreter interpreter(model, resolver, tensor_arena,
+                                       kTensorArenaSize, &micro_error_reporter);
+  // Allocate memory from the tensor_arena for the model's tensors
+  EXPECT_EQ(interpreter.AllocateTensors(), kTfLiteOk);
+
+  // Obtain a pointer to the model's input tensor
+  TfLiteTensor* input = interpreter.input(0);
+
+  // Make sure the input has the properties we expect
+  EXPECT_NE(nullptr, input);
+  // The property "dims" tells us the tensor's shape. It has one element for
+  // each dimension. Our input is a 2D tensor containing 1 element, so "dims"
+  // should have size 2.
+  EXPECT_EQ(2, input->dims->size);
+  // The value of each element gives the length of the corresponding tensor.
+  // We should expect two single element tensors (one is contained within the
+  // other).
+  EXPECT_EQ(1, input->dims->data[0]);
+  EXPECT_EQ(1, input->dims->data[1]);
+  // The input is an 8 bit integer value
+  EXPECT_EQ(kTfLiteInt8, input->type);
+
+  // Get the input quantization parameters
+  float input_scale = input->params.scale;
+  int input_zero_point = input->params.zero_point;
+
+  // Quantize the input from floating-point to integer
+  int8_t x_quantized = x / input_scale + input_zero_point;
+  // Place the quantized input in the model's input tensor
+  input->data.int8[0] = x_quantized;
+
+  // Run the model and check that it succeeds
+  TfLiteStatus invoke_status = interpreter.Invoke();
+  EXPECT_EQ(kTfLiteOk, invoke_status);
+
+  // Obtain a pointer to the output tensor and make sure it has the
+  // properties we expect. It should be the same as the input tensor.
+  TfLiteTensor* output = interpreter.output(0);
+  EXPECT_EQ(2, output->dims->size);
+  EXPECT_EQ(1, output->dims->data[0]);
+  EXPECT_EQ(1, output->dims->data[1]);
+  EXPECT_EQ(kTfLiteInt8, output->type);
+
+  // Get the output quantization parameters
+  float output_scale = output->params.scale;
+  int output_zero_point = output->params.zero_point;
+
+  // Obtain the quantized output from model's output tensor
+  int8_t y_pred_quantized = output->data.int8[0];
+  // Dequantize the output from integer to floating-point
+  float y_pred = (y_pred_quantized - output_zero_point) * output_scale;
+
+  // Check if the output is within a small range of the expected output
+  float epsilon = 0.05f;
+  EXPECT_NEAR(y_true, y_pred, epsilon);
+
+  // Run inference on several more values and confirm the expected outputs
+  x = 1.f;
+  y_true = sin(x);
+  input->data.int8[0] = x / input_scale + input_zero_point;
+  interpreter.Invoke();
+  y_pred = (output->data.int8[0] - output_zero_point) * output_scale;
+  EXPECT_NEAR(y_true, y_pred, epsilon);
+
+  x = 3.f;
+  y_true = sin(x);
+  input->data.int8[0] = x / input_scale + input_zero_point;
+  interpreter.Invoke();
+  y_pred = (output->data.int8[0] - output_zero_point) * output_scale;
+  EXPECT_NEAR(y_true, y_pred, epsilon);
+
+  x = 5.f;
+  y_true = sin(x);
+  input->data.int8[0] = x / input_scale + input_zero_point;
+  interpreter.Invoke();
+  y_pred = (output->data.int8[0] - output_zero_point) * output_scale;
+  EXPECT_NEAR(y_true, y_pred, epsilon);
+}

--- a/tensorflow/lite/micro/kernels/Makefile.inc
+++ b/tensorflow/lite/micro/kernels/Makefile.inc
@@ -105,3 +105,7 @@ tensorflow/lite/micro/kernels/zeros_like_test.cc
 # Generate simple kernel test targets in a common way
 $(foreach TEST_TARGET,$(MICROLITE_KERNEL_SIMPLE_TEST_SRCS),\
 $(eval $(call microlite_test,kernel_$(notdir $(basename $(TEST_TARGET))),$(TEST_TARGET))))
+
+# Tests using Pigweed's unit test module
+$(eval $(call pigweed_unit_test,kernel_fill_test_pigweed,\
+  tensorflow/lite/micro/kernels/fill_test.pigweed.cc))

--- a/tensorflow/lite/micro/kernels/fill_test.pigweed.cc
+++ b/tensorflow/lite/micro/kernels/fill_test.pigweed.cc
@@ -1,0 +1,229 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/micro/kernels/kernel_runner.h"
+#include "tensorflow/lite/micro/micro_utils.h"
+#include "tensorflow/lite/micro/test_helpers.h"
+#include "tensorflow/lite/micro/testing/pigweed_unit_test.h"
+
+namespace {
+using ::tflite::testing::CreateTensor;
+using ::tflite::testing::IntArrayFromInts;
+
+// The layout of tensors is fixed.
+constexpr int kDimsIndex = 0;
+constexpr int kValueIndex = 1;
+constexpr int kOutputIndex = 2;
+constexpr int kInputsTensor[] = {2, kDimsIndex, kValueIndex};
+constexpr int kOutputsTensor[] = {1, kOutputIndex};
+
+// This function is NOT thread safe.
+template <typename DimsType, typename ValueType, typename OutputType>
+tflite::micro::KernelRunner CreateFillTestRunner(
+    int* dims_shape, DimsType* dims_data, int* value_shape,
+    ValueType* value_data, int* output_shape, OutputType* output_data) {
+  // Some targets do not support dynamic memory (i.e., no malloc or new), thus,
+  // the test need to place non-transitent memories in static variables. This is
+  // safe because tests are guarateed to run serially.
+  // Both below structures are trivially destructible.
+  static TfLiteRegistration registration;
+  static TfLiteTensor tensors[3];
+
+  tensors[0] = CreateTensor(dims_data, IntArrayFromInts(dims_shape));
+  tensors[1] = CreateTensor(value_data, IntArrayFromInts(value_shape));
+  tensors[2] = CreateTensor(output_data, IntArrayFromInts(output_shape));
+
+  // The output type matches the value type.
+  EXPECT_EQ(tensors[kOutputIndex].type,
+            tensors[kValueIndex].type);
+
+  registration = tflite::Register_FILL();
+  tflite::micro::KernelRunner runner = tflite::micro::KernelRunner(
+      registration, tensors, sizeof(tensors) / sizeof(TfLiteTensor),
+      IntArrayFromInts(const_cast<int*>(kInputsTensor)),
+      IntArrayFromInts(const_cast<int*>(kOutputsTensor)),
+      /*builtin_data=*/nullptr);
+  return runner;
+}
+
+template <typename DimsType, typename ValueType, typename OutputType>
+void TestFill(int* dims_shape, DimsType* dims_data, int* value_shape,
+              ValueType* value_data, int* output_shape,
+              OutputType* output_data) {
+  tflite::micro::KernelRunner runner =
+      CreateFillTestRunner(dims_shape, dims_data, value_shape, value_data,
+                           output_shape, output_data);
+
+  EXPECT_EQ(runner.InitAndPrepare(), kTfLiteOk);
+  EXPECT_EQ(runner.Invoke(), kTfLiteOk);
+
+  // The output shape must match the shape requested via dims.
+  const auto output_rank = output_shape[0];
+  if (dims_data != nullptr) {
+    const auto requested_rank = dims_shape[1];  // yes, 1
+    if (EXPECT_EQ(output_rank, requested_rank)) {
+      for (int i = 0; i < requested_rank; ++i) {
+        EXPECT_EQ(output_shape[i + 1], dims_data[i]);
+      }
+    }
+  }
+
+  // The output elements contain the fill value.
+  const auto elements = tflite::ElementCount(*IntArrayFromInts(output_shape));
+  for (int i = 0; i < elements; ++i) {
+    EXPECT_EQ(output_data[i], value_data[0]);
+  }
+}
+
+}  // namespace
+
+TEST(KernelFill, FloatInt64Dims) {
+  constexpr int kDim1 = 2;
+  constexpr int kDim2 = 2;
+  constexpr int kDim3 = 2;
+
+  int dims_shape[] = {1, 3};
+  int64_t dims_data[] = {kDim1, kDim2, kDim3};
+
+  int value_shape[] = {0};
+  float value_data[] = {4.0};
+
+  int output_shape[] = {3, kDim1, kDim2, kDim3};
+  float output_data[kDim1 * kDim2 * kDim3];
+
+  TestFill(dims_shape, dims_data, value_shape, value_data, output_shape,
+           output_data);
+}
+
+// Fill a 2x2x2 tensor with a int32 scalar value. The dimension of the tensor is
+// of int64 type.
+TEST(KernelFill, Int32Int64Dims) {
+  constexpr int kDim1 = 2;
+  constexpr int kDim2 = 2;
+  constexpr int kDim3 = 2;
+
+  int dims_shape[] = {1, 3};
+  int64_t dims_data[] = {kDim1, kDim2, kDim3};
+
+  int value_shape[] = {0};
+  int32_t value_data[] = {4};
+
+  int output_shape[] = {3, kDim1, kDim2, kDim3};
+  int32_t output_data[kDim1 * kDim2 * kDim3];
+
+  TestFill(dims_shape, dims_data, value_shape, value_data, output_shape,
+           output_data);
+}
+
+// Fill a 2x2x2 tensor with a int8 scalar value. The dimension of the tensor is
+// of int32 type.
+TEST(KernelFill, Int8Int32Dims) {
+  constexpr int kDim1 = 2;
+  constexpr int kDim2 = 2;
+  constexpr int kDim3 = 2;
+
+  int dims_shape[] = {1, 3};
+  int32_t dims_data[] = {kDim1, kDim2, kDim3};
+
+  int value_shape[] = {0};
+  int8_t value_data[] = {4};
+
+  int output_shape[] = {3, kDim1, kDim2, kDim3};
+  int8_t output_data[kDim1 * kDim2 * kDim3];
+
+  TestFill(dims_shape, dims_data, value_shape, value_data, output_shape,
+           output_data);
+}
+
+// Verify the FILL still works when the input dims tensor is an activation
+// tensor (i.e. has not prepopulated value). Fill a 2x2x2 tensor with a int8
+// scalar value.
+TEST(KernelFill, Int8NoInputDimsData) {
+  constexpr int kDim1 = 2;
+  constexpr int kDim2 = 2;
+  constexpr int kDim3 = 2;
+
+  // The dims tensor with unknown data. Note that shape is always known.
+  int dims_shape[] = {1, 3};
+  int32_t* dims_data = nullptr;
+
+  int value_shape[] = {0};
+  int8_t value_data[] = {4};
+
+  int output_shape[] = {3, kDim1, kDim2, kDim3};
+  int8_t output_data[kDim1 * kDim2 * kDim3];
+
+  TestFill(dims_shape, dims_data, value_shape, value_data, output_shape,
+           output_data);
+}
+
+TEST(KernelFill, FloatInt32Dims) {
+  constexpr int kDim1 = 2;
+  constexpr int kDim2 = 2;
+  constexpr int kDim3 = 2;
+
+  int dims_shape[] = {1, 3};
+  int32_t dims_data[] = {kDim1, kDim2, kDim3};
+
+  int value_shape[] = {0};
+  float value_data[] = {4.0};
+
+  int output_shape[] = {3, kDim1, kDim2, kDim3};
+  float output_data[kDim1 * kDim2 * kDim3];
+
+  TestFill(dims_shape, dims_data, value_shape, value_data, output_shape,
+           output_data);
+}
+
+TEST(KernelFill, Scalar) {
+  int dims_shape[] = {1, 0};
+  int64_t dims_data[] = {0};
+
+  int value_shape[] = {0};
+  float value_data[] = {4.0};
+
+  int output_shape[] = {0};
+  float output_data[] = {0};
+
+  TestFill(dims_shape, dims_data, value_shape, value_data, output_shape,
+           output_data);
+}
+
+// When input dimension tensor mismatch with the output tensor's dimension,
+// the FILL op shall return error at init/prepare stage.
+TEST(KernelFill, InputDimsMismatchWithOutputShallFail) {
+  constexpr int kDim1 = 2;
+  constexpr int kDim2 = 2;
+  constexpr int kDim3 = 2;
+
+  int dims_shape[] = {1, 3};
+  int64_t dims_data[] = {kDim1, kDim2, kDim3};
+
+  int value_shape[] = {0};
+  int8_t value_data[] = {4};
+
+  // Output shape is supposed to be the same as dims_data.
+  // Intentionally +1 to kDim1 to verify the code catches this error.
+  int output_shape[] = {3, kDim1 + 1, kDim2, kDim3};
+  int8_t output_data[(kDim1 + 1) * kDim2 * kDim3];
+
+  tflite::micro::KernelRunner runner =
+      CreateFillTestRunner(dims_shape, dims_data, value_shape, value_data,
+                           output_shape, output_data);
+
+  EXPECT_EQ(runner.InitAndPrepare(), kTfLiteError);
+}

--- a/tensorflow/lite/micro/memory_helpers.cc
+++ b/tensorflow/lite/micro/memory_helpers.cc
@@ -103,7 +103,7 @@ TfLiteStatus BytesRequiredForTensor(const tflite::Tensor& flatbuffer_tensor,
   // If flatbuffer_tensor.shape == nullptr, then flatbuffer_tensor is a scalar
   // so has 1 element.
   if (flatbuffer_tensor.shape() != nullptr) {
-    for (size_t n = 0; n < flatbuffer_tensor.shape()->Length(); ++n) {
+    for (size_t n = 0; n < flatbuffer_tensor.shape()->size(); ++n) {
       element_count *= flatbuffer_tensor.shape()->Get(n);
     }
   }

--- a/tensorflow/lite/micro/testing/pigweed_unit_test.cc
+++ b/tensorflow/lite/micro/testing/pigweed_unit_test.cc
@@ -1,0 +1,33 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "pw_unit_test/simple_printing_event_handler.h"
+#include "tensorflow/lite/micro/debug_log.h"
+#include "tensorflow/lite/micro/testing/pigweed_unit_test.h"
+
+namespace {
+void WriteString(const std::string_view& string, bool newline) {
+  DebugLog(string.data());
+  if (newline) {
+    DebugLog("\r\n");
+  }
+}
+}  // namespace
+
+int main() {
+  pw::unit_test::SimplePrintingEventHandler handler(WriteString);
+  pw::unit_test::RegisterEventHandler(&handler);
+  return RUN_ALL_TESTS();
+}

--- a/tensorflow/lite/micro/testing/pigweed_unit_test.h
+++ b/tensorflow/lite/micro/testing/pigweed_unit_test.h
@@ -1,0 +1,45 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Include this header to define unit tests using Pigweed's unit test module,
+// pw_unit_test. This header includes all of the necessary headers from Pigweed
+// and elsewhere. Including this header and integration into the build system,
+// e.g., via the Makefile helper function `pigweed_unit_test,` is all that's
+// required to define a unit test. Test definition and assertion macros operate
+// roughly like those in Google Test. See the Pigweed documentation and example
+// tests elsewhere in tflite-micro.
+
+#ifndef TENSORFLOW_LITE_MICRO_TESTING_PIGWEED_UNIT_TEST_H_
+#define TENSORFLOW_LITE_MICRO_TESTING_PIGWEED_UNIT_TEST_H_
+
+#include "pw_unit_test/framework.h"
+#include "tensorflow/lite/micro/micro_error_reporter.h"
+
+// Define EXPECT_NEAR in terms of ADD_FAILURE, because Pigweed does not have an
+// EXPECT_NEAR. Copy the implementation from micro_test.
+#define EXPECT_NEAR(x, y, epsilon)                                            \
+  do {                                                                        \
+    auto vx = (x);                                                            \
+    auto vy = (y);                                                            \
+    auto delta = ((vx) > (vy)) ? ((vx) - (vy)) : ((vy) - (vx));               \
+    if (vx != vy && delta > epsilon) {                                        \
+      MicroPrintf(#x " (%f) near " #y " (%f) failed at %s:%d",                \
+                  static_cast<double>(vx), static_cast<double>(vy), __FILE__, \
+                  __LINE__);                                                  \
+      ADD_FAILURE();                                                          \
+    }                                                                         \
+  } while (false)
+
+#endif // TENSORFLOW_LITE_MICRO_TESTING_PIGWEED_UNIT_TEST_H_

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -153,7 +153,7 @@ ifeq ($(TARGET), $(HOST_OS))
 endif
 
 CXXFLAGS := \
-  -std=c++11 \
+  -std=c++17 \
   -fno-rtti \
   -fno-exceptions \
   -fno-threadsafe-statics \

--- a/tensorflow/lite/micro/tools/make/helper_functions.inc
+++ b/tensorflow/lite/micro/tools/make/helper_functions.inc
@@ -107,3 +107,5 @@ endef
 # 2 - File pattern, e.g: *.h
 recursive_find = $(wildcard $(1)$(2)) $(foreach dir,$(wildcard $(1)*),$(call recursive_find,$(dir)/,$(2)))
 
+# Include helpers for declaring unit tests that use Pigweed's pw_unit_test module
+include $(MAKEFILE_DIR)/pigweed_unit_test.inc

--- a/tensorflow/lite/micro/tools/make/pigweed_unit_test.inc
+++ b/tensorflow/lite/micro/tools/make/pigweed_unit_test.inc
@@ -1,0 +1,41 @@
+# Makefile helpers for defining tests based on Pigweed's unit test module.
+
+PIGWEED_ROOT := tensorflow/lite/micro/tools/make/downloads/pigweed
+
+PIGWEED_UNIT_TEST_INCLUDES := \
+  -I$(PIGWEED_ROOT)/pw_unit_test/public \
+  -I$(PIGWEED_ROOT)/pw_polyfill/public \
+  -I$(PIGWEED_ROOT)/pw_polyfill/standard_library_public \
+  -I$(PIGWEED_ROOT)/pw_polyfill/public_overrides \
+  -I$(PIGWEED_ROOT)/pw_preprocessor/public \
+  -I$(PIGWEED_ROOT)/pw_string/public \
+  -I$(PIGWEED_ROOT)/pw_status/public \
+  -I$(PIGWEED_ROOT)/pw_span/public \
+  -I$(PIGWEED_ROOT)/pw_span/public_overrides
+
+PIGWEED_UNIT_TEST_SRCS := \
+  $(PIGWEED_ROOT)/pw_unit_test/framework.cc \
+  $(PIGWEED_ROOT)/pw_unit_test/simple_printing_event_handler.cc \
+  $(PIGWEED_ROOT)/pw_string/format.cc \
+  $(PIGWEED_ROOT)/pw_string/string_builder.cc \
+  $(PIGWEED_ROOT)/pw_string/type_to_string.cc \
+  tensorflow/lite/micro/testing/pigweed_unit_test.cc
+
+# Generate targets for binaries that employ Pigweed's unit test module. Call eval
+# on the output to create the targets.
+#
+# See elsewhere the definition and uses of the underlying microlite_test for
+# full details. Target basenames that end with _test are added as test targets
+# (i.e., can be executed with `make test_<basename>).
+#
+# Arguments are:
+# 1 - Basename of target
+# 2 - C/C++ source files
+# 3 - C/C++ header files
+# 4 - Model sources and model test inputs in.tflite, .wav, .bmp or .csv format
+#
+define pigweed_unit_test
+$(1)_BINARY := $$(BINDIR)$(1)
+$$($(1)_BINARY): INCLUDES += $(PIGWEED_UNIT_TEST_INCLUDES)
+$(call microlite_test,$(1),$(2) $(PIGWEED_UNIT_TEST_SRCS),$(3),$(4))
+endef


### PR DESCRIPTION
Integrate and demonstrate the use of Pigweed's unit test module. This series of commits adds a header and Makefile build helper for writing tests using Pigweed's unit test module, pw_unit_test, in the same manner as tests using the existing micro_test. They add two example uses: a pw_unit_test rendition of the test in examples/hello_world and a pw_unit_test rendition of the unit test for kernels/fill. The Pigweed-based tests coexist in parallel with the micro_test-based tests.

Of note is the bump from C++11 to C++17 required to use Pigweed. See the relevant commit's log for some discussion.