### PR TITLE
Add missing include header

### DIFF
--- a/tensorflow/lite/micro/ibuffer_allocator.h
+++ b/tensorflow/lite/micro/ibuffer_allocator.h
@@ -15,6 +15,11 @@ limitations under the License.
 #ifndef TENSORFLOW_LITE_MICRO_IBUFFER_ALLOCATOR_H_
 #define TENSORFLOW_LITE_MICRO_IBUFFER_ALLOCATOR_H_
 
+#include <cstddef>
+#include <cstdint>
+
+#include "tensorflow/lite/c/c_api_types.h"
+
 namespace tflite {
 // Interface classes that the TFLM framework relies on to get buffers it needs.
 // There are two types of buffers that the TFLM framework requires: persistent


### PR DESCRIPTION
Add missing include header that is causing a internal compilation
issue. This is a backport of patch in cl/439828828.

BUG=observe compilation issue when importing