### PR TITLE
Limit pytorch to tflite convertion test to HIFI5 only

### DIFF
--- a/third_party/xtensa/examples/pytorch_to_tflite/pytorch_to_tflite_test.cc
+++ b/third_party/xtensa/examples/pytorch_to_tflite/pytorch_to_tflite_test.cc
@@ -46,7 +46,7 @@ limitations under the License.
 
 TF_LITE_MICRO_TESTS_BEGIN
 
-#if !defined(HIFI4) && !defined(HIFI4_INTERNAL)
+#if defined(HIFI5)
 
 TF_LITE_MICRO_TEST(TestInvoke) {
   // Set up logging.
@@ -146,6 +146,6 @@ TF_LITE_MICRO_TEST(TestInvoke) {
 
   TF_LITE_REPORT_ERROR(&micro_error_reporter, "Ran successfully\n");
 }
-#endif  // !defined(HIFI4) && !defined(HIFI4_INTERNAL)
+#endif  // defined(HIFI5)
 
 TF_LITE_MICRO_TESTS_END


### PR DESCRIPTION
BUG=PyTorch to TFLite conversion test fails nightly Vision P6 test