### PR TITLE
enable reduce_sum kernel tests for Xtensa.

### DIFF
--- a/tensorflow/lite/micro/kernels/reduce_test.cc
+++ b/tensorflow/lite/micro/kernels/reduce_test.cc
@@ -37,11 +37,8 @@ static const int32_t kAxisData2D[] = {1};
 static const int kOutputElements2D = 2;
 static int kOutputShape2D[] = {2, 1, 2};
 static const float kGoldenData2D[] = {2.5, 6.5};
-#if !defined(XTENSA)
-// The reduce sum op doesn't exist in Xtensa optimized reduce kernel, so the
-// tests only make sense outside of Xtensa.
+
 static const float kGoldenDataSum2D[] = {10.0, 26.0};
-#endif
 
 // Common 3D inputs, outputs and axis.
 static const int kInputElements3D = 8;
@@ -54,9 +51,8 @@ static const int32_t kAxisData3D[] = {1, 2};
 static const int kOutputElements3D = 2;
 static int kOutputShape3D[] = {2, 1, 2};
 static const float kGoldenData3D[] = {2.5, 6.5};
-#if !defined(XTENSA)
+
 static const float kGoldenDataSum3D[] = {10.0, 26.0};
-#endif
 
 // Common 4D inputs, outputs and axis.
 static const int kInputElements4D = 24;
@@ -71,12 +67,9 @@ static const int32_t kAxisData4D[] = {1, 2};
 static const int kOutputElements4D = 4;
 static int kOutputShape4D[] = {4, 2, 1, 1, 2};
 static const float kGoldenData4D[] = {6, 7, 18, 19};
-#if !defined(XTENSA)
+
 static const float kGoldenDataSum4D[] = {36, 42, 108, 114};
 static const float kGoldenDataSum4DOverflow[] = {36, 42, 108 - 128, 114 - 128};
-#endif
-
-// Axis shape and contents are independent of input / output dimensions.
 
 template <typename T>
 TfLiteStatus ValidateReduceGoldens(TfLiteTensor* tensors, int tensors_size,
@@ -565,8 +558,6 @@ TF_LITE_MICRO_TEST(MeanInt84DWithoutKeepDimsWithPrecision) {
       output_zero_point, tflite::Register_MEAN(), &params, 1.0);
 }
 
-#if !defined(XTENSA)
-
 TF_LITE_MICRO_TEST(SumFloatFlatten2ReduceDims) {
   int input_shape[] = {3, 4, 3, 2};
   int output_shape[] = {1, 4};
@@ -953,7 +944,5 @@ TF_LITE_MICRO_TEST(SumFloatScalar) {
       input_shape, input_data, axis_shape, axis_data, output_shape,
       actual_output_data, expected_output, tflite::Register_SUM(), &params);
 }
-
-#endif
 
 TF_LITE_MICRO_TESTS_END


### PR DESCRIPTION
PR #1229 ported over reduce sum but did not add a reference fallback to `kernels/xtensa/reduce.cc`. As a result #1229 put the kernel tests behind a `#if !defined(XTENSA)` guard.

Instead of excluding targets in the kernel tests, what we would like to do is add reference code fallbacks to the optimized kernel sources so that we can guarantee that the optimized kernels have the same functionality as the reference kernels (even if not all the code paths are truly optimized).

With PR #1274 (specifically [this commit](https://github.com/tensorflow/tflite-micro/pull/1274/commits/d36c9dd598dcbf352f2c60463fd0d4153703a1cd)), we added reference fallbacks to `xtensa/reduce.cc` but missed the fact that the kernel test cases had been ifdef'd out.

The current PR enables all the kernels test cases for all targets.

BUG=http://b/236681001
