### PR TITLE
Use HIFI4_COPTS for Fusion F1 targets

### DIFF
--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -118,11 +118,6 @@ cc_library(
     ],
 )
 
-FUSION_F1_COPS = [
-    "-DXTENSA=1",
-    "-DHIFI4=1",
-]
-
 HIFI4_COPTS = [
     "-DXTENSA=1",
     "-DHIFI4_INTERNAL=1",
@@ -258,7 +253,7 @@ tflm_kernel_cc_library(
         xtensa_hifi_5_config(): glob(["xtensa/**/*.cc"]),
     },
     copts = micro_copts() + select({
-        xtensa_fusion_f1_config(): FUSION_F1_COPS,
+        xtensa_fusion_f1_config(): HIFI4_COPTS,
         xtensa_hifi_3z_config(): HIFI4_COPTS,
         xtensa_hifi_5_config(): HIFI5_COPTS,
         "//conditions:default": [],


### PR DESCRIPTION
Revert https://github.com/tensorflow/tflite-micro/pull/808 now the bug in the internal hifi4 code has been fixed for Fusion F1

BUG=http://b/211515389
