### PR TITLE
Exclude conv.cc from Xtensa optimizations on VP6

### DIFF
--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -261,7 +261,10 @@ tflm_kernel_cc_library(
         xtensa_fusion_f1_config(): glob(["xtensa/**/*.cc"]),
         xtensa_hifi_3z_config(): glob(["xtensa/**/*.cc"]),
         xtensa_hifi_5_config(): glob(["xtensa/**/*.cc"]),
-        xtensa_vision_p6_config(): glob(["xtensa/**/*.cc"]),
+        xtensa_vision_p6_config(): glob(
+            ["xtensa/**/*.cc"],
+            exclude = ["xtensa/conv.cc"],
+        ),
     },
     copts = micro_copts() + select({
         xtensa_fusion_f1_config(): HIFI4_COPTS,


### PR DESCRIPTION
Some model validation tests are failing when the conv.cc optimization is
enabled. Exclude the conv.cc optimization so that other optimizations
may by used while the issue with conv.cc is debugged.

BUG=b/228102789