### PR TITLE
Add DIV and SUM ops to mutable ops resolver.

### DIFF
--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -225,6 +225,10 @@ class MicroMutableOpResolver : public MicroOpResolver {
                      tflite::Register_DETECTION_POSTPROCESS());
   }
 
+  TfLiteStatus AddDiv() {
+    return AddBuiltin(BuiltinOperator_DIV, tflite::Register_DIV(), ParseDiv);
+  }
+
   TfLiteStatus AddElu() {
     return AddBuiltin(BuiltinOperator_ELU, tflite::Register_ELU(), ParseElu);
   }
@@ -528,6 +532,10 @@ class MicroMutableOpResolver : public MicroOpResolver {
 
   TfLiteStatus AddSub() {
     return AddBuiltin(BuiltinOperator_SUB, tflite::Register_SUB(), ParseSub);
+  }
+
+  TfLiteStatus AddReduceSum() {
+    return AddBuiltin(BuiltinOperator_SUM, Register_SUM(), ParseReducer);
   }
 
   TfLiteStatus AddSvdf(


### PR DESCRIPTION
- Add micro implementation for the reduce sum op.
- Fix the error message for supported types in reduce ops
- Refactor reduce_test: replace TestMeanFloatInput4D with the more general version.
- Refactor reduce_test: replace TestMeanOpQuantized with the more general version.
- Add eval helper function for the reduce sum op.
- Use ReduceGeneric for reduce sum implementation.
- Add tests for reduce sum.
- Use MicroPrintf instead of TF_LITE_ENSURE_MSG for errors.
- Port a few more tests for reduce sum from Lite.
- Fix linter issue in reduce_test.cc
- Skip the reduce_sum tests when using Xtensa.
- Don't compile the expected outputs for reduce_sum when running on Xtensa.
- Add operators DIV and SUM to mutable op resolver.
- Add operators DIV and SUM to mutable op resolver.
