### PR TITLE
Update the ethosu driver version

### DIFF
--- a/tensorflow/lite/micro/kernels/ethos_u/ethosu.cc
+++ b/tensorflow/lite/micro/kernels/ethos_u/ethosu.cc
@@ -1,4 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ limitations under the License.
 #include "flatbuffers/flexbuffers.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_context.h"
 
 namespace tflite {
 namespace {
@@ -121,8 +122,9 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   num_tensors = std::min(num_tensors, 8);
 
   struct ethosu_driver* drv = ethosu_reserve_driver();
-  result = ethosu_invoke(drv, cms_data, data->cms_data_size, base_addrs,
-                         base_addrs_size, num_tensors);
+  result = ethosu_invoke_v3(drv, cms_data, data->cms_data_size, base_addrs,
+                            base_addrs_size, num_tensors,
+                            GetMicroContext(context)->external_context());
   ethosu_release_driver(drv);
 
   if (-1 == result) {

--- a/tensorflow/lite/micro/tools/make/targets/cortex_m_corstone_300_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/cortex_m_corstone_300_makefile.inc
@@ -1,4 +1,4 @@
-# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -163,6 +163,8 @@ endif
 
 PLATFORM_FLAGS = \
   -DTF_LITE_MCU_DEBUG_LOG \
+  -DETHOSU_ARCH=u55 \
+  -DETHOSU55 \
   -mthumb \
   -mfloat-abi=$(FLOAT) \
   -funsigned-char \

--- a/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
@@ -1,4 +1,4 @@
-# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -156,6 +156,8 @@ endif
 
 PLATFORM_FLAGS = \
   -DTF_LITE_MCU_DEBUG_LOG \
+  -DETHOSU_ARCH=u55 \
+  -DETHOSU55 \
   -mthumb \
   -mfloat-abi=$(FLOAT) \
   -funsigned-char \

--- a/tensorflow/lite/micro/tools/make/third_party_downloads.inc
+++ b/tensorflow/lite/micro/tools/make/third_party_downloads.inc
@@ -42,5 +42,5 @@ EMBARC_MLI_PRE_COMPILED_MD5 := "173990c2dde4efef6a2c95b92d1f0244"
 ZEPHYR_URL := "http://mirror.tensorflow.org/github.com/antmicro/zephyr/archive/55e36b9.zip"
 ZEPHYR_MD5 := "755622eb4812fde918a6382b65d50c3b"
 
-ETHOSU_URL := "https://git.mlplatform.org/ml/ethos-u/ethos-u-core-driver.git/snapshot/ethos-u-core-driver-547ca53bb26a705cfceb1348373dd628eada2422.tar.gz"
-ETHOSU_MD5 := "f24119b34a9a6448b608f8ccea335c8b"
+ETHOSU_URL := "https://git.mlplatform.org/ml/ethos-u/ethos-u-core-driver.git/snapshot/ethos-u-core-driver-b3cde3c0db2049a27941af520061742f3be92bbc.tar.gz"
+ETHOSU_MD5 := "af8f2973eea34653f9e3a84060eddfd2"


### PR DESCRIPTION
Update the ethos-u-core-driver version and make changes accordingly in the ethosu-glue code.
That is, add ETHOSU_ARCH- and ETHOSU55-flag to the corstone-300- and cortex_m_generic-makefile, and pass the external_context to the ethosu_invoke() function.