### PR TITLE
Use GitHub workflows to add ci:run to PR when ci:ready_to_merge is applied.

### DIFF
--- a/.github/workflows/apply_cirun.yml
+++ b/.github/workflows/apply_cirun.yml
@@ -1,6 +1,15 @@
+# Apply ci:run on the following conditions:
+#   1. ci:ready_to_merge is added to a PR (e.g. on review approval). This makes
+#      it so that a review approval is sufficient to get all the CI machinery
+#      going and have the PR be merged (if all the tests pass).
+#
+#   2. PR is updated and ci:ready_to_merge is already a label on the PR. This
+#      allows mergify to update the PR and keep the merging process moving
+#      along.
+
 on:
   pull_request_target:
-    types: [synchronize]
+    types: [labeled, synchronize]
 
 jobs:
   apply-label:
@@ -9,7 +18,7 @@ jobs:
     steps:
       - uses: actions/github-script@v5
         with:
-          github-token: ${{ secrets.TFLM_BOT_REPO_TOKEN }} 
+          github-token: ${{ secrets.TFLM_BOT_REPO_TOKEN }}
           script: |
             github.rest.issues.addLabels({
               issue_number: context.issue.number,

--- a/.github/workflows/remove-labels.yml
+++ b/.github/workflows/remove-labels.yml
@@ -3,7 +3,7 @@ name: Remove Labels
 on:
   pull_request_target:
     types: [labeled]
-  
+
 jobs:
   label_cleanup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When `ci:ready_to_merge` is applied (mostly as a result of a review approval), the intent is to have the PR get in the merge queue so `ci:run` should also be automatically applied.

We had previously attempted to apply both labels via the google-ml-butler bot, but that didn't quite work (http://b/219973800).

BUG=http://b/219973800 and http://b/210946861
