### PR TITLE
Resolving the issue related to std::unique_ptr::reset

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/unidirectional_sequence_lstm.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/unidirectional_sequence_lstm.cc
@@ -670,6 +670,11 @@ TfLiteStatus PrecomputeZeroPointTimesWeightWithBias(
   TF_LITE_ENSURE_EQ(context, weight_shape.DimensionsCount(), 2);
   const int row = weight_shape.Dims(0);
   const int col = weight_shape.Dims(1);
+  /* Releases ownership of its stored pointer, by returning its value
+     and replacing it with a null pointer. */
+  int *temp = output->release();
+  (void)temp;
+
   output->reset(new int32_t[row]);
   if (bias_tensor == nullptr) {
     memset(output->get(), 0, row * sizeof(int32_t));


### PR DESCRIPTION
For unique_ptr, "new" takescare of both memory allocation and
initialization.
But in TFLM, memory allocations happens using AllocatePersistenBuffer and
AllocateTempBuffe API. This doesn't takes care of initialization.
Calling "release" before "reset" to resolve the issue of initialization.