### PR TITLE
Store scratch buffer arrays separately for each subgraph.

### DIFF
--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -564,6 +564,7 @@ SubgraphAllocations* MicroAllocator::StartModelAllocation(const Model* model) {
     MicroPrintf("Failed to allocate memory for model metadata.");
     return nullptr;
   }
+  memset(output, 0, sizeof(SubgraphAllocations) * model->subgraphs()->size());
 
   if (AllocateTfLiteEvalTensors(model, output) != kTfLiteOk ||
       AllocateNodeAndRegistrations(model, output) != kTfLiteOk) {

--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -939,18 +939,6 @@ TfLiteStatus MicroAllocator::CommitStaticMemoryPlan(
   memory_allocator_->DeallocateTemp(planner_arena);
   memory_allocator_->ResetTempAllocations();
 
-  size_t actual_available_arena_size =
-      memory_allocator_->GetAvailableMemory(MicroArenaBufferAlignment());
-
-  // Make sure we have enough arena size.
-  if (memory_planner_->GetMaximumMemorySize() > actual_available_arena_size) {
-    TF_LITE_REPORT_ERROR(
-        error_reporter_,
-        "Arena size is too small for all buffers. Needed %u but only "
-        "%u was available.",
-        memory_planner_->GetMaximumMemorySize(), actual_available_arena_size);
-    return kTfLiteError;
-  }
   // Commit the plan.
   TF_LITE_ENSURE_STATUS(CommitPlan(error_reporter_, memory_planner_,
                                    memory_allocator_->GetHeadBuffer(),

--- a/tensorflow/lite/micro/micro_allocator.h
+++ b/tensorflow/lite/micro/micro_allocator.h
@@ -61,6 +61,9 @@ typedef struct {
   // determine the lifetime of the buffer. In AllocationInfo, this buffer will
   // have `before` = node_idx and `after` = node_idx.
   int node_idx;
+  // Subgraph for which the scratch buffer is allocated. The scratch buffer will
+  // only be part of the memory plan for its subgraph.
+  int subgraph_idx;
 } ScratchBufferRequest;
 
 }  // namespace internal
@@ -79,10 +82,13 @@ typedef struct {
 } ScratchBufferHandle;
 
 // Stores all per-subgraph allocations. This includes the node and registration
-// array, tensor list and scratch buffer handles for each subgraph.
+// array, tensor list, scratch buffer handles and scratch buffer counts for each
+// subgraph.
 typedef struct {
   NodeAndRegistration* node_and_registrations;
   TfLiteEvalTensor* tensors;
+  ScratchBufferHandle* scratch_buffer_handles;
+  int scratch_buffer_request_count_;
 } SubgraphAllocations;
 
 // Allocator responsible for allocating memory for all intermediate tensors
@@ -160,9 +166,8 @@ class MicroAllocator {
   // handles are stored in the out-param `scratch_buffer_handles` array which is
   // allocated in this method. This value will be used in `GetScratchBuffer`
   // call to retrieve scratch buffers.
-  TfLiteStatus FinishModelAllocation(
-      const Model* model, SubgraphAllocations* subgraph_allocations,
-      ScratchBufferHandle** scratch_buffer_handles);
+  TfLiteStatus FinishModelAllocation(const Model* model,
+                                     SubgraphAllocations* subgraph_allocations);
 
   // Allocates a TfLiteTensor struct and populates the returned value with
   // properties from the model flatbuffer. This struct is allocated from
@@ -199,8 +204,9 @@ class MicroAllocator {
   // This method only requests a buffer with a given size to be used after a
   // model has finished allocation via FinishModelAllocation(). All requested
   // buffers will be accessible by the out-param in that method.
-  TfLiteStatus RequestScratchBufferInArena(size_t bytes, int subgraph_idx,
-                                           int* buffer_idx);
+  TfLiteStatus RequestScratchBufferInArena(
+      SubgraphAllocations* subgraph_allocations, size_t bytes, int subgraph_idx,
+      int* buffer_idx);
 
   // Finish allocating a specific NodeAndRegistration prepare block (kernel
   // entry for a model) with a given node ID. This call ensures that any scratch
@@ -291,7 +297,7 @@ class MicroAllocator {
 
   // Holds the number of ScratchBufferRequest instances stored in the head
   // section when a model is allocating.
-  size_t scratch_buffer_request_count_ = 0;
+  size_t total_scratch_requests_ = 0;
 
   // Holds the byte length of the memory plan with the largest head usage. Used
   // to ensure that multi-tenant allocations can share the head for buffers.

--- a/tensorflow/lite/micro/micro_allocator.h
+++ b/tensorflow/lite/micro/micro_allocator.h
@@ -267,7 +267,8 @@ class MicroAllocator {
   // the head section.
   virtual TfLiteStatus CommitStaticMemoryPlan(
       const Model* model, TfLiteEvalTensor* eval_tensors,
-      ScratchBufferHandle* scratch_buffer_handles, int subgraph_idx);
+      ScratchBufferHandle* scratch_buffer_handles, int scratch_request_count,
+      int subgraph_idx);
 
   // Allocates an array of ScratchBufferHandle structs in the tail section for a
   // given number of handles.

--- a/tensorflow/lite/micro/micro_allocator_test.cc
+++ b/tensorflow/lite/micro/micro_allocator_test.cc
@@ -458,10 +458,6 @@ TF_LITE_MICRO_TEST(TestMultiTenantAllocation) {
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
       arena, arena_size, tflite::GetMicroErrorReporter());
   TF_LITE_MICRO_EXPECT_NE(nullptr, allocator);
-  printf("arena used bytes %lu\n", allocator->used_bytes());
-  printf("sizeof(MicroAllocator=%ld\n", sizeof(tflite::MicroAllocator));
-  printf("sizeof(GreedyMemoryPlanner=%ld\n",
-         sizeof(tflite::GreedyMemoryPlanner));
 
   // Allocate for model 1. We use ComplexMockModel here to cover the code path
   // allocatig variables.

--- a/tensorflow/lite/micro/micro_allocator_test.cc
+++ b/tensorflow/lite/micro/micro_allocator_test.cc
@@ -116,7 +116,7 @@ void AllocateAndVerifyMockWeightTensor(
 void EnsureUniqueVariableTensorBuffer(const Model* model,
                                       TfLiteEvalTensor* eval_tensors,
                                       const int variable_tensor_idx) {
-  for (size_t i = 0; i < GetModelTensorCount(model, 0); i++) {
+  for (size_t i = 0; i < GetModelTensorCount(model); i++) {
     if (i != static_cast<size_t>(variable_tensor_idx)) {
       TF_LITE_MICRO_EXPECT_NE(eval_tensors[variable_tensor_idx].data.raw,
                               eval_tensors[i].data.raw);
@@ -325,7 +325,7 @@ TF_LITE_MICRO_TEST(TestMockModelAllocation) {
           /*is_memory_planner_injected=*/false);
   TF_LITE_MICRO_EXPECT_EQ(allocator->used_bytes(), expected_arena_used_bytes);
 
-  size_t model_tensor_size = tflite::testing::GetModelTensorCount(model, 0);
+  size_t model_tensor_size = tflite::testing::GetModelTensorCount(model);
   TF_LITE_MICRO_EXPECT_EQ(static_cast<size_t>(4), model_tensor_size);
 
   tflite::testing::AllocateAndVerifyMockTensor(model, allocator,
@@ -370,7 +370,7 @@ TF_LITE_MICRO_TEST(TestMockModelAllocationWithGivenMemoryPlanner) {
           /*is_memory_planner_injected=*/true);
   TF_LITE_MICRO_EXPECT_EQ(allocator->used_bytes(), expected_arena_used_bytes);
 
-  size_t model_tensor_size = tflite::testing::GetModelTensorCount(model, 0);
+  size_t model_tensor_size = tflite::testing::GetModelTensorCount(model);
   TF_LITE_MICRO_EXPECT_EQ(static_cast<size_t>(4), model_tensor_size);
 
   tflite::testing::AllocateAndVerifyMockTensor(model, allocator,
@@ -538,7 +538,7 @@ TF_LITE_MICRO_TEST(TestAllocationForComplexModelAllocation) {
   TF_LITE_MICRO_EXPECT_EQ(
       kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
-  size_t model_tensor_size = tflite::testing::GetModelTensorCount(model, 0);
+  size_t model_tensor_size = tflite::testing::GetModelTensorCount(model);
   TF_LITE_MICRO_EXPECT_EQ(static_cast<size_t>(10), model_tensor_size);
 
   // NOTE: Tensor indexes match the values in GetComplexMockModel().
@@ -1084,7 +1084,7 @@ TF_LITE_MICRO_TEST(TestMockModelAllocationByNonPersistentMemoryPlannerShim) {
   TF_LITE_MICRO_EXPECT_EQ(
       kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
-  size_t model_tensor_size = tflite::testing::GetModelTensorCount(model, 0);
+  size_t model_tensor_size = tflite::testing::GetModelTensorCount(model);
   TF_LITE_MICRO_EXPECT_EQ(static_cast<size_t>(4), model_tensor_size);
   tflite::testing::AllocateAndVerifyMockWeightTensor(model, allocator,
                                                      subgraph_allocations, 1);

--- a/tensorflow/lite/micro/micro_allocator_test.cc
+++ b/tensorflow/lite/micro/micro_allocator_test.cc
@@ -289,7 +289,6 @@ TF_LITE_MICRO_TEST(TestFailsWhenModelStartsTwice) {
 
 TF_LITE_MICRO_TEST(TestFailsWithWrongSequence) {
   const tflite::Model* model = tflite::testing::GetSimpleMockModel();
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
   tflite::SubgraphAllocations* subgraph_allocations = nullptr;
   constexpr size_t arena_size = 1024;
@@ -299,9 +298,8 @@ TF_LITE_MICRO_TEST(TestFailsWithWrongSequence) {
   TF_LITE_MICRO_EXPECT_NE(nullptr, allocator);
 
   // We can't finish allocation before it ever got started.
-  TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteError, allocator->FinishModelAllocation(
-                        model, subgraph_allocations, &scratch_buffer_handles));
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteError, allocator->FinishModelAllocation(
+                                            model, subgraph_allocations));
 
   // Start twice is not allowed.
   TF_LITE_MICRO_EXPECT(nullptr != allocator->StartModelAllocation(model));
@@ -310,7 +308,6 @@ TF_LITE_MICRO_TEST(TestFailsWithWrongSequence) {
 
 TF_LITE_MICRO_TEST(TestMockModelAllocation) {
   const tflite::Model* model = tflite::testing::GetSimpleMockModel();
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
   constexpr size_t arena_size = 1024;
   uint8_t arena[arena_size];
@@ -321,8 +318,7 @@ TF_LITE_MICRO_TEST(TestMockModelAllocation) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
   size_t expected_arena_used_bytes =
       tflite::testing::GetArenaUsedBytesBySimpleMockModel(
           /*is_memory_planner_injected=*/false);
@@ -356,7 +352,6 @@ TF_LITE_MICRO_TEST(TestMockModelAllocation) {
 
 TF_LITE_MICRO_TEST(TestMockModelAllocationWithGivenMemoryPlanner) {
   const tflite::Model* model = tflite::testing::GetSimpleMockModel();
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
   constexpr size_t arena_size = 1024;
   uint8_t arena[arena_size];
@@ -368,8 +363,7 @@ TF_LITE_MICRO_TEST(TestMockModelAllocationWithGivenMemoryPlanner) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
   size_t expected_arena_used_bytes =
       tflite::testing::GetArenaUsedBytesBySimpleMockModel(
           /*is_memory_planner_injected=*/true);
@@ -412,7 +406,6 @@ TF_LITE_MICRO_TEST(TestMultiTenantAllocation) {
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
       arena, arena_size, tflite::GetMicroErrorReporter());
   TF_LITE_MICRO_EXPECT_NE(nullptr, allocator);
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
 
   // Allocate for model 1. We use ComplexMockModel here to cover the code path
   // allocatig variables.
@@ -420,9 +413,8 @@ TF_LITE_MICRO_TEST(TestMultiTenantAllocation) {
   tflite::SubgraphAllocations* subgraph_allocations1 =
       allocator->StartModelAllocation(model1);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations1);
-  TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model1, subgraph_allocations1,
-                                                  &scratch_buffer_handles));
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, allocator->FinishModelAllocation(
+                                         model1, subgraph_allocations1));
   const size_t single_model_used_bytes = allocator->used_bytes();
 
   // Allocate for model 2.
@@ -430,9 +422,8 @@ TF_LITE_MICRO_TEST(TestMultiTenantAllocation) {
   tflite::SubgraphAllocations* subgraph_allocations2 =
       allocator->StartModelAllocation(model2);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations2);
-  TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model2, subgraph_allocations2,
-                                                  &scratch_buffer_handles));
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, allocator->FinishModelAllocation(
+                                         model2, subgraph_allocations2));
 
   // Allocation for two instances of the same model takes less memory as `head`
   // of the arena is reused.
@@ -441,7 +432,6 @@ TF_LITE_MICRO_TEST(TestMultiTenantAllocation) {
 
 TF_LITE_MICRO_TEST(TestAllocationForModelsWithBranches) {
   const tflite::Model* model = tflite::testing::GetSimpleModelWithBranch();
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
@@ -452,8 +442,7 @@ TF_LITE_MICRO_TEST(TestAllocationForModelsWithBranches) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   uint8_t* start = subgraph_allocations[0].tensors[0].data.uint8;
   // Check test_helpers.cc BuildSimpleModelWithBranch for model structure.
@@ -485,7 +474,6 @@ TF_LITE_MICRO_TEST(TestAllocationForModelsWithBranches) {
 
 TF_LITE_MICRO_TEST(TestAllocationForComplexModelAllocation) {
   const tflite::Model* model = tflite::testing::GetComplexMockModel();
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
   constexpr size_t arena_size = 2048;
   uint8_t arena[arena_size];
@@ -496,8 +484,7 @@ TF_LITE_MICRO_TEST(TestAllocationForComplexModelAllocation) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   size_t model_tensor_size = tflite::testing::GetModelTensorCount(model);
   TF_LITE_MICRO_EXPECT_EQ(static_cast<size_t>(10), model_tensor_size);
@@ -574,8 +561,6 @@ TF_LITE_MICRO_TEST(OfflinePlannerBranchesAllOnline) {
   const tflite::Model* model = tflite::testing::GetModelWithOfflinePlanning(
       number_tensors, metadata_buffer, node_list, number_connections);
 
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
-
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
@@ -585,8 +570,7 @@ TF_LITE_MICRO_TEST(OfflinePlannerBranchesAllOnline) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   // Since all of the tensors are online planned and the model structure is
   // identical to that in TestAllocationForModelsWithBranches,
@@ -629,7 +613,6 @@ TF_LITE_MICRO_TEST(OfflinePlannerBasic) {
   const tflite::Model* model = tflite::testing::GetModelWithOfflinePlanning(
       number_tensors, metadata_buffer, node_list, number_connections);
 
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
@@ -639,8 +622,7 @@ TF_LITE_MICRO_TEST(OfflinePlannerBasic) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   uint8_t* start = subgraph_allocations[0].tensors[0].data.uint8;
   TF_LITE_MICRO_EXPECT_EQ(
@@ -676,7 +658,6 @@ TF_LITE_MICRO_TEST(OfflinePlannerOverlappingAllocation) {
   const tflite::Model* model = tflite::testing::GetModelWithOfflinePlanning(
       number_tensors, metadata_buffer, node_list, number_connections);
 
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
@@ -686,8 +667,7 @@ TF_LITE_MICRO_TEST(OfflinePlannerOverlappingAllocation) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   uint8_t* start = subgraph_allocations[0].tensors[0].data.uint8;
   TF_LITE_MICRO_EXPECT_EQ(
@@ -729,7 +709,6 @@ TF_LITE_MICRO_TEST(OfflinePlannerOfflineOnline) {
   const tflite::Model* model = tflite::testing::GetModelWithOfflinePlanning(
       number_tensors, metadata_buffer, node_list, number_connections);
 
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
@@ -739,8 +718,7 @@ TF_LITE_MICRO_TEST(OfflinePlannerOfflineOnline) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   uint8_t* start = subgraph_allocations[0].tensors[0].data.uint8;
   TF_LITE_MICRO_EXPECT_EQ(
@@ -873,7 +851,6 @@ TF_LITE_MICRO_TEST(TestOperatorInputsNotInSubgraphInputs) {
       number_tensors, metadata_buffer, node_list, number_connections,
       /*Only first tensor (t0) is in subgraph input list=*/1);
 
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
@@ -883,8 +860,7 @@ TF_LITE_MICRO_TEST(TestOperatorInputsNotInSubgraphInputs) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   uint8_t* start = subgraph_allocations[0].tensors[0].data.uint8;
   TF_LITE_MICRO_EXPECT_EQ(
@@ -931,7 +907,6 @@ TF_LITE_MICRO_TEST(TestTypicalFirstOpAndSecondOpWithScratchTensors) {
       number_tensors, metadata_buffer, node_list, number_connections,
       /*Only first tensor (t0) is in subgraph input list=*/1);
 
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
@@ -941,8 +916,7 @@ TF_LITE_MICRO_TEST(TestTypicalFirstOpAndSecondOpWithScratchTensors) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   uint8_t* start = subgraph_allocations[0].tensors[0].data.uint8;
   TF_LITE_MICRO_EXPECT_EQ(
@@ -964,7 +938,6 @@ TF_LITE_MICRO_TEST(TestModelWithUnusedTensors) {
 
   const tflite::Model* model = tflite::testing::GetModelWithUnusedInputs();
 
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
@@ -974,8 +947,7 @@ TF_LITE_MICRO_TEST(TestModelWithUnusedTensors) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   // Unused input tensor should not occupy any space.
   uint8_t* start = subgraph_allocations[0].tensors[2].data.uint8;
@@ -996,7 +968,6 @@ TF_LITE_MICRO_TEST(TestModelWithUnusedOperatorOutputs) {
   const tflite::Model* model =
       tflite::testing::GetModelWithUnusedOperatorOutputs();
 
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
@@ -1006,8 +977,7 @@ TF_LITE_MICRO_TEST(TestModelWithUnusedOperatorOutputs) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   // Unused output tensor should have its own allocation.
   uint8_t* start = subgraph_allocations[0].tensors[1].data.uint8;
@@ -1050,7 +1020,6 @@ TF_LITE_MICRO_TEST(TestMockModelAllocationByNonPersistentMemoryPlannerShim) {
 
   tflite::NonPersistentMemoryPlannerShim planner(non_persistent_buffer_plan);
 
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
   constexpr size_t arena_size = 1024;
   uint8_t arena[arena_size];
@@ -1061,8 +1030,7 @@ TF_LITE_MICRO_TEST(TestMockModelAllocationByNonPersistentMemoryPlannerShim) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   size_t model_tensor_size = tflite::testing::GetModelTensorCount(model);
   TF_LITE_MICRO_EXPECT_EQ(static_cast<size_t>(4), model_tensor_size);

--- a/tensorflow/lite/micro/micro_allocator_test.cc
+++ b/tensorflow/lite/micro/micro_allocator_test.cc
@@ -445,6 +445,10 @@ TF_LITE_MICRO_TEST(TestScratchBufferAllocationMultipleSubgraphs) {
   TF_LITE_MICRO_EXPECT_EQ(subgraph0_tensor1_ptr + 128, subgraph0_tensor0_ptr);
   TF_LITE_MICRO_EXPECT_EQ(subgraph0_tensor0_ptr + 128, subgraph0_scratch_ptr);
   TF_LITE_MICRO_EXPECT_EQ(subgraph1_tensor0_ptr + 128, subgraph1_scratch_ptr);
+
+  // Each subgraph is planned separately, so the first planned tensor in each
+  // (the last, largest tensor) should occupy the same memory.
+  TF_LITE_MICRO_EXPECT_EQ(subgraph0_tensor1_ptr, subgraph1_tensor0_ptr);
 }
 
 TF_LITE_MICRO_TEST(TestMultiTenantAllocation) {

--- a/tensorflow/lite/micro/micro_allocator_test.cc
+++ b/tensorflow/lite/micro/micro_allocator_test.cc
@@ -396,6 +396,57 @@ TF_LITE_MICRO_TEST(TestMockModelAllocationWithGivenMemoryPlanner) {
                                                        /*num_subgraphs=*/1);
 }
 
+TF_LITE_MICRO_TEST(TestScratchBufferAllocationMultipleSubgraphs) {
+  const tflite::Model* model = tflite::testing::GetModelWithTwoSubgraphs();
+  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  constexpr size_t arena_size = 10 * 1024;
+  uint8_t arena[arena_size];
+  tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
+      arena, arena_size, tflite::GetMicroErrorReporter());
+  TF_LITE_MICRO_EXPECT(nullptr != allocator);
+  tflite::SubgraphAllocations* subgraph_allocations =
+      allocator->StartModelAllocation(model);
+  TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
+  for (int subgraph_idx = 0;
+       subgraph_idx < static_cast<int>(model->subgraphs()->size());
+       subgraph_idx++) {
+    int buffer_idx = -1;
+    TF_LITE_MICRO_EXPECT_EQ(
+        kTfLiteOk,
+        allocator->RequestScratchBufferInArena(
+            subgraph_allocations, sizeof(uint8_t), subgraph_idx, &buffer_idx));
+    TF_LITE_MICRO_EXPECT_GE(buffer_idx, 0);
+    allocator->FinishPrepareNodeAllocations(0);
+  }
+  TF_LITE_MICRO_EXPECT_EQ(
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
+
+  // SimpleModelWithSubgraphsAndIf has 1 operators per subgraph and 3 subgraphs:
+  tflite::testing::VerifyRegistrationAndNodeAllocation(subgraph_allocations,
+                                                       /*count=*/1,
+                                                       /*num_subgraphs=*/3);
+
+  uintptr_t subgraph0_tensor0_ptr =
+      reinterpret_cast<uintptr_t>(subgraph_allocations[0].tensors[0].data.raw);
+  uintptr_t subgraph0_tensor1_ptr =
+      reinterpret_cast<uintptr_t>(subgraph_allocations[0].tensors[1].data.raw);
+  uintptr_t subgraph1_tensor0_ptr =
+      reinterpret_cast<uintptr_t>(subgraph_allocations[1].tensors[0].data.raw);
+  uintptr_t subgraph0_scratch_ptr = reinterpret_cast<uintptr_t>(
+      subgraph_allocations[0].scratch_buffer_handles[0].data);
+  uintptr_t subgraph1_scratch_ptr = reinterpret_cast<uintptr_t>(
+      subgraph_allocations[1].scratch_buffer_handles[0].data);
+
+  // The memory layout is expected to be:
+  // subgraph 0:
+  // [tensor1 (128 bytes)] [tensor 0 (128 bytes)] [scratch (16 bytes)]
+  // subgraph 1:
+  // [tensor0 (128 bytes)] [scratch (16 bytes)]
+  TF_LITE_MICRO_EXPECT_EQ(subgraph0_tensor1_ptr + 128, subgraph0_tensor0_ptr);
+  TF_LITE_MICRO_EXPECT_EQ(subgraph0_tensor0_ptr + 128, subgraph0_scratch_ptr);
+  TF_LITE_MICRO_EXPECT_EQ(subgraph1_tensor0_ptr + 128, subgraph1_scratch_ptr);
+}
+
 TF_LITE_MICRO_TEST(TestMultiTenantAllocation) {
   // The `OpResolver` is shared among different models in this test for
   // simplicity but in practice you could have different `OpResolver`.

--- a/tensorflow/lite/micro/micro_context.cc
+++ b/tensorflow/lite/micro/micro_context.cc
@@ -35,13 +35,13 @@ void* MicroContext::AllocatePersistentBuffer(size_t bytes) {
 TfLiteStatus MicroContext::RequestScratchBufferInArena(size_t bytes,
                                                        int* buffer_idx) {
   return allocator_.RequestScratchBufferInArena(
-      graph_.GetAllocations(), bytes, graph_.GetCurrentSubgraphIndex(), buffer_idx);
+      graph_.GetAllocations(), bytes, graph_.GetCurrentSubgraphIndex(),
+      buffer_idx);
 }
 
 void* MicroContext::GetScratchBuffer(int buffer_idx) {
   ScratchBufferHandle* handle =
-      graph_
-          .GetAllocations()[graph_.GetCurrentSubgraphIndex()]
+      graph_.GetAllocations()[graph_.GetCurrentSubgraphIndex()]
           .scratch_buffer_handles +
       buffer_idx;
   return handle->data;

--- a/tensorflow/lite/micro/micro_context.cc
+++ b/tensorflow/lite/micro/micro_context.cc
@@ -40,10 +40,10 @@ TfLiteStatus MicroContext::RequestScratchBufferInArena(size_t bytes,
 }
 
 void* MicroContext::GetScratchBuffer(int buffer_idx) {
+  SubgraphAllocations subgraph_allocations =
+      graph_.GetAllocations()[graph_.GetCurrentSubgraphIndex()];
   ScratchBufferHandle* handle =
-      graph_.GetAllocations()[graph_.GetCurrentSubgraphIndex()]
-          .scratch_buffer_handles +
-      buffer_idx;
+      subgraph_allocations.scratch_buffer_handles + buffer_idx;
   return handle->data;
 }
 

--- a/tensorflow/lite/micro/micro_context.cc
+++ b/tensorflow/lite/micro/micro_context.cc
@@ -35,11 +35,15 @@ void* MicroContext::AllocatePersistentBuffer(size_t bytes) {
 TfLiteStatus MicroContext::RequestScratchBufferInArena(size_t bytes,
                                                        int* buffer_idx) {
   return allocator_.RequestScratchBufferInArena(
-      bytes, graph_.GetCurrentSubgraphIndex(), buffer_idx);
+      graph_.GetAllocations(), bytes, graph_.GetCurrentSubgraphIndex(), buffer_idx);
 }
 
 void* MicroContext::GetScratchBuffer(int buffer_idx) {
-  ScratchBufferHandle* handle = scratch_buffer_handles_ + buffer_idx;
+  ScratchBufferHandle* handle =
+      graph_
+          .GetAllocations()[graph_.GetCurrentSubgraphIndex()]
+          .scratch_buffer_handles +
+      buffer_idx;
   return handle->data;
 }
 
@@ -52,11 +56,6 @@ TfLiteTensor* MicroContext::GetTensor(int tensor_idx) {
 TfLiteEvalTensor* MicroContext::GetEvalTensor(int tensor_idx) {
   return &graph_.GetAllocations()[graph_.GetCurrentSubgraphIndex()]
               .tensors[tensor_idx];
-}
-
-void MicroContext::SetScratchBufferHandles(
-    ScratchBufferHandle* scratch_buffer_handles) {
-  scratch_buffer_handles_ = scratch_buffer_handles;
 }
 
 TfLiteStatus MicroContext::set_external_context(

--- a/tensorflow/lite/micro/micro_context.h
+++ b/tensorflow/lite/micro/micro_context.h
@@ -77,7 +77,6 @@ class MicroContext {
   MicroGraph& graph_;
   const Model* model_;
 
-  ScratchBufferHandle* scratch_buffer_handles_ = nullptr;
   void* external_context_payload_ = nullptr;
 
   TF_LITE_REMOVE_VIRTUAL_DELETE

--- a/tensorflow/lite/micro/micro_context.h
+++ b/tensorflow/lite/micro/micro_context.h
@@ -72,11 +72,6 @@ class MicroContext {
 
   MicroGraph& graph() { return graph_; }
 
-  // Sets the pointer to a list of ScratchBufferHandle instances.
-  // Not API between TFLM and kernels. Primarily used by the framework for
-  // housekeeping in MicroContext.
-  void SetScratchBufferHandles(ScratchBufferHandle* scratch_buffer_handles);
-
  private:
   MicroAllocator& allocator_;
   MicroGraph& graph_;

--- a/tensorflow/lite/micro/micro_interpreter.cc
+++ b/tensorflow/lite/micro/micro_interpreter.cc
@@ -222,13 +222,8 @@ TfLiteStatus MicroInterpreter::AllocateTensors() {
   context_.GetScratchBuffer = MicroContextGetScratchBuffer;
 
   TF_LITE_ENSURE_OK(&context_, allocator_.FinishModelAllocation(
-                                   model_, graph_.GetAllocations(),
-                                   &scratch_buffer_handles_));
+                                   model_, graph_.GetAllocations()));
 
-  micro_context_.SetScratchBufferHandles(scratch_buffer_handles_);
-
-  // TODO(b/162311891): Drop these allocations when the interpreter supports
-  // handling buffers from TfLiteEvalTensor.
   input_tensors_ =
       reinterpret_cast<TfLiteTensor**>(allocator_.AllocatePersistentBuffer(
           sizeof(TfLiteTensor*) * inputs_size()));
@@ -251,8 +246,6 @@ TfLiteStatus MicroInterpreter::AllocateTensors() {
     }
   }
 
-  // TODO(b/162311891): Drop these allocations when the interpreter supports
-  // handling buffers from TfLiteEvalTensor.
   output_tensors_ =
       reinterpret_cast<TfLiteTensor**>(allocator_.AllocatePersistentBuffer(
           sizeof(TfLiteTensor*) * outputs_size()));

--- a/tensorflow/lite/micro/micro_interpreter.h
+++ b/tensorflow/lite/micro/micro_interpreter.h
@@ -157,7 +157,7 @@ class MicroInterpreter {
 
   TfLiteStatus initialization_status_;
 
-  ScratchBufferHandle* scratch_buffer_handles_ = nullptr;
+  void* external_context_payload_ = nullptr;
 
   // TODO(b/162311891): Clean these pointers up when this class supports buffers
   // from TfLiteEvalTensor.

--- a/tensorflow/lite/micro/micro_interpreter.h
+++ b/tensorflow/lite/micro/micro_interpreter.h
@@ -157,8 +157,6 @@ class MicroInterpreter {
 
   TfLiteStatus initialization_status_;
 
-  void* external_context_payload_ = nullptr;
-
   // TODO(b/162311891): Clean these pointers up when this class supports buffers
   // from TfLiteEvalTensor.
   TfLiteTensor** input_tensors_;

--- a/tensorflow/lite/micro/recording_micro_allocator_test.cc
+++ b/tensorflow/lite/micro/recording_micro_allocator_test.cc
@@ -67,7 +67,7 @@ TF_LITE_MICRO_TEST(TestRecordsTfLiteEvalTensorArrayData) {
 
   micro_allocator->PrintAllocations();
 
-  size_t tensors_count = tflite::testing::GetModelTensorCount(model);
+  size_t tensors_count = tflite::testing::GetModelTensorCount(model, 0);
 
   TF_LITE_MICRO_EXPECT_EQ(recorded_allocation.count, tensors_count);
   TF_LITE_MICRO_EXPECT_EQ(recorded_allocation.requested_bytes,
@@ -144,7 +144,7 @@ TF_LITE_MICRO_TEST(TestRecordsMultiTenantAllocations) {
   TF_LITE_MICRO_EXPECT_EQ(status, kTfLiteOk);
   if (status != kTfLiteOk) return 1;
 
-  size_t tensors_count = tflite::testing::GetModelTensorCount(model);
+  size_t tensors_count = tflite::testing::GetModelTensorCount(model, 0);
 
   tflite::RecordedAllocation recorded_allocation =
       micro_allocator->GetRecordedAllocation(

--- a/tensorflow/lite/micro/recording_micro_allocator_test.cc
+++ b/tensorflow/lite/micro/recording_micro_allocator_test.cc
@@ -37,7 +37,6 @@ constexpr int kTestConvArenaSize = 1024 * 12;
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestRecordsTfLiteEvalTensorArrayData) {
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::AllOpsResolver all_ops_resolver;
   const tflite::Model* model = tflite::GetModel(kTestConvModelData);
   uint8_t arena[kTestConvArenaSize];
@@ -55,8 +54,8 @@ TF_LITE_MICRO_TEST(TestRecordsTfLiteEvalTensorArrayData) {
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   if (subgraph_allocations == nullptr) return 1;
 
-  TfLiteStatus status = micro_allocator->FinishModelAllocation(
-      model, subgraph_allocations, &scratch_buffer_handles);
+  TfLiteStatus status =
+      micro_allocator->FinishModelAllocation(model, subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(status, kTfLiteOk);
   if (status != kTfLiteOk) return 1;
 
@@ -78,7 +77,6 @@ TF_LITE_MICRO_TEST(TestRecordsTfLiteEvalTensorArrayData) {
 }
 
 TF_LITE_MICRO_TEST(TestRecordsNodeAndRegistrationArrayData) {
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::AllOpsResolver all_ops_resolver;
   const tflite::Model* model = tflite::GetModel(kTestConvModelData);
   uint8_t arena[kTestConvArenaSize];
@@ -94,8 +92,8 @@ TF_LITE_MICRO_TEST(TestRecordsNodeAndRegistrationArrayData) {
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   if (subgraph_allocations == nullptr) return 1;
 
-  TfLiteStatus status = micro_allocator->FinishModelAllocation(
-      model, subgraph_allocations, &scratch_buffer_handles);
+  TfLiteStatus status =
+      micro_allocator->FinishModelAllocation(model, subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(status, kTfLiteOk);
   if (status != kTfLiteOk) return 1;
 
@@ -112,7 +110,6 @@ TF_LITE_MICRO_TEST(TestRecordsNodeAndRegistrationArrayData) {
 }
 
 TF_LITE_MICRO_TEST(TestRecordsMultiTenantAllocations) {
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::AllOpsResolver all_ops_resolver;
   const tflite::Model* model = tflite::GetModel(kTestConvModelData);
 
@@ -133,8 +130,7 @@ TF_LITE_MICRO_TEST(TestRecordsMultiTenantAllocations) {
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   if (subgraph_allocations == nullptr) return 1;
 
-  status = micro_allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles);
+  status = micro_allocator->FinishModelAllocation(model, subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(status, kTfLiteOk);
   if (status != kTfLiteOk) return 1;
 
@@ -143,8 +139,8 @@ TF_LITE_MICRO_TEST(TestRecordsMultiTenantAllocations) {
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   if (subgraph_allocations == nullptr) return 1;
 
-  status = kTfLiteOk, micro_allocator->FinishModelAllocation(
-                          model, subgraph_allocations, &scratch_buffer_handles);
+  status = kTfLiteOk,
+  micro_allocator->FinishModelAllocation(model, subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(status, kTfLiteOk);
   if (status != kTfLiteOk) return 1;
 

--- a/tensorflow/lite/micro/recording_micro_allocator_test.cc
+++ b/tensorflow/lite/micro/recording_micro_allocator_test.cc
@@ -67,7 +67,7 @@ TF_LITE_MICRO_TEST(TestRecordsTfLiteEvalTensorArrayData) {
 
   micro_allocator->PrintAllocations();
 
-  size_t tensors_count = tflite::testing::GetModelTensorCount(model, 0);
+  size_t tensors_count = tflite::testing::GetModelTensorCount(model);
 
   TF_LITE_MICRO_EXPECT_EQ(recorded_allocation.count, tensors_count);
   TF_LITE_MICRO_EXPECT_EQ(recorded_allocation.requested_bytes,
@@ -144,7 +144,7 @@ TF_LITE_MICRO_TEST(TestRecordsMultiTenantAllocations) {
   TF_LITE_MICRO_EXPECT_EQ(status, kTfLiteOk);
   if (status != kTfLiteOk) return 1;
 
-  size_t tensors_count = tflite::testing::GetModelTensorCount(model, 0);
+  size_t tensors_count = tflite::testing::GetModelTensorCount(model);
 
   tflite::RecordedAllocation recorded_allocation =
       micro_allocator->GetRecordedAllocation(

--- a/tensorflow/lite/micro/test_helpers.cc
+++ b/tensorflow/lite/micro/test_helpers.cc
@@ -1831,10 +1831,10 @@ TfLiteTensor CreateSymmetricPerChannelQuantizedTensor(
   return result;
 }
 
-size_t GetModelTensorCount(const Model* model, int subgraph_idx) {
+size_t GetModelTensorCount(const Model* model) {
   auto* subgraphs = model->subgraphs();
   if (subgraphs) {
-    return (*subgraphs)[subgraph_idx]->tensors()->size();
+    return (*subgraphs)[0]->tensors()->size();
   }
   return 0;
 }

--- a/tensorflow/lite/micro/test_helpers.cc
+++ b/tensorflow/lite/micro/test_helpers.cc
@@ -1756,10 +1756,10 @@ TfLiteTensor CreateSymmetricPerChannelQuantizedTensor(
   return result;
 }
 
-size_t GetModelTensorCount(const Model* model) {
+size_t GetModelTensorCount(const Model* model, int subgraph_idx) {
   auto* subgraphs = model->subgraphs();
   if (subgraphs) {
-    return (*subgraphs)[0]->tensors()->size();
+    return (*subgraphs)[subgraph_idx]->tensors()->size();
   }
   return 0;
 }

--- a/tensorflow/lite/micro/test_helpers.h
+++ b/tensorflow/lite/micro/test_helpers.h
@@ -161,7 +161,8 @@ const Model* GetSimpleModelWithSubgraphsAndIf();
 // of "if" subgraph overlaps with the input tensor 2 of subgraph 1.
 const Model* GetModelWithIfAndSubgraphInputTensorOverlap();
 
-// Returns a flatbuffer model with two subgraphs.
+// Returns a flatbuffer model with two subgraphs. Subgraph 0 has two tensors
+// and subgraph 1 has one tensor.
 const Model* GetModelWithTwoSubgraphs();
 
 // Returns a flatbuffer model with null subgraph/operator inputs and outputs.
@@ -274,8 +275,8 @@ TfLiteTensor CreateSymmetricPerChannelQuantizedTensor(
     int* zero_points, TfLiteAffineQuantization* affine_quant,
     int quantized_dimension, bool is_variable = false);
 
-// Returns the number of tensors in the given subgraph for a tflite::Model.
-size_t GetModelTensorCount(const Model* model, int subgraph_idx);
+// Returns the number of tensors in the default subgraph for a tflite::Model.
+size_t GetModelTensorCount(const Model* model);
 
 // Derives the quantization scaling factor from a min and max range.
 template <typename T>

--- a/tensorflow/lite/micro/test_helpers.h
+++ b/tensorflow/lite/micro/test_helpers.h
@@ -271,8 +271,8 @@ TfLiteTensor CreateSymmetricPerChannelQuantizedTensor(
     int* zero_points, TfLiteAffineQuantization* affine_quant,
     int quantized_dimension, bool is_variable = false);
 
-// Returns the number of tensors in the default subgraph for a tflite::Model.
-size_t GetModelTensorCount(const Model* model);
+// Returns the number of tensors in the given subgraph for a tflite::Model.
+size_t GetModelTensorCount(const Model* model, int subgraph_idx);
 
 // Derives the quantization scaling factor from a min and max range.
 template <typename T>

--- a/tensorflow/lite/micro/test_helpers.h
+++ b/tensorflow/lite/micro/test_helpers.h
@@ -161,6 +161,9 @@ const Model* GetSimpleModelWithSubgraphsAndIf();
 // of "if" subgraph overlaps with the input tensor 2 of subgraph 1.
 const Model* GetModelWithIfAndSubgraphInputTensorOverlap();
 
+// Returns a flatbuffer model with two subgraphs.
+const Model* GetModelWithTwoSubgraphs();
+
 // Returns a flatbuffer model with null subgraph/operator inputs and outputs.
 const Model* GetSimpleModelWithNullInputsAndOutputs();
 


### PR DESCRIPTION
Allocate scratch buffers separately for each subgraph. This avoids
allocating extra memory, and fixes correctness bugs where scratch arrays
were allocated multiple times, causing scratch buffers to be invalid in
all subgraphs except the last run during allocation (maximum index).

TESTED=ran release test which failed previously, verified scratch
buffers are only allocated once.

BUG=http://b/211906909