### PR TITLE
Modified Espressif Dev boards build badge to include ESP32-S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ additional documentation.
 Platform      |    Status     |
 -----------     | --------------|
 Arduino         | [![Arduino](https://github.com/tensorflow/tflite-micro-arduino-examples/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/tensorflow/tflite-micro-arduino-examples/actions/workflows/ci.yml) [![Antmicro](https://github.com/antmicro/tensorflow-arduino-examples/actions/workflows/test_examples.yml/badge.svg)](https://github.com/antmicro/tensorflow-arduino-examples/actions/workflows/test_examples.yml) |
-ESP32           | [![ESP32](https://github.com/espressif/tflite-micro-esp-examples/actions/workflows/build.yml/badge.svg)](https://github.com/espressif/tflite-micro-esp-examples/actions/workflows/build.yml) |
+Espressif Systems Dev Boards  | [![ESP Dev Boards](https://github.com/espressif/tflite-micro-esp-examples/actions/workflows/ci.yml/badge.svg)](https://github.com/espressif/tflite-micro-esp-examples/actions/workflows/ci.yml) |
 Silicon Labs Dev Kits        | [TFLM Examples for Silicon Labs Dev Kits](https://github.com/SiliconLabs/tflite-micro-efr32-examples)
 Sparkfun Edge   | [![Sparkfun Edge](https://github.com/advaitjain/tflite-micro-sparkfun-edge-examples/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/advaitjain/tflite-micro-sparkfun-edge-examples/actions/workflows/ci.yml)
 Texas Instruments Dev Boards | [![Texas Instruments Dev Boards](https://github.com/TexasInstruments/tensorflow-lite-micro-examples/actions/workflows/ci.yml/badge.svg?event=status)](https://github.com/TexasInstruments/tensorflow-lite-micro-examples/actions/workflows/ci.yml)


### PR DESCRIPTION
The new badge now looks like this:
![Screenshot 2022-05-11 at 5 38 13 PM](https://user-images.githubusercontent.com/5511751/167846292-db72ba64-1336-4a29-b3a7-a52b44fa4b88.png)

BUG=