### PR TITLE
Fix LSTM test bug with wrong output dimension

### DIFF
--- a/tensorflow/lite/micro/kernels/unidirectional_sequence_lstm.cc
+++ b/tensorflow/lite/micro/kernels/unidirectional_sequence_lstm.cc
@@ -1267,12 +1267,10 @@ TfLiteStatus UnidirectionalSequenceLstmPrepare(TfLiteContext* context,
   TF_LITE_ENSURE_EQ(context, NumElements(cell_state), n_batch * n_cell);
 
   // Check the shape of output tensor against that of input tensor
-  TF_LITE_ENSURE_EQ(context, input->dims->size, output->dims->size);
-  for (int i = 0; i < input->dims->size - 1; ++i) {
-    TF_LITE_ENSURE_EQ(context, input->dims->data[i], output->dims->data[i]);
-  }
-  TF_LITE_ENSURE_EQ(context, output->dims->data[output->dims->size - 1],
-                    n_output);
+  TF_LITE_ENSURE_EQ(context, output->dims->size, 3);
+  TF_LITE_ENSURE_EQ(context, input->dims->data[0], output->dims->data[0]);
+  TF_LITE_ENSURE_EQ(context, input->dims->data[1], output->dims->data[1]);
+  TF_LITE_ENSURE_EQ(context, output->dims->data[2], n_output);
 
   if (is_integer) {
     const int num_intermediate_tensors = node->intermediates->size;

--- a/tensorflow/lite/micro/kernels/unidirectional_sequence_lstm.cc
+++ b/tensorflow/lite/micro/kernels/unidirectional_sequence_lstm.cc
@@ -1266,6 +1266,14 @@ TfLiteStatus UnidirectionalSequenceLstmPrepare(TfLiteContext* context,
   TF_LITE_ENSURE_EQ(context, NumElements(output_state), n_batch * n_output);
   TF_LITE_ENSURE_EQ(context, NumElements(cell_state), n_batch * n_cell);
 
+  // Check the shape of output tensor against that of input tensor
+  TF_LITE_ENSURE_EQ(context, input->dims->size, output->dims->size);
+  for (int i = 0; i < input->dims->size - 1; ++i) {
+    TF_LITE_ENSURE_EQ(context, input->dims->data[i], output->dims->data[i]);
+  }
+  TF_LITE_ENSURE_EQ(context, output->dims->data[output->dims->size - 1],
+                    n_output);
+
   if (is_integer) {
     const int num_intermediate_tensors = node->intermediates->size;
     TF_LITE_ENSURE(context, num_intermediate_tensors == 5);

--- a/tensorflow/lite/micro/kernels/unidirectional_sequence_lstm_test.cc
+++ b/tensorflow/lite/micro/kernels/unidirectional_sequence_lstm_test.cc
@@ -819,8 +819,8 @@ void TestUnidirectionalSequenceLstmInteger(
     inputs_array_data[kLstmProjectionWeightsTensor + 1] =
         kLstmProjectionWeightsTensor;
 
+    int projection_bias_dim[2] = {1, n_output};
     if (use_projection_bias) {
-      int projection_bias_dim[2] = {1, n_output};
       quantization_params =
           SetQuantizationParams<int32_t>(ranges[kLstmProjectionBiasTensor][0],
                                          ranges[kLstmProjectionBiasTensor][1]);
@@ -918,7 +918,7 @@ void TestUnidirectionalSequenceLstmInteger(
     inputs_array_data[kLstmOutputLayerNormCoefficientsTensor + 1] =
         kTfLiteOptionalTensor;
   }
-  int output_dim[3] = {2, n_batch, n_output};
+  int output_dim[4] = {3, sequence_length, n_batch, n_output};
   quantization_params = SetQuantizationParams<int8_t>(
       ranges[output_tensor_index][0], ranges[output_tensor_index][1]);
   tensors[output_tensor_index] = CreateQuantizedTensor<int8_t>(
@@ -952,7 +952,7 @@ void TestUnidirectionalSequenceLstmInteger(
       IntArrayFromInts(intermediate_array_data));
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.InitAndPrepare());
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.Invoke());
-  for (int i = 0; i < n_batch * n_output; ++i) {
+  for (int i = 0; i < sequence_length * n_batch * n_output; ++i) {
     TF_LITE_MICRO_EXPECT_EQ(expected_output[i], output[i]);
   }
 }


### PR DESCRIPTION
The output tensor dimensions for the integer LSTM tests were specified incorrectly. This PR fixes this bug, and added guards in the kernel to protect mistakenly specified output dimensions. It also corrects a minor issue that affects the lifetime of a pointer.

BUG=#920, http://b/218742676