### PR TITLE
Fix yapf version in docker container

### DIFF
--- a/ci/Dockerfile.micro
+++ b/ci/Dockerfile.micro
@@ -31,7 +31,7 @@ RUN ln -s /usr/bin/clang-format-12 /usr/bin/clang-format
 
 # Install yapf to check for Python formatting as part of the TFLM continuous
 # integration.
-RUN pip install yapf
+RUN pip install yapf==0.32.0
 
 # Pillow was added first for the C array generation as a result of the following
 # PRs:


### PR DESCRIPTION
When upgrading the docker container, we see new format
fix/check on existing python file. That is because we did not
fix yapf version. This PR sets the yapf version to the
latest 0.32.0, which is what the latest container is using

BUG=https://issuetracker.google.com/216670232