### PR TITLE
common.c is renamed to common.cc in upstream

### DIFF
--- a/ci/tflite_files.txt
+++ b/ci/tflite_files.txt
@@ -1,5 +1,5 @@
 tensorflow/lite/context_util.h
-tensorflow/lite/c/common.c
+tensorflow/lite/c/common.cc
 tensorflow/lite/core/api/error_reporter.cc
 tensorflow/lite/core/api/flatbuffer_conversions.cc
 tensorflow/lite/core/api/op_resolver.cc


### PR DESCRIPTION
common.c is renamed to common.cc in upstream
github.com/tensorflow/tensorflow/commit/848e84c5a3acda31847457cbd52742436e024984

Hence, change the name to sync it properly

BUG=observe error in sync from tf upstream