### PR TITLE
Update bazel version to 5.1.0

### DIFF
--- a/ci/install_bazel.sh
+++ b/ci/install_bazel.sh
@@ -15,7 +15,7 @@
 # ==============================================================================
 
 # Select bazel version.
-BAZEL_VERSION="5.0.0"
+BAZEL_VERSION="5.1.0"
 
 set +e
 local_bazel_ver=$(bazel version 2>&1 | grep -i label | awk '{print $3}')


### PR DESCRIPTION
Upstream TF sync now expects bazel version 5.1.0.

BUG=Code sync from upstream TF failure
