### PR TITLE
Create an allocator to manage persistent arena

### DIFF
--- a/tensorflow/lite/micro/arena_allocator/BUILD
+++ b/tensorflow/lite/micro/arena_allocator/BUILD
@@ -48,6 +48,31 @@ cc_test(
 )
 
 cc_library(
+    name = "persistent_arena_buffer_allocator",
+    srcs = ["persistent_arena_buffer_allocator.cc"],
+    hdrs = ["persistent_arena_buffer_allocator.h"],
+    copts = micro_copts(),
+    deps = [
+        ":ibuffer_allocator",
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/micro:memory_helpers",
+        "//tensorflow/lite/micro:micro_arena_constants",
+        "//tensorflow/lite/micro:micro_compatibility",
+        "//tensorflow/lite/micro:micro_error_reporter",
+    ],
+)
+
+cc_test(
+    name = "persistent_arena_buffer_allocator_test",
+    srcs = ["persistent_arena_buffer_allocator_test.cc"],
+    deps = [
+        ":persistent_arena_buffer_allocator",
+        "//tensorflow/lite/micro:test_helpers",
+        "//tensorflow/lite/micro/testing:micro_test",
+    ],
+)
+
+cc_library(
     name = "simple_memory_allocator",
     srcs = [
         "simple_memory_allocator.cc",

--- a/tensorflow/lite/micro/arena_allocator/persistent_arena_buffer_allocator.cc
+++ b/tensorflow/lite/micro/arena_allocator/persistent_arena_buffer_allocator.cc
@@ -1,0 +1,52 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/micro/arena_allocator/persistent_arena_buffer_allocator.h"
+
+#include "tensorflow/lite/micro/memory_helpers.h"
+#include "tensorflow/lite/micro/micro_error_reporter.h"
+
+namespace tflite {
+
+PersistentArenaBufferAllocator::PersistentArenaBufferAllocator(
+    uint8_t* buffer, size_t buffer_size)
+    : buffer_head_(buffer),
+      buffer_tail_(buffer + buffer_size),
+      tail_temp_(buffer_tail_) {}
+
+PersistentArenaBufferAllocator::~PersistentArenaBufferAllocator() {}
+
+uint8_t* PersistentArenaBufferAllocator::AllocatePersistentBuffer(
+    size_t size, size_t alignment) {
+  uint8_t* const aligned_result =
+      AlignPointerDown(tail_temp_ - size, alignment);
+  if (aligned_result < buffer_head_) {
+#ifndef TF_LITE_STRIP_ERROR_STRINGS
+    const size_t missing_memory = buffer_head_ - aligned_result;
+    MicroPrintf(
+        "Failed to allocate tail memory. Requested: %u, "
+        "available %u, missing: %u",
+        size, size - missing_memory, missing_memory);
+#endif
+    return nullptr;
+  }
+  tail_temp_ = aligned_result;
+  return aligned_result;
+}
+
+size_t PersistentArenaBufferAllocator::GetPersistentUsedBytes() const {
+  return buffer_tail_ - tail_temp_;
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/arena_allocator/persistent_arena_buffer_allocator.h
+++ b/tensorflow/lite/micro/arena_allocator/persistent_arena_buffer_allocator.h
@@ -1,0 +1,59 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_LITE_MICRO_ARENA_ALLOCATOR_PERSISTENT_ARENA_BUFFER_ALLOCATOR_H_
+#define TENSORFLOW_LITE_MICRO_ARENA_ALLOCATOR_PERSISTENT_ARENA_BUFFER_ALLOCATOR_H_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/core/api/error_reporter.h"
+#include "tensorflow/lite/micro/arena_allocator/ibuffer_allocator.h"
+#include "tensorflow/lite/micro/compatibility.h"
+
+namespace tflite {
+
+// PersistentArenaBufferAllocator is an implementatation of
+// IPersistentBufferAllocator interface on an arena that is dedicated for
+// persistent buffers.
+class PersistentArenaBufferAllocator : public IPersistentBufferAllocator {
+ public:
+  PersistentArenaBufferAllocator(uint8_t* buffer, size_t buffer_size);
+  virtual ~PersistentArenaBufferAllocator();
+
+  // Allocates persistent memory. The persistent buffer is never freed.
+  // Returns nullptr if errors occured.
+  uint8_t* AllocatePersistentBuffer(size_t size, size_t alignment) override;
+
+  // Returns the size of all persistent allocations in bytes.
+  size_t GetPersistentUsedBytes() const override;
+
+  TF_LITE_REMOVE_VIRTUAL_DELETE
+ private:
+  // The memory arena that this allocator manages.
+  uint8_t* const buffer_head_;
+  uint8_t* const buffer_tail_;
+
+  // The whole region is split into two parts:
+  // tail_temp_ to buffer_tail_ contains allocated buffers;
+  // buffer_head_ to tail_temp_ - 1 belongs to still available spaces.
+  // So in essence, the allocated region grows from the bottom and emulates
+  // SimpleMemoryAllocator's persistent part.
+  uint8_t* tail_temp_;
+};
+
+}  // namespace tflite
+
+#endif  // TENSORFLOW_LITE_MICRO_ARENA_ALLOCATOR_PERSISTENT_ARENA_BUFFER_ALLOCATOR_H_

--- a/tensorflow/lite/micro/arena_allocator/persistent_arena_buffer_allocator_test.cc
+++ b/tensorflow/lite/micro/arena_allocator/persistent_arena_buffer_allocator_test.cc
@@ -1,0 +1,98 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/micro/arena_allocator/persistent_arena_buffer_allocator.h"
+
+#include <cstdint>
+
+#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/testing/micro_test.h"
+
+TF_LITE_MICRO_TESTS_BEGIN
+
+// Test that the right amount of memory are allocated.
+TF_LITE_MICRO_TEST(TestGetPersistentUsedBytes) {
+  constexpr size_t arena_size = 1024;
+  uint8_t arena[arena_size];
+  tflite::PersistentArenaBufferAllocator allocator(arena, arena_size);
+
+  const size_t size1 = 10;
+  allocator.AllocatePersistentBuffer(size1, 1);
+  TF_LITE_MICRO_EXPECT_EQ(size1, allocator.GetPersistentUsedBytes());
+
+  const size_t size2 = 15;
+  allocator.AllocatePersistentBuffer(size2, 1);
+
+  TF_LITE_MICRO_EXPECT_EQ(size1 + size2, allocator.GetPersistentUsedBytes());
+}
+
+// Test allocation shall fail if total memory exceeds the limit.
+TF_LITE_MICRO_TEST(TestAllocatePersistBufferShallFailIfExceedLimit) {
+  constexpr size_t arena_size = 1024;
+  uint8_t arena[arena_size];
+  tflite::PersistentArenaBufferAllocator allocator(arena, arena_size);
+
+  const size_t size1 = 10;
+  uint8_t* persist1 = allocator.AllocatePersistentBuffer(size1, 1);
+  TF_LITE_MICRO_EXPECT(persist1 != nullptr);
+
+  const size_t size2 = arena_size - size1 + 1;
+  uint8_t* persist2 = allocator.AllocatePersistentBuffer(size2, 1);
+
+  TF_LITE_MICRO_EXPECT(persist2 == nullptr);
+}
+
+// Test allocation shall pass if total memory does not exceed the limit.
+TF_LITE_MICRO_TEST(TestAllocatePersistBufferShallPassIfWithinLimit) {
+  constexpr size_t arena_size = 1024;
+  uint8_t arena[arena_size];
+  tflite::PersistentArenaBufferAllocator allocator(arena, arena_size);
+
+  const size_t size1 = 10;
+  uint8_t* persist1 = allocator.AllocatePersistentBuffer(size1, 1);
+  TF_LITE_MICRO_EXPECT(persist1 != nullptr);
+
+  const size_t size2 = arena_size - size1;
+  uint8_t* persist2 = allocator.AllocatePersistentBuffer(size2, 1);
+
+  TF_LITE_MICRO_EXPECT(persist2 != nullptr);
+  TF_LITE_MICRO_EXPECT_EQ(arena_size, allocator.GetPersistentUsedBytes());
+}
+
+// Test alignment works.
+TF_LITE_MICRO_TEST(TestAllocatePersistBufferAligns) {
+  constexpr size_t arena_size = 1024;
+  uint8_t arena[arena_size];
+  tflite::PersistentArenaBufferAllocator allocator(arena, arena_size);
+
+  const size_t size1 = 10;
+  const size_t alignment = 16;
+  uint8_t* persist1 = allocator.AllocatePersistentBuffer(size1, alignment);
+  TF_LITE_MICRO_EXPECT(persist1 != nullptr);
+  TF_LITE_MICRO_EXPECT_EQ(
+      (reinterpret_cast<std::uintptr_t>(persist1)) % alignment,
+      static_cast<std::uintptr_t>(0));
+  TF_LITE_MICRO_EXPECT_GE(allocator.GetPersistentUsedBytes(), size1);
+
+  const size_t size2 = 16;
+  uint8_t* persist2 = allocator.AllocatePersistentBuffer(size2, alignment);
+  TF_LITE_MICRO_EXPECT(persist2 != nullptr);
+  TF_LITE_MICRO_EXPECT_EQ(
+      (reinterpret_cast<std::uintptr_t>(persist2)) % alignment,
+      static_cast<std::uintptr_t>(0));
+  TF_LITE_MICRO_EXPECT_EQ(static_cast<size_t>(persist1 - persist2), size2);
+  TF_LITE_MICRO_EXPECT_GE(allocator.GetPersistentUsedBytes(), size1);
+}
+TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -287,6 +287,7 @@ tensorflow/lite/micro/micro_time_test.cc \
 tensorflow/lite/micro/micro_utils_test.cc \
 tensorflow/lite/micro/recording_micro_allocator_test.cc \
 tensorflow/lite/micro/arena_allocator/non_persistent_arena_buffer_allocator_test.cc \
+tensorflow/lite/micro/arena_allocator/persistent_arena_buffer_allocator_test.cc \
 tensorflow/lite/micro/arena_allocator/recording_simple_memory_allocator_test.cc \
 tensorflow/lite/micro/arena_allocator/simple_memory_allocator_test.cc \
 tensorflow/lite/micro/testing_helpers_test.cc \
@@ -365,7 +366,6 @@ tensorflow/lite/micro/kernels/quantize.cc \
 tensorflow/lite/micro/kernels/quantize_common.cc \
 tensorflow/lite/micro/kernels/read_variable.cc \
 tensorflow/lite/micro/kernels/reduce.cc \
-tensorflow/lite/micro/kernels/reduce_common.cc \
 tensorflow/lite/micro/kernels/reshape.cc \
 tensorflow/lite/micro/kernels/resize_bilinear.cc \
 tensorflow/lite/micro/kernels/resize_nearest_neighbor.cc \


### PR DESCRIPTION
This PR corresponds to internal cl/452380512.

Create an allocator to manage persistent arena.
This is another step towards the feature of enabling the client to
have two separate memory arenas.

BUG=https://b/226971240