### PR TITLE
Add `kTfLiteActRelu0To1` for a new fused activation

### DIFF
--- a/tensorflow/lite/c/builtin_op_data.h
+++ b/tensorflow/lite/c/builtin_op_data.h
@@ -71,6 +71,7 @@ typedef enum {
   kTfLiteActTanh,
   kTfLiteActSignBit,
   kTfLiteActSigmoid,
+  kTfLiteActRelu0To1,  // min(max(0, x), 1)
 } TfLiteFusedActivation;
 
 typedef struct {

--- a/tensorflow/lite/micro/kernels/activation_utils.h
+++ b/tensorflow/lite/micro/kernels/activation_utils.h
@@ -37,6 +37,8 @@ inline float ActivationValFloat(TfLiteFusedActivation act, float a) {
       return TfLiteMax(0.0f, a);
     case kTfLiteActReluN1To1:
       return TfLiteMax(-1.0f, TfLiteMin(a, 1.0f));
+    case kTfLiteActRelu0To1: 
+      return TfLiteMax(0.0f, TfLiteMin(a, 1.0f));
     case kTfLiteActRelu6:
       return TfLiteMax(0.0f, TfLiteMin(a, 6.0f));
     case kTfLiteActTanh:


### PR DESCRIPTION
This PR adds a new ReLU activation clamping into [0, 1] to avoid the inefficiency of the current two steps - Relu6 -> [0, 6] and multiplying 0.166667. This PR is required to pass the internal testing because the source of truth of `tflite-micro` is github.