### PR TITLE
Enable hifi4 internal tests for Fusion F1 core

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_xtensa_fusion_f1.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_xtensa_fusion_f1.sh
@@ -28,6 +28,22 @@ readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
 # TODO(b/143904317): downloading first to allow for parallel builds.
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile third_party_downloads
 
+# optional command line parameter "INTERNAL" uses internal test code
+if [[ ${1} == "INTERNAL" ]]; then
+readable_run make -f tensorflow/lite/micro/tools/make/Makefile \
+  TARGET=xtensa \
+  TARGET_ARCH=hifi4_internal \
+  OPTIMIZED_KERNEL_DIR=xtensa \
+  XTENSA_CORE=F1_190305_swupgrade \
+  build -j$(nproc)
+
+readable_run make -f tensorflow/lite/micro/tools/make/Makefile \
+  TARGET=xtensa \
+  TARGET_ARCH=hifi4_internal \
+  OPTIMIZED_KERNEL_DIR=xtensa \
+  XTENSA_CORE=F1_190305_swupgrade \
+  test -j$(nproc)
+else
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile \
   TARGET=xtensa \
   TARGET_ARCH=hifi4 \
@@ -41,3 +57,4 @@ readable_run make -f tensorflow/lite/micro/tools/make/Makefile \
   OPTIMIZED_KERNEL_DIR=xtensa \
   XTENSA_CORE=F1_190305_swupgrade \
   test -j$(nproc)
+fi


### PR DESCRIPTION
Add an "INTERNAL" command line argument to enable Fusion F1 test to use internal code.

This is very similar to https://github.com/tingyan19/tflite-micro/commit/f44cba606f7e4d7a47a51f38fcbd815caed98553

BUG=http://b/218516993
