### PR TITLE
Remove hard coded DWT registers for Arm targets

### DIFF
--- a/tensorflow/lite/micro/cortex_m_corstone_300/system_setup.cc
+++ b/tensorflow/lite/micro/cortex_m_corstone_300/system_setup.cc
@@ -1,4 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,45 +15,16 @@ limitations under the License.
 
 #ifdef ETHOS_U
 #include "ethosu_driver.h"
+#endif
 
 // This is set in micro/tools/make/targets/cortex_m_corstone_300_makefile.inc.
-// It is needed for the calls to NVIC_SetVector()/NVIC_EnableIR().
+// It is needed for the calls to NVIC_SetVector()/NVIC_EnableIR() and for the
+// DWT and PMU counters.
 #include CMSIS_DEVICE_ARM_CORTEX_M_XX_HEADER_FILE
-#endif
+
 #include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/micro_time.h"
 #include "tensorflow/lite/micro/system_setup.h"
-
-// DWT (Data Watchpoint and Trace) registers, only exists on ARM Cortex with a
-// DWT unit.
-#define KIN1_DWT_CONTROL (*((volatile uint32_t*)0xE0001000))
-
-// DWT Control register.
-#define KIN1_DWT_CYCCNTENA_BIT (1UL << 0)
-
-// CYCCNTENA bit in DWT_CONTROL register.
-#define KIN1_DWT_CYCCNT (*((volatile uint32_t*)0xE0001004))
-
-// DWT Cycle Counter register.
-#define KIN1_DEMCR (*((volatile uint32_t*)0xE000EDFC))
-
-// DEMCR: Debug Exception and Monitor Control Register.
-#define KIN1_TRCENA_BIT (1UL << 24)
-
-// Trace enable bit in DEMCR register.
-#define KIN1_LAR (*((volatile uint32_t*)0xE0001FB0))
-
-// Unlock access to DWT (ITM, etc.)registers.
-#define KIN1_UnlockAccessToDWT() KIN1_LAR = 0xC5ACCE55;
-
-// TRCENA: Enable trace and debug block DEMCR (Debug Exception and Monitor
-// Control Register.
-#define KIN1_InitCycleCounter() KIN1_DEMCR |= KIN1_TRCENA_BIT
-
-#define KIN1_ResetCycleCounter() KIN1_DWT_CYCCNT = 0
-#define KIN1_EnableCycleCounter() KIN1_DWT_CONTROL |= KIN1_DWT_CYCCNTENA_BIT
-#define KIN1_DisableCycleCounter() KIN1_DWT_CONTROL &= ~KIN1_DWT_CYCCNTENA_BIT
-#define KIN1_GetCycleCounter() KIN1_DWT_CYCCNT
 
 namespace tflite {
 
@@ -63,7 +34,17 @@ constexpr int kClocksPerSecond = 25e6;
 
 int32_t ticks_per_second() { return kClocksPerSecond; }
 
-int32_t GetCurrentTimeTicks() { return KIN1_GetCycleCounter(); }
+int32_t GetCurrentTimeTicks() {
+#ifndef TF_LITE_STRIP_ERROR_STRINGS
+#ifdef ARMCM55
+  return ARM_PMU_Get_CCNTR();
+#else
+  return DWT->CYCCNT;
+#endif
+#else
+  return 0;
+#endif  // TF_LITE_STRIP_ERROR_STRINGS
+}
 
 #ifdef ETHOS_U
 #if defined(ETHOSU_FAST_MEMORY_SIZE) && ETHOSU_FAST_MEMORY_SIZE > 0
@@ -86,10 +67,23 @@ void uart_init(void);
 void InitializeTarget() {
   uart_init();
 
-  KIN1_UnlockAccessToDWT();
-  KIN1_InitCycleCounter();
-  KIN1_ResetCycleCounter();
-  KIN1_EnableCycleCounter();
+#ifndef TF_LITE_STRIP_ERROR_STRINGS
+#ifdef ARMCM55
+  ARM_PMU_Enable();
+  DCB->DEMCR |= DCB_DEMCR_TRCENA_Msk;
+
+  ARM_PMU_CYCCNT_Reset();
+  ARM_PMU_CNTR_Enable(PMU_CNTENSET_CCNTR_ENABLE_Msk);
+
+#else
+  CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+
+  // Reset and enable DWT cycle counter.
+  DWT->CYCCNT = 0;
+  DWT->CTRL |= 1UL;
+
+#endif
+#endif  // TF_LITE_STRIP_ERROR_STRINGS
 
 #ifdef ETHOS_U
   constexpr int ethosu_base_address = 0x48102000;

--- a/tensorflow/lite/micro/cortex_m_generic/micro_time.cc
+++ b/tensorflow/lite/micro/cortex_m_generic/micro_time.cc
@@ -1,4 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,38 +15,11 @@ limitations under the License.
 
 #include "tensorflow/lite/micro/micro_time.h"
 
-// DWT (Data Watchpoint and Trace) registers, only exists on ARM Cortex with a
-// DWT unit.
-#define KIN1_DWT_CONTROL (*((volatile uint32_t*)0xE0001000))
-/*!< DWT Control register */
-
-// DWT Control register.
-#define KIN1_DWT_CYCCNTENA_BIT (1UL << 0)
-
-// CYCCNTENA bit in DWT_CONTROL register.
-#define KIN1_DWT_CYCCNT (*((volatile uint32_t*)0xE0001004))
-
-// DWT Cycle Counter register.
-#define KIN1_DEMCR (*((volatile uint32_t*)0xE000EDFC))
-
-// DEMCR: Debug Exception and Monitor Control Register.
-#define KIN1_TRCENA_BIT (1UL << 24)
-
-#define KIN1_LAR (*((volatile uint32_t*)0xE0001FB0))
-
-#define KIN1_DWT_CONTROL (*((volatile uint32_t*)0xE0001000))
-
-// Unlock access to DWT (ITM, etc.)registers.
-#define KIN1_UnlockAccessToDWT() KIN1_LAR = 0xC5ACCE55;
-
-// TRCENA: Enable trace and debug block DEMCR (Debug Exception and Monitor
-// Control Register.
-#define KIN1_InitCycleCounter() KIN1_DEMCR |= KIN1_TRCENA_BIT
-
-#define KIN1_ResetCycleCounter() KIN1_DWT_CYCCNT = 0
-#define KIN1_EnableCycleCounter() KIN1_DWT_CONTROL |= KIN1_DWT_CYCCNTENA_BIT
-#define KIN1_DisableCycleCounter() KIN1_DWT_CONTROL &= ~KIN1_DWT_CYCCNTENA_BIT
-#define KIN1_GetCycleCounter() KIN1_DWT_CYCCNT
+// Set in micro/tools/make/targets/cortex_m_generic_makefile.inc.
+// Needed for the DWT and PMU counters.
+#ifdef CMSIS_DEVICE_ARM_CORTEX_M_XX_HEADER_FILE
+#include CMSIS_DEVICE_ARM_CORTEX_M_XX_HEADER_FILE
+#endif
 
 namespace tflite {
 
@@ -54,14 +27,41 @@ int32_t ticks_per_second() { return 0; }
 
 int32_t GetCurrentTimeTicks() {
   static bool is_initialized = false;
+
   if (!is_initialized) {
-    KIN1_UnlockAccessToDWT();
-    KIN1_InitCycleCounter();
-    KIN1_ResetCycleCounter();
-    KIN1_EnableCycleCounter();
+#ifndef TF_LITE_STRIP_ERROR_STRINGS
+#ifdef ARM_MODEL_USE_PMU_COUNTERS
+    ARM_PMU_Enable();
+    DCB->DEMCR |= DCB_DEMCR_TRCENA_Msk;
+
+    ARM_PMU_CYCCNT_Reset();
+    ARM_PMU_CNTR_Enable(PMU_CNTENSET_CCNTR_ENABLE_Msk);
+
+#else
+#ifdef ARMCM7
+    DWT->LAR = 0xC5ACCE55;
+#endif
+    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+
+    // Reset and DWT cycle counter.
+    DWT->CYCCNT = 0;
+    DWT->CTRL |= 1UL;
+
+#endif
+#endif  // TF_LITE_STRIP_ERROR_STRINGS
+
     is_initialized = true;
   }
-  return KIN1_GetCycleCounter();
+
+#ifndef TF_LITE_STRIP_ERROR_STRINGS
+#ifdef ARM_MODEL_USE_PMU_COUNTERS
+  return ARM_PMU_Get_CCNTR();
+#else
+  return DWT->CYCCNT;
+#endif
+#else
+  return 0;
+#endif  // TF_LITE_STRIP_ERROR_STRINGS
 }
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
@@ -26,11 +26,9 @@ ifeq ($(TARGET_ARCH), cortex-m0)
   CORE=M0
   ARM_LDFLAGS := -Wl,--cpu=Cortex-M0
 
-
 else ifeq ($(TARGET_ARCH), cortex-m0plus)
   CORE=M0plus
   ARM_LDFLAGS := -Wl,--cpu=Cortex-M0plus
-
 
 else ifeq ($(TARGET_ARCH), cortex-m3)
   CORE=M3
@@ -39,7 +37,7 @@ else ifeq ($(TARGET_ARCH), cortex-m3)
 else ifeq ($(TARGET_ARCH), cortex-m33)
   CORE=M33
   ARM_LDFLAGS := -Wl,--cpu=Cortex-M33
-  TARGET_SPECIFIC_FLAGS += -D__DSP_PRESENT=1 -D__FPU_PRESENT=1 -D__VTOR_PRESENT=1 -D__FPU_USED=1
+  CMSIS_ARM_FEATURES := _DSP_FP
   FLOAT=hard
 
 else ifeq ($(TARGET_ARCH), cortex-m33+nodsp)
@@ -54,21 +52,20 @@ else ifeq ($(TARGET_ARCH), cortex-m4)
 else ifeq ($(TARGET_ARCH), cortex-m4+fp)
   CORE=M4
   ARM_LDFLAGS := -Wl,--cpu=Cortex-M4
-  TARGET_SPECIFIC_FLAGS += -D__FPU_PRESENT=1
+  CMSIS_ARM_FEATURES := _FP
   FLOAT=hard
   GCC_TARGET_ARCH := cortex-m4
 
 else ifeq ($(TARGET_ARCH), cortex-m4+sfp)
   CORE=M4
   ARM_LDFLAGS := -Wl,--cpu=Cortex-M4
-  TARGET_SPECIFIC_FLAGS += -D__FPU_PRESENT=1
+  CMSIS_ARM_FEATURES := _FP
   FLOAT=softfp
   GCC_TARGET_ARCH := cortex-m4
 
 else ifeq ($(TARGET_ARCH), cortex-m55)
   CORE=M55
   ARM_LDFLAGS := -Wl,--cpu=8.1-M.Main.mve.fp
-  TARGET_SPECIFIC_FLAGS += -D__DSP_PRESENT=1 -D__FPU_PRESENT=1
   FLOAT=hard
 
 else ifeq ($(TARGET_ARCH), cortex-m55+nodsp+nofp)
@@ -78,7 +75,6 @@ else ifeq ($(TARGET_ARCH), cortex-m55+nodsp+nofp)
 else ifeq ($(TARGET_ARCH), cortex-m55+nofp)
   CORE=M55
   ARM_LDFLAGS := -Wl,--cpu=8.1-M.Main.mve.no_fp
-  TARGET_SPECIFIC_FLAGS += -D__DSP_PRESENT=1
 
 else ifeq ($(TARGET_ARCH), cortex-m7)
   CORE=M7
@@ -91,11 +87,26 @@ else ifeq ($(TARGET_ARCH), cortex-m7+fp)
   FLOAT=hard
   GCC_TARGET_ARCH := cortex-m7
 
+else ifeq ($(TARGET_ARCH), cortex-m85)
+  CORE=M85
+  ARM_LDFLAGS := -Wl,--cpu=8.1-M.Main.mve.fp
+  FLOAT=hard
+  # GCC does not yet support cortex-m85 option hence go with cortex-m55 for now.
+  GCC_TARGET_ARCH := cortex-m55
+
 else ifeq ($(TARGET_ARCH), project_generation)
  # None of the parameters matter since we are not going to build any code.
 else
   $(error "TARGET_ARCH=$(TARGET_ARCH) is not supported")
 endif
+
+# Dependency to CMSIS-Device for DWT/PMU counters.
+ARM_CPU := "ARMC$(CORE)"
+CMSIS_DEFAULT_DOWNLOAD_PATH := $(MAKEFILE_DIR)/downloads/cmsis
+CMSIS_PATH := $(CMSIS_DEFAULT_DOWNLOAD_PATH)
+INCLUDES += \
+  -I$(CMSIS_PATH)/Device/ARM/$(ARM_CPU)/Include \
+  -I$(CMSIS_PATH)/CMSIS/Core/Include
 
 ifneq ($(filter cortex-m55%,$(TARGET_ARCH)),)
   # soft-abi=soft disables MVE - use softfp instead for M55.
@@ -164,8 +175,16 @@ PLATFORM_FLAGS = \
   -Wno-unused-private-field \
   -fomit-frame-pointer \
   -MD \
-  -DCPU_$(CORE)=1 \
-  $(TARGET_SPECIFIC_FLAGS)
+  -DCPU_$(CORE)=1
+
+# For DWT/PMU counters. Header file name is depending on target architecture.
+PLATFORM_FLAGS += -DCMSIS_DEVICE_ARM_CORTEX_M_XX_HEADER_FILE=\"$(ARM_CPU)$(CMSIS_ARM_FEATURES).h\"
+PLATFORM_FLAGS += -D$(ARM_CPU)
+
+# Arm Cortex-M55 and Cortex-M85 use PMU counters.
+ifneq ($(filter "ARMCM55" "ARMCM85",$(ARM_CPU)),)
+  PLATFORM_FLAGS += -DARM_MODEL_USE_PMU_COUNTERS
+endif
 
 # Common + C/C++ flags
 CXXFLAGS += $(PLATFORM_FLAGS)


### PR DESCRIPTION
Arm Cortex-M55 uses the more realistic PMU counters.
Adds Arm Cortex-M85 for cortex_m_generic target.

BUG=https://github.com/tensorflow/tflite-micro/issues/1166