### PR TITLE
Rename variable/function name in tflite_size and move file IO out of converter itself to facilitate test

### DIFF
--- a/tensorflow/lite/micro/python/tflite_size/src/BUILD
+++ b/tensorflow/lite/micro/python/tflite_size/src/BUILD
@@ -2,6 +2,8 @@ load("@pybind11_bazel//:build_defs.bzl", "pybind_extension", "pybind_library")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["-layering_check"],
+    licenses = ["notice"],
 )
 
 # Append _lib at the end to avoid naming collision with the extension below

--- a/tensorflow/lite/micro/python/tflite_size/src/flatbuffer_size.cc
+++ b/tensorflow/lite/micro/python/tflite_size/src/flatbuffer_size.cc
@@ -116,7 +116,7 @@ struct IterationVisitor {
   // These mark the scope of a table or struct.
   virtual void StartSequence() {}
   virtual void EndSequence(size_t) {}
-  // Called for each field regardless of wether it is present or not.
+  // Called for each field regardless of whether it is present or not.
   // If not present, val == nullptr. set_idx is the index of all set fields.
   virtual void Field(size_t /*field_idx*/, size_t /*set_idx*/,
                      ElementaryType /*type*/, bool /*is_vector*/,

--- a/tensorflow/lite/micro/python/tflite_size/src/flatbuffer_size_graph.py
+++ b/tensorflow/lite/micro/python/tflite_size/src/flatbuffer_size_graph.py
@@ -50,31 +50,31 @@ class FlatbufferSizeGraph:
     self._root = FNode()
     self._verbose = False
 
-  def _buildNodeForField(self, name, flatbuffer_json):
-    fNode = FNode()
-    fNode.name = name
+  def _build_node_for_field(self, name, flatbuffer_json):
+    node = FNode()
+    node.name = name
 
     if self._verbose:
       print("Start processing %s" % flatbuffer_json)
-      fNode.print()
+      node.print()
 
     if "value" in flatbuffer_json.keys(
     ) and "total_size" in flatbuffer_json.keys():
-      fNode.size = flatbuffer_json["total_size"]
-      self._processValue(fNode, flatbuffer_json["value"])
+      node.size = flatbuffer_json["total_size"]
+      self._process_value(node, flatbuffer_json["value"])
     else:
       raise Exception("Filed not a dict with value and total size!")
 
     if self._verbose:
       print("End processing %s" % flatbuffer_json)
-      fNode.print()
-    return fNode
+      node.print()
+    return node
 
-  def _processValue(self, fNode, value_in_flatbuffer_json):
+  def _process_value(self, node, value_in_flatbuffer_json):
     if type(value_in_flatbuffer_json) is not dict and type(
         value_in_flatbuffer_json) is not list:
-      fNode.value = value_in_flatbuffer_json
-      fNode.isLeaf = True
+      node.value = value_in_flatbuffer_json
+      node.isLeaf = True
 
     if type(value_in_flatbuffer_json) is dict:
       if "value" in value_in_flatbuffer_json.keys(
@@ -83,17 +83,18 @@ class FlatbufferSizeGraph:
             "Field is another dict with value and total size again??")
 
       for name in value_in_flatbuffer_json.keys():
-        fNode.children.append(
-            self._buildNodeForField(name, value_in_flatbuffer_json[name]))
+        node.children.append(
+            self._build_node_for_field(name, value_in_flatbuffer_json[name]))
     elif type(value_in_flatbuffer_json) is list:
       for nidx, next_obj in enumerate(value_in_flatbuffer_json):
-        leaf_name = "%s[%d]" % (fNode.name, nidx)
+        leaf_name = "%s[%d]" % (node.name, nidx)
         # array: "operator_codes": {"value": [{"value": {"version": {"value": 2, "total_size": 4}}, "total_size": 4}], "total_size": 4}
         # so, each element must be of {"value: { field_name: }", total_size}
-        fNode.children.append(self._buildNodeForField(leaf_name, next_obj))
+        node.children.append(self._build_node_for_field(leaf_name, next_obj))
 
-  def createGraph(self, flatbuffer_in_json_with_size):
-    self._root = self._buildNodeForField("ROOT", flatbuffer_in_json_with_size)
+  def create_graph(self, flatbuffer_in_json_with_size):
+    self._root = self._build_node_for_field("ROOT",
+                                            flatbuffer_in_json_with_size)
 
-  def displayGraph(self, graphTraveser):
-    return graphTraveser.displayFlatbuffer(self._root)
+  def display_graph(self, graph_traveser):
+    return graph_traveser.display_flatbuffer(self._root)

--- a/tensorflow/lite/micro/python/tflite_size/src/flatbuffer_size_graph_html_converter.py
+++ b/tensorflow/lite/micro/python/tflite_size/src/flatbuffer_size_graph_html_converter.py
@@ -87,24 +87,23 @@ class HtmlConverter:
   """ A class to convert the size graph to a tree of collapsible list """
 
   def __init__(self):
-    self._htmlBody = HTML_HEAD
+    self._html_body = HTML_HEAD
 
-  def _drawCollapsibleList(self, fNode):
-    #print("visiting %s %d %d " % (fNode.name , fNode.isLeaf, len(fNode.children)))
-    if fNode.isLeaf is True or len(fNode.children) == 0:
-      self._htmlBody += "<li> %s: %s (size: %d) </li>\n" % (
-          fNode.name, fNode.value, fNode.size)
+  def _draw_collapsible_list(self, node):
+    if node.isLeaf is True or len(node.children) == 0:
+      self._html_body += "<li> %s: %s (size: %d) </li>\n" % (
+          node.name, node.value, node.size)
     else:
-      self._htmlBody += "<li> <span class = \"caret\"> %s (size: %d) </span>\n" % (
-          fNode.name, fNode.size)
-      self._htmlBody += "<ul class=\"nested\">\n"
-      for node in fNode.children:
-        self._drawCollapsibleList(node)
-      self._htmlBody += "</ul>\n"
-      self._htmlBody += "</li>\n"
+      self._html_body += "<li> <span class = \"caret\"> %s (size: %d) </span>\n" % (
+          node.name, node.size)
+      self._html_body += "<ul class=\"nested\">\n"
+      for node in node.children:
+        self._draw_collapsible_list(node)
+      self._html_body += "</ul>\n"
+      self._html_body += "</li>\n"
 
-  def displayFlatbuffer(self, rootNode):
-    self._htmlBody = HTML_HEAD
-    self._drawCollapsibleList(rootNode)
-    self._htmlBody += HTML_TAIL
-    return self._htmlBody
+  def display_flatbuffer(self, root):
+    self._html_body = HTML_HEAD
+    self._draw_collapsible_list(root)
+    self._html_body += HTML_TAIL
+    return self._html_body

--- a/tensorflow/lite/micro/python/tflite_size/tests/BUILD
+++ b/tensorflow/lite/micro/python/tflite_size/tests/BUILD
@@ -25,7 +25,7 @@ py_test(
         "noubsan",
     ],
     deps = [
-        "//tensorflow/lite/micro/python/tflite_size/src:flatbuffer_size",
         requirement("tensorflow-cpu"),
+        "//tensorflow/lite/micro/python/tflite_size/src:flatbuffer_size",
     ],
 )

--- a/tensorflow/lite/micro/python/tflite_size/tests/flatbuffer_size_test.py
+++ b/tensorflow/lite/micro/python/tflite_size/tests/flatbuffer_size_test.py
@@ -12,34 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import os
+
 from tensorflow.python.framework import test_util
 from tensorflow.python.platform import test
 from tflite_micro.tensorflow.lite.micro.python.tflite_size.src import flatbuffer_size
 
-root_dir = 'tensorflow/lite/micro/python/tflite_size/tests'
-
 
 class FlatbufferSizeTest(test_util.TensorFlowTestCase):
 
-  def _compareFile(self, file1, file2):
+  def _compareFile(self, file1, data2):
     with open(file1, 'rb') as f1:
       data1 = f1.read()
-    with open(file2, 'rb') as f2:
-      data2 = f2.read()
-    self.assertEqual(data1, data2)
+    self.assertEqual(data1, data2.encode())
 
   def testCompareWithTFLite(self):
+    root_dir = os.path.split(os.path.abspath(__file__))[0]
+
     in_filename = root_dir + '/simple_add_model.tflite'
-    out_json_file = root_dir + '/simple_add_model.json'
-    out_html_file = root_dir + '/simple_add_model.json.html'
     gold_json_file = root_dir + '/gold_simple_add_model_json.txt'
     gold_html_file = root_dir + '/gold_simple_add_model_html.txt'
 
-    flatbuffer_size.convert_tflite_to_html(in_filename, out_html_file,
-                                           out_json_file)
+    with open(in_filename, 'rb') as f:
+      model = f.read()
 
-    self._compareFile(out_json_file, gold_json_file)
-    self._compareFile(out_html_file, gold_html_file)
+    html_string, formatted_json = flatbuffer_size.convert_tflite_to_html(model)
+
+    self._compareFile(gold_json_file, formatted_json)
+    self._compareFile(gold_html_file, html_string)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Follow c-style naming for variable/functions following python style guide
2. Move file IO out of convert_tflite_to_html function. File io make
testing this function hard. 
3. Avoid file write in test and other complaints discovered in importing
   to internal

BUG=discovery these when importing