### PR TITLE
Tensorflow now requires version 5.0.0.

### DIFF
--- a/ci/install_bazel.sh
+++ b/ci/install_bazel.sh
@@ -15,7 +15,7 @@
 # ==============================================================================
 
 # Select bazel version.
-BAZEL_VERSION="4.2.2"
+BAZEL_VERSION="5.0.0"
 
 set +e
 local_bazel_ver=$(bazel version 2>&1 | grep -i label | awk '{print $3}')


### PR DESCRIPTION
Without this change, the sync workflow fails with a Bazel version error.

BUG=fix broken sync from upstream TF