### PR TITLE
Replace std::round() with round() to resolve RISC V test issue

### DIFF
--- a/tensorflow/lite/micro/kernels/unidirectional_sequence_lstm_test.cc
+++ b/tensorflow/lite/micro/kernels/unidirectional_sequence_lstm_test.cc
@@ -532,7 +532,7 @@ QuantizationParams SetQuantizationParams(float f_min, float f_max) {
   } else if (zero_point_double > qmax_double) {
     nudged_zero_point = qmax;
   } else {
-    nudged_zero_point = static_cast<T>(std::round(zero_point_double));
+    nudged_zero_point = static_cast<T>(round(zero_point_double));
   }
 
   // The zero point should always be in the range of quantized value,


### PR DESCRIPTION
std::round() caused a compilation error in RISC V test. Replace it with round().

BUG=RISC V test fails.
