### PR TITLE
Add AllocateTempInputTensor to replace GetInput() and Add AllocateTempOutputTensor to replace GetOutput()

### DIFF
--- a/tensorflow/lite/micro/fake_micro_context.cc
+++ b/tensorflow/lite/micro/fake_micro_context.cc
@@ -39,8 +39,17 @@ FakeMicroContext::FakeMicroContext(TfLiteTensor* tensors,
       tensors_(tensors),
       allocator_(allocator) {}
 
-TfLiteTensor* FakeMicroContext::GetTensor(int tensor_index) {
+TfLiteTensor* FakeMicroContext::AllocateTempTfLiteTensor(int tensor_index) {
+  allocated_tensor_count_++;
   return &tensors_[tensor_index];
+}
+
+void FakeMicroContext::DeallocateTempTfLiteTensor(TfLiteTensor* tensor) {
+  allocated_tensor_count_--;
+}
+
+bool FakeMicroContext::IsAllTempTfLiteTensorDeallocated() {
+  return !allocated_tensor_count_;
 }
 
 TfLiteEvalTensor* FakeMicroContext::GetEvalTensor(int tensor_index) {

--- a/tensorflow/lite/micro/fake_micro_context.h
+++ b/tensorflow/lite/micro/fake_micro_context.h
@@ -31,7 +31,10 @@ class FakeMicroContext : public MicroContext {
                                            int* buffer_index) override;
   void* GetScratchBuffer(int buffer_index) override;
 
-  TfLiteTensor* GetTensor(int tensor_index) override;
+  TfLiteTensor* AllocateTempTfLiteTensor(int tensor_index) override;
+  void DeallocateTempTfLiteTensor(TfLiteTensor* tensor) override;
+  bool IsAllTempTfLiteTensorDeallocated();
+
   TfLiteEvalTensor* GetEvalTensor(int tensor_index) override;
 
  private:
@@ -41,6 +44,8 @@ class FakeMicroContext : public MicroContext {
   uint8_t* scratch_buffers_[kNumScratchBuffers_];
 
   TfLiteTensor* tensors_;
+  int allocated_tensor_count_ = 0;
+
   SimpleMemoryAllocator* allocator_;
 
   TF_LITE_REMOVE_VIRTUAL_DELETE

--- a/tensorflow/lite/micro/kernels/if_test.cc
+++ b/tensorflow/lite/micro/kernels/if_test.cc
@@ -61,6 +61,9 @@ void TestIf(int* input1_dims_data, const bool* input1_data,
                              outputs_array, &params);
 
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.InitAndPrepare());
+
+  TF_LITE_MICRO_EXPECT_TRUE(runner.ValidateTempBufferDeallocated());
+
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.Invoke());
 
   TF_LITE_MICRO_EXPECT_EQ(output_dims_count, 2);
@@ -72,6 +75,8 @@ void TestIf(int* input1_dims_data, const bool* input1_data,
                           runner.GetMockGraph()->get_invoke_count(1));
   TF_LITE_MICRO_EXPECT_EQ(subgraph2_invoke_count_golden,
                           runner.GetMockGraph()->get_invoke_count(2));
+
+  TF_LITE_MICRO_EXPECT_TRUE(runner.ValidateTempBufferDeallocated());
 }
 
 }  // namespace

--- a/tensorflow/lite/micro/kernels/kernel_runner.cc
+++ b/tensorflow/lite/micro/kernels/kernel_runner.cc
@@ -56,14 +56,25 @@ KernelRunner::KernelRunner(const TfLiteRegistration& registration,
   node_.builtin_data = builtin_data;
 }
 
+bool KernelRunner::ValidateTempBufferDeallocated() {
+  return fake_micro_context_.IsAllTempTfLiteTensorDeallocated();
+}
+
 TfLiteStatus KernelRunner::InitAndPrepare(const char* init_data,
                                           size_t length) {
   if (registration_.init) {
     node_.user_data = registration_.init(&context_, init_data, length);
   }
+  // TODO(b/209453859): enforce all temp buffers are deallocated at the end of
+  // init TF_LITE_MICRO_EXPECT_TRUE(ValidateTempBufferDeallocated() );
+
   if (registration_.prepare) {
     TF_LITE_ENSURE_STATUS(registration_.prepare(&context_, &node_));
   }
+
+  // TODO(b/209453859): enforce all temp buffers are deallocated at the end of
+  // init TF_LITE_MICRO_EXPECT_TRUE(ValidateTempBufferDeallocated() );
+
   return kTfLiteOk;
 }
 

--- a/tensorflow/lite/micro/kernels/kernel_runner.h
+++ b/tensorflow/lite/micro/kernels/kernel_runner.h
@@ -51,6 +51,11 @@ class KernelRunner {
   // to stub out MicroGraph methods and track invocations on each subgraph.
   MockMicroGraph* GetMockGraph() { return &mock_micro_graph_; }
 
+  // Returns true if all temp buffer in tests are deallocated.
+  // TODO(b/209453859): move this function to private after deallocation checks
+  // are enabled for all kernel tests.
+  bool ValidateTempBufferDeallocated();
+
  private:
   static constexpr int kKernelRunnerBufferSize_ = 10000;
   static uint8_t kKernelRunnerBuffer_[kKernelRunnerBufferSize_];

--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -740,6 +740,28 @@ TfLiteTensor* MicroAllocator::AllocatePersistentTfLiteTensor(
   return tensor;
 }
 
+void MicroAllocator::DeallocateTempTfLiteTensor(TfLiteTensor* tensor) {
+  TFLITE_DCHECK(tensor != nullptr);
+
+  if (tensor->quantization.type == kTfLiteAffineQuantization) {
+    TFLITE_DCHECK(tensor->quantization.params != nullptr);
+    TfLiteAffineQuantization* quantization =
+        reinterpret_cast<TfLiteAffineQuantization*>(
+            tensor->quantization.params);
+
+    memory_allocator_->DeallocateTemp(
+        reinterpret_cast<uint8_t*>(quantization->zero_point));
+    memory_allocator_->DeallocateTemp(reinterpret_cast<uint8_t*>(quantization));
+  }
+
+  // Clear the data in case someone still access tensor arena by mistake
+  tensor->quantization.type = kTfLiteNoQuantization;
+  tensor->quantization.params = nullptr;
+  tensor->data.data = nullptr;
+  tensor->dims = nullptr;
+  memory_allocator_->DeallocateTemp(reinterpret_cast<uint8_t*>(tensor));
+}
+
 TfLiteTensor* MicroAllocator::AllocateTempTfLiteTensor(
     const Model* model, const SubgraphAllocations* subgraph_allocations,
     int tensor_index, int subgraph_index) {
@@ -782,6 +804,10 @@ TfLiteTensor* MicroAllocator::AllocateTempTfLiteTensor(
 
 void MicroAllocator::ResetTempAllocations() {
   memory_allocator_->ResetTempAllocations();
+}
+
+bool MicroAllocator::IsAllTempDeallocated() {
+  return memory_allocator_->IsAllTempDeallocated();
 }
 
 TfLiteStatus MicroAllocator::AllocateTfLiteEvalTensors(

--- a/tensorflow/lite/micro/micro_allocator.h
+++ b/tensorflow/lite/micro/micro_allocator.h
@@ -185,10 +185,16 @@ class MicroAllocator {
       const Model* model, const SubgraphAllocations* subgraph_allocations,
       int tensor_index, int subgraph_index);
 
+  virtual void DeallocateTempTfLiteTensor(TfLiteTensor*);
+
   // Resets all temporary allocations. This method should be called after a
   // chain of temp allocations (e.g. chain of TfLiteTensor objects via
   // AllocateTfLiteTensor()).
   virtual void ResetTempAllocations();
+
+  // Returns true if all temporary buffers including temp TfLiteTensor are
+  // already deallocated.
+  virtual bool IsAllTempDeallocated();
 
   // Allocates persistent buffer which has the same life time as the allocator.
   // The memory is immediately available and is allocated from the tail of the

--- a/tensorflow/lite/micro/micro_context.h
+++ b/tensorflow/lite/micro/micro_context.h
@@ -55,9 +55,27 @@ class MicroContext {
   // Virtual so that it can be faked for kernel tests.
   virtual void* GetScratchBuffer(int buffer_idx);
 
-  // Returns a TfLiteTensor struct for a given index.
+  // Returns a temporary TfLiteTensor struct for a given index.
   // Virtual so that it can be faked for kernel tests.
-  virtual TfLiteTensor* GetTensor(int tensor_idx);
+  virtual TfLiteTensor* AllocateTempTfLiteTensor(int tensor_idx);
+
+  // Returns a temporary TfLiteTensor struct for the specified input tensor of a
+  // given mode. This is the recommended API over the deprecated
+  // GetInput/GetInputSafe to get a temp input tensor. The returned tensor shall
+  // be freed via calling DeallocateTempTfLiteTensor.
+  virtual TfLiteTensor* AllocateTempInputTensor(const TfLiteNode* node,
+                                                int index);
+
+  // Returns a temporary TfLiteTensor struct for the specified output tensor of
+  // a given mode. This is the recommended API over the deprecated
+  // GetOutput/GetOutputSafe to get a temp output tensor. The returned tensor
+  // shall be freed via calling DeallocateTempTfLiteTensor.
+  virtual TfLiteTensor* AllocateTempOutputTensor(const TfLiteNode* node,
+                                                 int index);
+
+  // Deallocates a temp TfLiteTensor.
+  // Virtual so that it can be faked for kernel tests.
+  virtual void DeallocateTempTfLiteTensor(TfLiteTensor* tensor);
 
   // Returns a TfLiteEvalTensor struct for a given index.
   // Virtual so that it can be faked for kernel tests.
@@ -78,6 +96,10 @@ class MicroContext {
   void SetScratchBufferHandles(ScratchBufferHandle* scratch_buffer_handles);
 
  private:
+  // Return the tensor index as tensor_indices[index]. tensor_indices is of
+  // max_size. Return -1 if index is not in the valid range of tensor_indices.
+  int GetTensorIndex(int index, int max_size, const int* tensor_indices);
+
   MicroAllocator& allocator_;
   MicroGraph& graph_;
   const Model* model_;
@@ -111,7 +133,7 @@ inline void* MicroContextGetScratchBuffer(TfLiteContext* ctx, int buffer_idx) {
 }
 inline TfLiteTensor* MicroContextGetTensor(const struct TfLiteContext* context,
                                            int tensor_idx) {
-  return GetMicroContext(context)->GetTensor(tensor_idx);
+  return GetMicroContext(context)->AllocateTempTfLiteTensor(tensor_idx);
 }
 inline TfLiteEvalTensor* MicroContextGetEvalTensor(
     const struct TfLiteContext* context, int tensor_idx) {

--- a/tensorflow/lite/micro/simple_memory_allocator.h
+++ b/tensorflow/lite/micro/simple_memory_allocator.h
@@ -71,7 +71,7 @@ class SimpleMemoryAllocator {
   // ResetTempAllocations is called as it is right now.
   virtual void DeallocateTemp(uint8_t* buf);
 
-  // Returns true if all temporary buffers are already deallocted.
+  // Returns true if all temporary buffers are already deallocated.
   virtual bool IsAllTempDeallocated();
 
   // Resets a chain of temporary allocations back to the current head of the


### PR DESCRIPTION
Add more informative api AllocateTempInputTensor to replace GetInput()
and AllocateTempOutputTensor to replace GetOutput(). These two new API
call out the fact that what GetInput and GetOutput returns are in
temporary buffer and  need to call DeallocateTempTensor() afterwards.

IF operator is the first OP to use these APIs.

BUG=https://b/209453859