### PR TITLE
Disable ubsan for interpreter_test

### DIFF
--- a/tensorflow/lite/micro/python/interpreter/tests/BUILD
+++ b/tensorflow/lite/micro/python/interpreter/tests/BUILD
@@ -10,6 +10,7 @@ py_test(
     tags = [
         "noasan",
         "nomsan",  # Python doesn't like these symbols from interpreter_wrapper_pybind.so
+        "noubsan",
     ],
     deps = [
         requirement("numpy"),


### PR DESCRIPTION
Asan and msan are already disabled, ubsan should be as well but was
initially undetected because ubsan tests are already disabled on GitHub
CI. This was caught during the internal sync.

BUG=b/234879912