### PR TITLE
Add portable_tensor_utils library into BUILD

### DIFF
--- a/tensorflow/lite/kernels/internal/BUILD
+++ b/tensorflow/lite/kernels/internal/BUILD
@@ -69,6 +69,23 @@ cc_library(
 )
 
 cc_library(
+    name = "portable_tensor_utils",
+    srcs = [
+        "reference/portable_tensor_utils.cc",
+    ],
+    hdrs = [
+        "reference/portable_tensor_utils.h",
+        "reference/portable_tensor_utils_impl.h",
+    ],
+    copts = tflite_copts(),
+    deps = [
+        ":common",
+        ":compatibility",
+        ":cppmath",
+    ],
+)
+
+cc_library(
     name = "reference_base",
     srcs = [],
     hdrs = glob([


### PR DESCRIPTION
Add portable_tensor_utils library into BUILD so that enable bazel test that utilizes this library

BUG=https://github.com/tensorflow/tflite-micro/issues/920, http://b/218742676
