### PR TITLE
When building without error strings, there there are no references to…

### DIFF
--- a/tensorflow/lite/micro/arena_allocator/simple_memory_allocator.cc
+++ b/tensorflow/lite/micro/arena_allocator/simple_memory_allocator.cc
@@ -32,7 +32,10 @@ namespace tflite {
 SimpleMemoryAllocator::SimpleMemoryAllocator(ErrorReporter* error_reporter,
                                              uint8_t* buffer_head,
                                              uint8_t* buffer_tail)
-    : error_reporter_(error_reporter),
+    :
+#if !defined(TF_LITE_STRIP_ERROR_STRINGS)
+      error_reporter_(error_reporter),
+#endif
       buffer_head_(buffer_head),
       buffer_tail_(buffer_tail),
       head_(buffer_head),

--- a/tensorflow/lite/micro/arena_allocator/simple_memory_allocator.h
+++ b/tensorflow/lite/micro/arena_allocator/simple_memory_allocator.h
@@ -126,7 +126,9 @@ class SimpleMemoryAllocator : public INonPersistentBufferAllocator,
  private:
   size_t GetBufferSize() const;
 
+#if !defined(TF_LITE_STRIP_ERROR_STRINGS)
   ErrorReporter* error_reporter_;
+#endif
   uint8_t* buffer_head_;
   uint8_t* buffer_tail_;
   uint8_t* head_;

--- a/tensorflow/lite/micro/micro_allocation_info.h
+++ b/tensorflow/lite/micro/micro_allocation_info.h
@@ -134,7 +134,9 @@ class AllocationInfoBuilder {
 
   const tflite::Model* model_ = nullptr;
   INonPersistentBufferAllocator* non_persistent_allocator_ = nullptr;
+#if !defined(TF_LITE_STRIP_ERROR_STRINGS)
   ErrorReporter* reporter_ = nullptr;
+#endif
 
   GraphAllocationInfo info_;
   int allocation_scope_count_ = 0;

--- a/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
@@ -44,10 +44,6 @@ PLATFORM_FLAGS = \
   $(TARGET_ARCH_DEFINES) \
   -mlongcalls
 
-ifeq ($(BUILD_TYPE), release)
-  PLATFORM_FLAGS += -Wno-unused-private-field
-endif
-
 export PATH := $(XTENSA_BASE)/tools/$(XTENSA_TOOLS_VERSION)/XtensaTools/bin:$(PATH)
 TARGET_TOOLCHAIN_PREFIX := xt-
 CXX_TOOL := clang++


### PR DESCRIPTION
… error reporter, which makes the Xtensa clang compiler

(and perhaps others) throw an "Unused Private Field" error. Although the
makfile defines -Wno-unused-private-field in release build, when building position independent code, xt-clang, for no apparent reason, insists on throwing an error. This seemse to be the only way to avoid the error.

BUG=228871380
.