### PR TITLE
Review approval applies tags

### DIFF
--- a/.github/workflows/ready_to_merge_apply.yml
+++ b/.github/workflows/ready_to_merge_apply.yml
@@ -1,0 +1,56 @@
+name: Ready To Merge Apply
+
+###
+#
+# Applies ci:ready_to_merge tag on pr number set in an artifact by ready_to_merge_trigger.yml.
+# Please see comments in that file for more
+#
+###
+
+on:
+  workflow_run:
+    workflows: ["Ready To Merge Trigger"]
+    types:
+      - completed
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      - run: unzip pr.zip
+
+      - name: 'add label'
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var fs = require('fs');
+            var issue_number = Number(fs.readFileSync('./NR'));
+            await github.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              labels: ['ci:ready_to_merge','ci:run']
+            });

--- a/.github/workflows/ready_to_merge_trigger.yml
+++ b/.github/workflows/ready_to_merge_trigger.yml
@@ -1,0 +1,37 @@
+name: Ready To Merge Trigger
+
+###
+#
+# On an approved review, stores the PR number as an artifact. Success triggers
+# ready_to_merge_apply, which will apply the ci:ready_to_merge tag to the pr. The two step
+# process is to deal with issues around permissions related to triggers originating from
+# the context of a PR from a fork.
+# A good deal of this code comes from github's recommendations at:
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+#
+###
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  send_pr:
+    runs-on: ubuntu-latest
+    name: archive pr number
+    if: github.event.review.state == 'approved'
+
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - run: echo ${{ github.event.review.state }}
+      - name: save pr number
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.pull_request.number }} > ./pr/NR
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/


### PR DESCRIPTION
Upon an approved review, the ci:run and ci:ready_to_merge tags are applied to the pr. 

This is a touch unwieldy and took a bit to figure out because it has to be two different files, ready_to_merge_apply and ready_to_merge trigger. This is due to the permissions issues around changing labels on PRs coming from forks. The pull_request_review trigger doesn't have the privilege escalation features of pull_request_target, thus the labeling portion has to handed off to another job triggered by workflow_run. 

These files can't be consolidated because workflow_run triggers on workflows, not jobs.

And the ugly bit with passing the pr number by artifacts is that the workflow_run event doesn't have a PR source, so you have to pass it in. There is no practical way you could get a false launch with this setup, although I think you could possibly end up with a situation where an approved review doesn't get tagged if you approve a spate of PRs and one gets delayed exactly correctly for the artifact to be overwritten by the following pr at the precise point between writing the artifact and reading it. I don't think this is a particularly high probability event and the worst case scenario is you will have to add the tags manually to some random PR out of a string.

BUG=https://issuetracker.google.com/issues/210946861