### PR TITLE
Store scratch buffer arrays separately for each subgraph.

### DIFF
--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -564,6 +564,7 @@ SubgraphAllocations* MicroAllocator::StartModelAllocation(const Model* model) {
     MicroPrintf("Failed to allocate memory for model metadata.");
     return nullptr;
   }
+  memset(output, 0, sizeof(SubgraphAllocations) * model->subgraphs()->size());
 
   if (AllocateTfLiteEvalTensors(model, output) != kTfLiteOk ||
       AllocateNodeAndRegistrations(model, output) != kTfLiteOk) {

--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -107,7 +107,7 @@ class AllocationInfoBuilder {
   // Add allocation information for the scratch buffers.
   TfLiteStatus AddScratchBuffers(
       internal::ScratchBufferRequest* scratch_buffer_requests,
-      ScratchBufferHandle* scratch_buffer_handles);
+      ScratchBufferHandle* scratch_buffer_handles, int subgraph_idx);
 
   // Returns a pointer to the built AllocationInfo array.
   const AllocationInfo* Finish() const { return info_; }
@@ -221,21 +221,24 @@ TfLiteStatus AllocationInfoBuilder::GetOfflinePlannedOffsets(
 
 TfLiteStatus AllocationInfoBuilder::AddScratchBuffers(
     internal::ScratchBufferRequest* scratch_buffer_requests,
-    ScratchBufferHandle* scratch_buffer_handles) {
+    ScratchBufferHandle* scratch_buffer_handles, int subgraph_idx) {
   // Set up allocation info for buffers.
-  for (size_t i = tensor_count_; i < tensor_count_ + buffer_count_; ++i) {
+  for (size_t i = 0, buffers_added = 0; i < buffer_count_; ++i) {
     internal::ScratchBufferRequest* current_request =
-        &(scratch_buffer_requests[i - tensor_count_]);
-    ScratchBufferHandle* current_handle =
-        &(scratch_buffer_handles[i - tensor_count_]);
+        &(scratch_buffer_requests[i]);
+    if (current_request->subgraph_idx == subgraph_idx) {
+      ScratchBufferHandle* current_handle =
+          &(scratch_buffer_handles[buffers_added]);
 
-    AllocationInfo* current = &info_[i];
-    current->output_ptr = reinterpret_cast<void**>(&current_handle->data);
-    current->bytes = current_request->bytes;
-    current->first_created = current_request->node_idx;
-    current->last_used = current_request->node_idx;
-    current->offline_offset = kOnlinePlannedBuffer;
-    current->needs_allocating = true;
+      AllocationInfo* current = &info_[tensor_count_ + buffers_added];
+      current->output_ptr = reinterpret_cast<void**>(&current_handle->data);
+      current->bytes = current_request->bytes;
+      current->first_created = current_request->node_idx;
+      current->last_used = current_request->node_idx;
+      current->offline_offset = kOnlinePlannedBuffer;
+      current->needs_allocating = true;
+      buffers_added++;
+    }
   }
   return kTfLiteOk;
 }
@@ -570,8 +573,7 @@ SubgraphAllocations* MicroAllocator::StartModelAllocation(const Model* model) {
 }
 
 TfLiteStatus MicroAllocator::FinishModelAllocation(
-    const Model* model, SubgraphAllocations* subgraph_allocations,
-    ScratchBufferHandle** scratch_buffer_handles) {
+    const Model* model, SubgraphAllocations* subgraph_allocations) {
   if (!model_is_allocating_) {
     TF_LITE_REPORT_ERROR(error_reporter_,
                          "MicroAllocator: Model allocation finished before "
@@ -586,10 +588,12 @@ TfLiteStatus MicroAllocator::FinishModelAllocation(
     TFLITE_DCHECK(subgraph != nullptr);
 
     TF_LITE_ENSURE_STATUS(AllocateScratchBufferHandles(
-        scratch_buffer_handles, scratch_buffer_request_count_));
+        &subgraph_allocations[subgraph_idx].scratch_buffer_handles,
+        subgraph_allocations[subgraph_idx].scratch_buffer_request_count_));
     TF_LITE_ENSURE_STATUS(CommitStaticMemoryPlan(
         model, subgraph_allocations[subgraph_idx].tensors,
-        *scratch_buffer_handles, subgraph_idx));
+        subgraph_allocations[subgraph_idx].scratch_buffer_handles,
+        subgraph_idx));
     TF_LITE_ENSURE_STATUS(AllocateVariables(
         subgraph, subgraph_allocations[subgraph_idx].tensors));
   }
@@ -602,9 +606,9 @@ void* MicroAllocator::AllocatePersistentBuffer(size_t bytes) {
                                              MicroArenaBufferAlignment());
 }
 
-TfLiteStatus MicroAllocator::RequestScratchBufferInArena(size_t bytes,
-                                                         int subgraph_idx,
-                                                         int* buffer_idx) {
+TfLiteStatus MicroAllocator::RequestScratchBufferInArena(
+    SubgraphAllocations* subgraph_allocations, size_t bytes, int subgraph_idx,
+    int* buffer_idx) {
   // All scratch buffer requests are stored in the head section of the arena
   // when a model is in the prepare phase. First align a scratch buffer request
   // pointer to the start of the head:
@@ -612,7 +616,7 @@ TfLiteStatus MicroAllocator::RequestScratchBufferInArena(size_t bytes,
 
   // Count the number of requested scratch buffers for the current node:
   size_t current_node_request_count = 0;
-  for (size_t i = 0; i < scratch_buffer_request_count_; ++i) {
+  for (size_t i = 0; i < total_scratch_requests_; ++i) {
     if (requests[i].node_idx == kUnassignedScratchBufferRequestIndex) {
       ++current_node_request_count;
     }
@@ -629,18 +633,20 @@ TfLiteStatus MicroAllocator::RequestScratchBufferInArena(size_t bytes,
 
   // Initialize and assign values for the request at the current index:
   internal::ScratchBufferRequest* current_request =
-      &requests[scratch_buffer_request_count_];
+      &requests[total_scratch_requests_];
   *current_request = {};
   // Assign -1 as a sentinel value that will be updated when the node finishes
   // allocating:
   current_request->bytes = bytes;
+  current_request->subgraph_idx = subgraph_idx;
+  subgraph_allocations[subgraph_idx].scratch_buffer_request_count_++;
   current_request->node_idx = kUnassignedScratchBufferRequestIndex;
 
   // Assign the current request index to the out-param:
-  *buffer_idx = scratch_buffer_request_count_;
+  *buffer_idx = total_scratch_requests_;
 
   // Bump the request count to prepare for the next request:
-  ++scratch_buffer_request_count_;
+  ++total_scratch_requests_;
   return kTfLiteOk;
 }
 
@@ -652,7 +658,7 @@ TfLiteStatus MicroAllocator::FinishPrepareNodeAllocations(int node_id) {
   // Find and update any new scratch buffer requests for the current node:
   internal::ScratchBufferRequest* requests = GetScratchBufferRequests();
 
-  for (size_t i = 0; i < scratch_buffer_request_count_; ++i) {
+  for (size_t i = 0; i < total_scratch_requests_; ++i) {
     // A request with a node_idx of -1 is a sentinel value used to indicate this
     // was a new request for the current node. The allocator finally knows the
     // node index at this point. Assign the value and update the list of new
@@ -667,7 +673,7 @@ TfLiteStatus MicroAllocator::FinishPrepareNodeAllocations(int node_id) {
   // kMaxScratchBuffersPerOp scratch buffer requests in the next operator:
   TF_LITE_ENSURE_STATUS(memory_allocator_->SetHeadBufferSize(
       sizeof(internal::ScratchBufferRequest) *
-          (scratch_buffer_request_count_ + kMaxScratchBuffersPerOp),
+          (total_scratch_requests_ + kMaxScratchBuffersPerOp),
       alignof(internal::ScratchBufferRequest)));
 
   return kTfLiteOk;
@@ -906,7 +912,7 @@ TfLiteStatus MicroAllocator::CommitStaticMemoryPlan(
 
   const SubGraph* subgraph = model->subgraphs()->Get(subgraph_idx);
   size_t allocation_info_count =
-      subgraph->tensors()->size() + scratch_buffer_request_count_;
+      subgraph->tensors()->size() + total_scratch_requests_;
   size_t bytes = sizeof(AllocationInfo) * allocation_info_count;
 
   // Allocate an array of AllocationInfo structs from the temp section. This
@@ -924,7 +930,7 @@ TfLiteStatus MicroAllocator::CommitStaticMemoryPlan(
   // Use the AllocationInfoBuilder class to help determine where buffers are
   // used in the subgraph.
   AllocationInfoBuilder builder(allocation_info, subgraph->tensors()->size(),
-                                scratch_buffer_request_count_, error_reporter_);
+                                total_scratch_requests_, error_reporter_);
 
   const int32_t* offline_planner_offsets = nullptr;
   TF_LITE_ENSURE_STATUS(
@@ -935,8 +941,8 @@ TfLiteStatus MicroAllocator::CommitStaticMemoryPlan(
   internal::ScratchBufferRequest* scratch_buffer_requests =
       GetScratchBufferRequests();
 
-  TF_LITE_ENSURE_STATUS(builder.AddScratchBuffers(scratch_buffer_requests,
-                                                  scratch_buffer_handles));
+  TF_LITE_ENSURE_STATUS(builder.AddScratchBuffers(
+      scratch_buffer_requests, scratch_buffer_handles, subgraph_idx));
 
   // Remaining arena size that memory planner can use for calculating offsets.
   size_t remaining_arena_size =
@@ -996,7 +1002,7 @@ TfLiteStatus MicroAllocator::AllocateScratchBufferHandles(
     ScratchBufferHandle** scratch_buffer_handles, size_t handle_count) {
   TFLITE_DCHECK(scratch_buffer_handles != nullptr);
 
-  if (scratch_buffer_request_count_ == 0) {
+  if (total_scratch_requests_ == 0) {
     // No scratch buffer requests were requested during model allocation.
     return kTfLiteOk;
   }
@@ -1014,7 +1020,7 @@ TfLiteStatus MicroAllocator::AllocateScratchBufferHandles(
 TfLiteStatus MicroAllocator::InitScratchBufferData() {
   // A model is preparing to allocate resources, ensure that scratch buffer
   // request counter is cleared:
-  scratch_buffer_request_count_ = 0;
+  total_scratch_requests_ = 0;
 
   // All requests will be stored in the head section. Each kernel is allowed at
   // most kMaxScratchBuffersPerOp requests. Adjust the head to reserve at most

--- a/tensorflow/lite/micro/micro_allocator_test.cc
+++ b/tensorflow/lite/micro/micro_allocator_test.cc
@@ -289,7 +289,6 @@ TF_LITE_MICRO_TEST(TestFailsWhenModelStartsTwice) {
 
 TF_LITE_MICRO_TEST(TestFailsWithWrongSequence) {
   const tflite::Model* model = tflite::testing::GetSimpleMockModel();
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
   tflite::SubgraphAllocations* subgraph_allocations = nullptr;
   constexpr size_t arena_size = 1024;
@@ -299,9 +298,8 @@ TF_LITE_MICRO_TEST(TestFailsWithWrongSequence) {
   TF_LITE_MICRO_EXPECT_NE(nullptr, allocator);
 
   // We can't finish allocation before it ever got started.
-  TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteError, allocator->FinishModelAllocation(
-                        model, subgraph_allocations, &scratch_buffer_handles));
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteError, allocator->FinishModelAllocation(
+                                            model, subgraph_allocations));
 
   // Start twice is not allowed.
   TF_LITE_MICRO_EXPECT(nullptr != allocator->StartModelAllocation(model));
@@ -310,7 +308,6 @@ TF_LITE_MICRO_TEST(TestFailsWithWrongSequence) {
 
 TF_LITE_MICRO_TEST(TestMockModelAllocation) {
   const tflite::Model* model = tflite::testing::GetSimpleMockModel();
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
   constexpr size_t arena_size = 1024;
   uint8_t arena[arena_size];
@@ -321,8 +318,7 @@ TF_LITE_MICRO_TEST(TestMockModelAllocation) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
   size_t expected_arena_used_bytes =
       tflite::testing::GetArenaUsedBytesBySimpleMockModel(
           /*is_memory_planner_injected=*/false);
@@ -356,7 +352,6 @@ TF_LITE_MICRO_TEST(TestMockModelAllocation) {
 
 TF_LITE_MICRO_TEST(TestMockModelAllocationWithGivenMemoryPlanner) {
   const tflite::Model* model = tflite::testing::GetSimpleMockModel();
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
   constexpr size_t arena_size = 1024;
   uint8_t arena[arena_size];
@@ -368,8 +363,7 @@ TF_LITE_MICRO_TEST(TestMockModelAllocationWithGivenMemoryPlanner) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
   size_t expected_arena_used_bytes =
       tflite::testing::GetArenaUsedBytesBySimpleMockModel(
           /*is_memory_planner_injected=*/true);
@@ -412,7 +406,6 @@ TF_LITE_MICRO_TEST(TestMultiTenantAllocation) {
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
       arena, arena_size, tflite::GetMicroErrorReporter());
   TF_LITE_MICRO_EXPECT_NE(nullptr, allocator);
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
 
   // Allocate for model 1. We use ComplexMockModel here to cover the code path
   // allocatig variables.
@@ -420,9 +413,8 @@ TF_LITE_MICRO_TEST(TestMultiTenantAllocation) {
   tflite::SubgraphAllocations* subgraph_allocations1 =
       allocator->StartModelAllocation(model1);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations1);
-  TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model1, subgraph_allocations1,
-                                                  &scratch_buffer_handles));
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, allocator->FinishModelAllocation(
+                                         model1, subgraph_allocations1));
   const size_t single_model_used_bytes = allocator->used_bytes();
 
   // Allocate for model 2.
@@ -430,9 +422,8 @@ TF_LITE_MICRO_TEST(TestMultiTenantAllocation) {
   tflite::SubgraphAllocations* subgraph_allocations2 =
       allocator->StartModelAllocation(model2);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations2);
-  TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model2, subgraph_allocations2,
-                                                  &scratch_buffer_handles));
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, allocator->FinishModelAllocation(
+                                         model2, subgraph_allocations2));
 
   // Allocation for two instances of the same model takes less memory as `head`
   // of the arena is reused.
@@ -441,7 +432,6 @@ TF_LITE_MICRO_TEST(TestMultiTenantAllocation) {
 
 TF_LITE_MICRO_TEST(TestAllocationForModelsWithBranches) {
   const tflite::Model* model = tflite::testing::GetSimpleModelWithBranch();
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
@@ -452,8 +442,7 @@ TF_LITE_MICRO_TEST(TestAllocationForModelsWithBranches) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   uint8_t* start = subgraph_allocations[0].tensors[0].data.uint8;
   // Check test_helpers.cc BuildSimpleModelWithBranch for model structure.
@@ -485,7 +474,6 @@ TF_LITE_MICRO_TEST(TestAllocationForModelsWithBranches) {
 
 TF_LITE_MICRO_TEST(TestAllocationForComplexModelAllocation) {
   const tflite::Model* model = tflite::testing::GetComplexMockModel();
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
   constexpr size_t arena_size = 2048;
   uint8_t arena[arena_size];
@@ -496,8 +484,7 @@ TF_LITE_MICRO_TEST(TestAllocationForComplexModelAllocation) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   size_t model_tensor_size = tflite::testing::GetModelTensorCount(model);
   TF_LITE_MICRO_EXPECT_EQ(static_cast<size_t>(10), model_tensor_size);
@@ -574,8 +561,6 @@ TF_LITE_MICRO_TEST(OfflinePlannerBranchesAllOnline) {
   const tflite::Model* model = tflite::testing::GetModelWithOfflinePlanning(
       number_tensors, metadata_buffer, node_list, number_connections);
 
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
-
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
@@ -585,8 +570,7 @@ TF_LITE_MICRO_TEST(OfflinePlannerBranchesAllOnline) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   // Since all of the tensors are online planned and the model structure is
   // identical to that in TestAllocationForModelsWithBranches,
@@ -629,7 +613,6 @@ TF_LITE_MICRO_TEST(OfflinePlannerBasic) {
   const tflite::Model* model = tflite::testing::GetModelWithOfflinePlanning(
       number_tensors, metadata_buffer, node_list, number_connections);
 
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
@@ -639,8 +622,7 @@ TF_LITE_MICRO_TEST(OfflinePlannerBasic) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   uint8_t* start = subgraph_allocations[0].tensors[0].data.uint8;
   TF_LITE_MICRO_EXPECT_EQ(
@@ -676,7 +658,6 @@ TF_LITE_MICRO_TEST(OfflinePlannerOverlappingAllocation) {
   const tflite::Model* model = tflite::testing::GetModelWithOfflinePlanning(
       number_tensors, metadata_buffer, node_list, number_connections);
 
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
@@ -686,8 +667,7 @@ TF_LITE_MICRO_TEST(OfflinePlannerOverlappingAllocation) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   uint8_t* start = subgraph_allocations[0].tensors[0].data.uint8;
   TF_LITE_MICRO_EXPECT_EQ(
@@ -729,7 +709,6 @@ TF_LITE_MICRO_TEST(OfflinePlannerOfflineOnline) {
   const tflite::Model* model = tflite::testing::GetModelWithOfflinePlanning(
       number_tensors, metadata_buffer, node_list, number_connections);
 
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
@@ -739,8 +718,7 @@ TF_LITE_MICRO_TEST(OfflinePlannerOfflineOnline) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   uint8_t* start = subgraph_allocations[0].tensors[0].data.uint8;
   TF_LITE_MICRO_EXPECT_EQ(
@@ -904,7 +882,6 @@ TF_LITE_MICRO_TEST(TestOperatorInputsNotInSubgraphInputs) {
       number_tensors, metadata_buffer, node_list, number_connections,
       /*Only first tensor (t0) is in subgraph input list=*/1);
 
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
@@ -914,8 +891,7 @@ TF_LITE_MICRO_TEST(TestOperatorInputsNotInSubgraphInputs) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   uint8_t* start = subgraph_allocations[0].tensors[0].data.uint8;
   TF_LITE_MICRO_EXPECT_EQ(
@@ -962,7 +938,6 @@ TF_LITE_MICRO_TEST(TestTypicalFirstOpAndSecondOpWithScratchTensors) {
       number_tensors, metadata_buffer, node_list, number_connections,
       /*Only first tensor (t0) is in subgraph input list=*/1);
 
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
@@ -972,8 +947,7 @@ TF_LITE_MICRO_TEST(TestTypicalFirstOpAndSecondOpWithScratchTensors) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   uint8_t* start = subgraph_allocations[0].tensors[0].data.uint8;
   TF_LITE_MICRO_EXPECT_EQ(
@@ -995,7 +969,6 @@ TF_LITE_MICRO_TEST(TestModelWithUnusedTensors) {
 
   const tflite::Model* model = tflite::testing::GetModelWithUnusedInputs();
 
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
@@ -1005,8 +978,7 @@ TF_LITE_MICRO_TEST(TestModelWithUnusedTensors) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   // Unused input tensor should not occupy any space.
   uint8_t* start = subgraph_allocations[0].tensors[2].data.uint8;
@@ -1027,7 +999,6 @@ TF_LITE_MICRO_TEST(TestModelWithUnusedOperatorOutputs) {
   const tflite::Model* model =
       tflite::testing::GetModelWithUnusedOperatorOutputs();
 
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator = tflite::MicroAllocator::Create(
@@ -1037,8 +1008,7 @@ TF_LITE_MICRO_TEST(TestModelWithUnusedOperatorOutputs) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   // Unused output tensor should have its own allocation.
   uint8_t* start = subgraph_allocations[0].tensors[1].data.uint8;
@@ -1081,7 +1051,6 @@ TF_LITE_MICRO_TEST(TestMockModelAllocationByNonPersistentMemoryPlannerShim) {
 
   tflite::NonPersistentMemoryPlannerShim planner(non_persistent_buffer_plan);
 
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
   constexpr size_t arena_size = 1024;
   uint8_t arena[arena_size];
@@ -1092,8 +1061,7 @@ TF_LITE_MICRO_TEST(TestMockModelAllocationByNonPersistentMemoryPlannerShim) {
       allocator->StartModelAllocation(model);
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(
-      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles));
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations));
 
   size_t model_tensor_size = tflite::testing::GetModelTensorCount(model);
   TF_LITE_MICRO_EXPECT_EQ(static_cast<size_t>(4), model_tensor_size);

--- a/tensorflow/lite/micro/micro_context.cc
+++ b/tensorflow/lite/micro/micro_context.cc
@@ -35,7 +35,7 @@ void* MicroContext::AllocatePersistentBuffer(size_t bytes) {
 TfLiteStatus MicroContext::RequestScratchBufferInArena(size_t bytes,
                                                        int* buffer_idx) {
   return allocator_.RequestScratchBufferInArena(
-      bytes, graph_.GetCurrentSubgraphIndex(), buffer_idx);
+      graph_.GetAllocations(), bytes, graph_.GetCurrentSubgraphIndex(), buffer_idx);
 }
 
 void* MicroContext::GetScratchBuffer(int buffer_idx) {
@@ -87,11 +87,6 @@ void MicroContext::DeallocateTempTfLiteTensor(TfLiteTensor* tensor) {
 TfLiteEvalTensor* MicroContext::GetEvalTensor(int tensor_idx) {
   return &graph_.GetAllocations()[graph_.GetCurrentSubgraphIndex()]
               .tensors[tensor_idx];
-}
-
-void MicroContext::SetScratchBufferHandles(
-    ScratchBufferHandle* scratch_buffer_handles) {
-  scratch_buffer_handles_ = scratch_buffer_handles;
 }
 
 TfLiteStatus MicroContext::set_external_context(

--- a/tensorflow/lite/micro/micro_interpreter.cc
+++ b/tensorflow/lite/micro/micro_interpreter.cc
@@ -222,13 +222,8 @@ TfLiteStatus MicroInterpreter::AllocateTensors() {
   context_.GetScratchBuffer = MicroContextGetScratchBuffer;
 
   TF_LITE_ENSURE_OK(&context_, allocator_.FinishModelAllocation(
-                                   model_, graph_.GetAllocations(),
-                                   &scratch_buffer_handles_));
+                                   model_, graph_.GetAllocations()));
 
-  micro_context_.SetScratchBufferHandles(scratch_buffer_handles_);
-
-  // TODO(b/162311891): Drop these allocations when the interpreter supports
-  // handling buffers from TfLiteEvalTensor.
   input_tensors_ =
       reinterpret_cast<TfLiteTensor**>(allocator_.AllocatePersistentBuffer(
           sizeof(TfLiteTensor*) * inputs_size()));
@@ -251,8 +246,6 @@ TfLiteStatus MicroInterpreter::AllocateTensors() {
     }
   }
 
-  // TODO(b/162311891): Drop these allocations when the interpreter supports
-  // handling buffers from TfLiteEvalTensor.
   output_tensors_ =
       reinterpret_cast<TfLiteTensor**>(allocator_.AllocatePersistentBuffer(
           sizeof(TfLiteTensor*) * outputs_size()));

--- a/tensorflow/lite/micro/micro_interpreter.h
+++ b/tensorflow/lite/micro/micro_interpreter.h
@@ -157,7 +157,7 @@ class MicroInterpreter {
 
   TfLiteStatus initialization_status_;
 
-  ScratchBufferHandle* scratch_buffer_handles_ = nullptr;
+  void* external_context_payload_ = nullptr;
 
   // TODO(b/162311891): Clean these pointers up when this class supports buffers
   // from TfLiteEvalTensor.

--- a/tensorflow/lite/micro/recording_micro_allocator_test.cc
+++ b/tensorflow/lite/micro/recording_micro_allocator_test.cc
@@ -37,7 +37,6 @@ constexpr int kTestConvArenaSize = 1024 * 12;
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestRecordsTfLiteEvalTensorArrayData) {
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::AllOpsResolver all_ops_resolver;
   const tflite::Model* model = tflite::GetModel(kTestConvModelData);
   uint8_t arena[kTestConvArenaSize];
@@ -55,8 +54,8 @@ TF_LITE_MICRO_TEST(TestRecordsTfLiteEvalTensorArrayData) {
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   if (subgraph_allocations == nullptr) return 1;
 
-  TfLiteStatus status = micro_allocator->FinishModelAllocation(
-      model, subgraph_allocations, &scratch_buffer_handles);
+  TfLiteStatus status =
+      micro_allocator->FinishModelAllocation(model, subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(status, kTfLiteOk);
   if (status != kTfLiteOk) return 1;
 
@@ -78,7 +77,6 @@ TF_LITE_MICRO_TEST(TestRecordsTfLiteEvalTensorArrayData) {
 }
 
 TF_LITE_MICRO_TEST(TestRecordsNodeAndRegistrationArrayData) {
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::AllOpsResolver all_ops_resolver;
   const tflite::Model* model = tflite::GetModel(kTestConvModelData);
   uint8_t arena[kTestConvArenaSize];
@@ -94,8 +92,8 @@ TF_LITE_MICRO_TEST(TestRecordsNodeAndRegistrationArrayData) {
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   if (subgraph_allocations == nullptr) return 1;
 
-  TfLiteStatus status = micro_allocator->FinishModelAllocation(
-      model, subgraph_allocations, &scratch_buffer_handles);
+  TfLiteStatus status =
+      micro_allocator->FinishModelAllocation(model, subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(status, kTfLiteOk);
   if (status != kTfLiteOk) return 1;
 
@@ -112,7 +110,6 @@ TF_LITE_MICRO_TEST(TestRecordsNodeAndRegistrationArrayData) {
 }
 
 TF_LITE_MICRO_TEST(TestRecordsMultiTenantAllocations) {
-  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::AllOpsResolver all_ops_resolver;
   const tflite::Model* model = tflite::GetModel(kTestConvModelData);
 
@@ -133,8 +130,7 @@ TF_LITE_MICRO_TEST(TestRecordsMultiTenantAllocations) {
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   if (subgraph_allocations == nullptr) return 1;
 
-  status = micro_allocator->FinishModelAllocation(model, subgraph_allocations,
-                                                  &scratch_buffer_handles);
+  status = micro_allocator->FinishModelAllocation(model, subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(status, kTfLiteOk);
   if (status != kTfLiteOk) return 1;
 
@@ -143,8 +139,8 @@ TF_LITE_MICRO_TEST(TestRecordsMultiTenantAllocations) {
   TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
   if (subgraph_allocations == nullptr) return 1;
 
-  status = kTfLiteOk, micro_allocator->FinishModelAllocation(
-                          model, subgraph_allocations, &scratch_buffer_handles);
+  status = kTfLiteOk,
+  micro_allocator->FinishModelAllocation(model, subgraph_allocations);
   TF_LITE_MICRO_EXPECT_EQ(status, kTfLiteOk);
   if (status != kTfLiteOk) return 1;
 


### PR DESCRIPTION
TESTED=ran release test which failed previously, verified scratch
buffers are only allocated once.

BUG=http://b/211906909