### PR TITLE
Relax 0 size constraint on intermediate tensors to a warning

### DIFF
--- a/tensorflow/lite/micro/micro_allocation_info.cc
+++ b/tensorflow/lite/micro/micro_allocation_info.cc
@@ -165,9 +165,9 @@ TfLiteStatus AllocationInfoBuilder::ValidateSubgraph(
           &eval_tensors[tensor_index], &tensor_size));
       if (tensor_size != 0) {
         MicroPrintf(
-            "Does not support intermediate tensor with non-zero size: %d",
+            "Warning: intermediate tensor with non-zero size likely waste "
+            "memory: %d",
             tensor_size);
-        return kTfLiteError;
       }
     }
   }


### PR DESCRIPTION
Once customer reports a non-zero size intermediate tensors.
The model is not public available; so this PR is for them
to move ahead and find out more.

BUG=request from customer