### PR TITLE
Add context_util.h to file list to sync from tensorflow

### DIFF
--- a/ci/tflite_files.txt
+++ b/ci/tflite_files.txt
@@ -1,3 +1,4 @@
+tensorflow/lite/context_util.h
 tensorflow/lite/c/common.c
 tensorflow/lite/core/api/error_reporter.cc
 tensorflow/lite/core/api/flatbuffer_conversions.cc


### PR DESCRIPTION
Inclusion of context_util.h, which was not included in the list of files to sync from TensorFlow, was recently added to kernel_util.cc. This caused CI tests for https://github.com/tensorflow/tflite-micro/pull/930 to fail. Add this file to the sync list. 

BUG=http://b/219969887
