### PR TITLE
Error Logging For Nightly Jobs

### DIFF
--- a/.github/scheduled-error-template.md
+++ b/.github/scheduled-error-template.md
@@ -1,0 +1,7 @@
+---
+title: scheduled workflow failed
+labels: bug
+---
+{{ env.WORKFLOW }} run number {{ env.RUN_NUMBER }} failed.  Please examine the run itself for more details.
+
+This issue has been automatically generated for notification purposes.

--- a/.github/scheduled-error-template.md
+++ b/.github/scheduled-error-template.md
@@ -1,5 +1,5 @@
 ---
-title: scheduled workflow failed
+title: Scheduled workflow failed
 labels: bug
 ---
 {{ env.WORKFLOW }} run number {{ env.RUN_NUMBER }} failed.  Please examine the run itself for more details.

--- a/.github/workflows/generate_integration_tests.yml
+++ b/.github/workflows/generate_integration_tests.yml
@@ -39,5 +39,5 @@ jobs:
           RUN_NUMBER: ${{ github.run_number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          assignees: tflm-team
+          assignees: jwithers
           filename: .github/scheduled-error-template.md

--- a/.github/workflows/generate_integration_tests.yml
+++ b/.github/workflows/generate_integration_tests.yml
@@ -31,3 +31,13 @@ jobs:
       - name: Test
         run: |
           tensorflow/lite/micro/tools/ci_build/test_generate_integration_tests.sh
+      - name: error trapping
+        if: ${{ failure() }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          WORKFLOW: ${{ github.workflow }}
+          RUN_NUMBER: ${{ github.run_number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          assignees: tflm-team
+          filename: .github/scheduled-error-template.md

--- a/.github/workflows/generate_integration_tests.yml
+++ b/.github/workflows/generate_integration_tests.yml
@@ -39,5 +39,4 @@ jobs:
           RUN_NUMBER: ${{ github.run_number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          assignees: jwithers
           filename: .github/scheduled-error-template.md


### PR DESCRIPTION
This adds issue creation on error to generate_integration_tests.yml so we can test it. This is a small chunk of boilerplate code that can be added to all of our scheduled jobs to generate an issue when they fail. 

Right now I have the issue being assigned to me. We can either assign it to someone else or skip assignment entirely depending. If we do assign the issue, then that is going to have to be hard coded in the job, since there is nothing in the automation that knows who a scheduled job should belong to for this purpose. 

The rest of the code here is generic and can be added to any scheduled job for issue on error behavior.

BUG=https://issuetracker.google.com/issues/229828377