### PR TITLE
Add support for int8 rsqrt

### DIFF
--- a/tensorflow/lite/micro/kernels/elementwise.cc
+++ b/tensorflow/lite/micro/kernels/elementwise.cc
@@ -153,6 +153,12 @@ inline TfLiteStatus EvalLogical(TfLiteContext* context, TfLiteNode* node,
   return EvalImpl<bool>(context, node, bool_func, kTfLiteBool);
 }
 
+void* ElementWiseQuantizedInit(TfLiteContext* context, const char* buffer,
+                               size_t length) {
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+  return context->AllocatePersistentBuffer(context, sizeof(OpData));
+}
+
 TfLiteStatus AbsEval(TfLiteContext* context, TfLiteNode* node) {
   return EvalNumeric(context, node, std::abs);
 }
@@ -246,8 +252,8 @@ GENERIC_PREPARE(PrepareRsqrt, elementwise::IsNumericSupportedType,
                 elementwise::kRsqrtName)
 
 TfLiteRegistration Register_RSQRT() {
-  return tflite::micro::RegisterOp(
-      /*init=*/nullptr, PrepareRsqrt, elementwise::RsqrtEval);
+  return tflite::micro::RegisterOp(elementwise::ElementWiseQuantizedInit,
+                                   PrepareRsqrt, elementwise::RsqrtEval);
 }
 
 GENERIC_PREPARE(PrepareSquare, elementwise::IsNumericSupportedType, "Square")

--- a/tensorflow/lite/micro/kernels/elementwise_test.cc
+++ b/tensorflow/lite/micro/kernels/elementwise_test.cc
@@ -109,6 +109,13 @@ void TestElementwiseQuantized(const TfLiteRegistration& registration,
   TfLiteIntArray* input_dims = IntArrayFromInts(input_dims_data);
   TfLiteIntArray* output_dims = IntArrayFromInts(output_dims_data);
   const int output_elements_count = ElementCount(*output_dims);
+  const int output_dims_count = ElementCount(*output_dims);
+
+  // Place zero in the uninitialized output buffer.
+  for (int i = 0; i < output_dims_count; ++i) {
+    output_quantized[i] = 0;
+    output_dequantized[i] = 0.0f;
+  }
 
   constexpr int inputs_size = 1;
   constexpr int outputs_size = 1;


### PR DESCRIPTION
Port int8 rsqrt code and tests from TFLite, based on:

https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/kernels/elementwise.cc
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/kernels/elementwise_test.cc

BUG=#1201
