### PR TITLE
Initialize input multiplier properly for tanh and logistic

### DIFF
--- a/tensorflow/lite/micro/kernels/logistic_common.cc
+++ b/tensorflow/lite/micro/kernels/logistic_common.cc
@@ -74,7 +74,9 @@ TfLiteStatus CalculateArithmeticOpDataLogistic(TfLiteContext* context,
         (15 - kInputIntegerBits) + input_scale_log2_rounded;
     param_scale_pot &= (data->input_left_shift == 0);
 
-    if (!param_scale_pot) {
+    if (param_scale_pot) {
+      data->input_multiplier = 0;
+    } else {
       // Calculate multiplier to change input scale to 1/(3*4096)
       // as required by the table lookup.
       // In this scaling +/-2^17 represents +/-10.7

--- a/tensorflow/lite/micro/kernels/tanh.cc
+++ b/tensorflow/lite/micro/kernels/tanh.cc
@@ -95,7 +95,9 @@ TfLiteStatus CalculateArithmeticOpData(TfLiteContext* context, TfLiteNode* node,
     param_scale_pot &=
         (data->input_left_shift == 0 || data->input_left_shift == 1);
 
-    if (!param_scale_pot) {
+    if (param_scale_pot) {
+      data->input_multiplier = 0;
+    } else {
       // Calculate multiplier to change input scale to 1/(3*4096)
       // as required by the table lookup.
       // The number 3.0 in the multiplier comes from here,


### PR DESCRIPTION
There is no guarantee that Opdata is initialized to zero upon
entry into the prepare function. Therefore, the input multiplier
needs to be initialized explicitly under all conditions.

BUG=#286
