### PR TITLE
Fix xtensa parallel build errors by checking directory before extracting downloaded files

### DIFF
--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
@@ -79,15 +79,21 @@ else
     exit 1
   fi
 
-  unzip -qo "$TEMPFILE" -d ${DOWNLOADS_DIR} >&2
+  # Check if another make process has already extracted the downloaded files.
+  # If so, skip extracting and patching.
+  if [ -d ${LIBRARY_INSTALL_PATH} ]; then
+    echo >&2 "${LIBRARY_INSTALL_PATH} already exists, skipping the extraction."
+  else
+    unzip -qo "$TEMPFILE" -d ${DOWNLOADS_DIR} >&2
 
-  rm -rf "${TEMPDIR}"
+    rm -rf "${TEMPDIR}"
 
-  pushd "${LIBRARY_INSTALL_PATH}" > /dev/null
-  chmod -R +w ./
-  if [[ -f "../../ext_libs/xa_nnlib_${2}.patch" ]]; then
-    create_git_repo ./
-    apply_patch_to_folder ./ "../../ext_libs/xa_nnlib_${2}.patch" "TFLM patch"
+    pushd "${LIBRARY_INSTALL_PATH}" > /dev/null
+    chmod -R +w ./
+    if [[ -f "../../ext_libs/xa_nnlib_${2}.patch" ]]; then
+      create_git_repo ./
+      apply_patch_to_folder ./ "../../ext_libs/xa_nnlib_${2}.patch" "TFLM patch"
+    fi
   fi
 fi
 


### PR DESCRIPTION
Building xtensa target with -jN fails because the different make processes overwrite each other's downloaded external libraries. The issue can be fixed by checking for existence of external library directory before extracting the files. This enables parallel builds for xtensa targets.

BUG=#1135