### PR TITLE
Add Uint8 Dequantize

### DIFF
--- a/tensorflow/lite/micro/kernels/dequantize.cc
+++ b/tensorflow/lite/micro/kernels/dequantize.cc
@@ -57,6 +57,13 @@ TfLiteStatus DequantizeEval(TfLiteContext* context, TfLiteNode* node) {
                                   tflite::micro::GetTensorShape(output),
                                   tflite::micro::GetTensorData<float>(output));
         break;
+      case kTfLiteUInt8:
+        reference_ops::Dequantize(data->quantization_params,
+                                  tflite::micro::GetTensorShape(input),
+                                  tflite::micro::GetTensorData<uint8_t>(input),
+                                  tflite::micro::GetTensorShape(output),
+                                  tflite::micro::GetTensorData<float>(output));
+        break;
       default:
         MicroPrintf("Input %s, output %s not supported.",
                     TfLiteTypeGetName(input->type),

--- a/tensorflow/lite/micro/kernels/dequantize_common.cc
+++ b/tensorflow/lite/micro/kernels/dequantize_common.cc
@@ -41,9 +41,9 @@ TfLiteStatus DequantizePrepare(TfLiteContext* context, TfLiteNode* node) {
   TfLiteTensor* output = micro_context->AllocateTempOutputTensor(node, 0);
   TF_LITE_ENSURE(context, output != nullptr);
 
-  TF_LITE_ENSURE(context,
-                 input->type == kTfLiteInt8 || input->type == kTfLiteInt16 ||
-                 input->type == kTfLiteUInt8);
+  TF_LITE_ENSURE(context, input->type == kTfLiteInt8 ||
+                              input->type == kTfLiteInt16 ||
+                              input->type == kTfLiteUInt8);
   TF_LITE_ENSURE(context, output->type == kTfLiteFloat32);
 
   if (output->type == kTfLiteInt32) {

--- a/tensorflow/lite/micro/kernels/dequantize_common.cc
+++ b/tensorflow/lite/micro/kernels/dequantize_common.cc
@@ -42,7 +42,8 @@ TfLiteStatus DequantizePrepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE(context, output != nullptr);
 
   TF_LITE_ENSURE(context,
-                 input->type == kTfLiteInt8 || input->type == kTfLiteInt16);
+                 input->type == kTfLiteInt8 || input->type == kTfLiteInt16 ||
+                 input->type == kTfLiteUInt8);
   TF_LITE_ENSURE(context, output->type == kTfLiteFloat32);
 
   if (output->type == kTfLiteInt32) {

--- a/tensorflow/lite/micro/kernels/dequantize_test.cc
+++ b/tensorflow/lite/micro/kernels/dequantize_test.cc
@@ -99,4 +99,17 @@ TF_LITE_MICRO_TEST(DequantizeOpTestInt16) {
                                          zero_point, dims, values, output);
 }
 
+TF_LITE_MICRO_TEST(DequantizeOpTestUint8) {
+  const int length = 10;
+  int dims[] = {2, 5, 2};
+  const float values[] = {-63.5, -63,  -62.5, -62,  -61.5,
+                          62,    62.5, 63,    63.5, 64};
+  const float scale = 0.5;
+  const int zero_point = 127;
+  uint8_t input_quantized[length];
+  float output[length];
+  tflite::testing::TestDequantizeToFloat(dims, values, input_quantized, scale,
+                                         zero_point, dims, values, output);
+}
+
 TF_LITE_MICRO_TESTS_END


### PR DESCRIPTION
While TFLM still doesn't allow uint8 quantization (https://github.com/tensorflow/tflite-micro/issues/216), there are
use-cases where having uint8 for quantize/dequantize/requantize can
enable legacy models. Restore support for uint8 dequantize.

Tested:
dequantize_test, running TF1.x SSD models on Coral Dev Board Micro

BUG=b/213518048