### PR TITLE
Enable unit test in Hexagon presubmit instead of just building

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_hexagon.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_hexagon.sh
@@ -43,12 +43,11 @@ readable_run make -f tensorflow/lite/micro/tools/make/Makefile \
   HEXAGON_TFLM_LIB=${HEXAGON_TFLM_LIB} \
   build -j$(nproc)
 
-# TODO(b/197888845): renable the test after hexagon unit test is passing
-# readable_run make -f tensorflow/lite/micro/tools/make/Makefile \
-#  TARGET=hexagon \
-#  OPTIMIZED_KERNEL_DIR=hexagon \
-#  OPTIMIZED_KERNEL_DIR_PREFIX=third_party \
-#  HEXAGON_TFLM_LIB=${HEXAGON_TFLM_LIB} \
-#  test -j$(nproc)
+readable_run make -f tensorflow/lite/micro/tools/make/Makefile \
+  TARGET=hexagon \
+  OPTIMIZED_KERNEL_DIR=hexagon \
+  OPTIMIZED_KERNEL_DIR_PREFIX=third_party \
+  HEXAGON_TFLM_LIB=${HEXAGON_TFLM_LIB} \
+  test -j$(nproc)
 
 

--- a/tensorflow/lite/micro/tools/make/targets/hexagon_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/hexagon_makefile.inc
@@ -105,5 +105,18 @@ INCLUDES += \
   -I${HEXAGON_SDK_ROOT}/rtos/qurt/computev66/include/posix \
   -I${HEXAGON_SDK_ROOT}/rtos/qurt/computev66/include/qurt
 
+# Excludes memory_arena_threshold_test because of the size difference between
+# reference OP and optimized OP.
+EXCLUDED_TESTS := \
+  tensorflow/lite/micro/memory_arena_threshold_test.cc
+
+MICROLITE_TEST_SRCS := $(filter-out $(EXCLUDED_TESTS), $(MICROLITE_TEST_SRCS))
+
+# TODO(b/227665919): This manually maintained list of excluded examples is
+# quite error prone.
+EXCLUDED_EXAMPLE_TESTS := \
+  tensorflow/lite/micro/examples/micro_speech/Makefile.inc
+MICRO_LITE_EXAMPLE_TESTS := $(filter-out $(EXCLUDED_EXAMPLE_TESTS), $(MICRO_LITE_EXAMPLE_TESTS))
+
 TEST_SCRIPT := $(TENSORFLOW_ROOT)tensorflow/lite/micro/testing/test_hexagon_binary.sh
 SIZE_SCRIPT := $(TENSORFLOW_ROOT)tensorflow/lite/micro/testing/size_hexagon_binary.sh


### PR DESCRIPTION
enable unit test for hexagon in presubmit.
Two brittle tests are temporarily disabled.

BUG=https://b/227665919