### PR TITLE
Include xtensa/conv.cc in Xtensa optimizations on VP6

### DIFF
--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -281,10 +281,7 @@ tflm_kernel_cc_library(
         xtensa_fusion_f1_config(): glob(["xtensa/**/*.cc"]),
         xtensa_hifi_3z_config(): glob(["xtensa/**/*.cc"]),
         xtensa_hifi_5_config(): glob(["xtensa/**/*.cc"]),
-        xtensa_vision_p6_config(): glob(
-            ["xtensa/**/*.cc"],
-            exclude = ["xtensa/conv.cc"],
-        ),
+        xtensa_vision_p6_config(): glob(["xtensa/**/*.cc"]),
     },
     copts = micro_copts() + select({
         xtensa_fusion_f1_config(): HIFI4_COPTS,


### PR DESCRIPTION
- Issue fixed in 5-17-22 xi_tflmlib_vision_p6

BUG=b/228102789