### PR TITLE
Support custom ops on TFLM Python interpreter

### DIFF
--- a/tensorflow/lite/micro/python/interpreter/src/BUILD
+++ b/tensorflow/lite/micro/python/interpreter/src/BUILD
@@ -19,6 +19,7 @@ pybind_library(
         "interpreter_wrapper.h",
         "numpy_utils.h",
         "python_utils.h",
+        "shared_library.h",
     ],
     deps = [
         "//tensorflow/lite/micro:micro_error_reporter",

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
@@ -30,22 +30,62 @@ limitations under the License.
 #include "tensorflow/lite/micro/micro_interpreter.h"
 #include "tensorflow/lite/micro/python/interpreter/src/numpy_utils.h"
 #include "tensorflow/lite/micro/python/interpreter/src/python_utils.h"
+#include "tensorflow/lite/micro/python/interpreter/src/shared_library.h"
 
 namespace tflite {
+namespace {
+// This function looks up the registerer symbol based on the string name
+// `registerer_name`. A registerer in this case is a function that calls the
+// `AddCustom` API of `AllOpsResolver` for custom ops that need to be registered
+// with the interpreter.
+bool AddCustomOpRegistererByName(const char* registerer_name,
+                                 tflite::AllOpsResolver* resolver) {
+  // Registerer functions take a pointer to a AllOpsResolver as an input
+  // parameter and return TfLiteStatus.
+  typedef bool (*RegistererFunctionType)(tflite::AllOpsResolver*);
+
+  // Look for the Registerer function by name.
+  RegistererFunctionType registerer = reinterpret_cast<RegistererFunctionType>(
+      SharedLibrary::GetSymbol(registerer_name));
+
+  // Fail in an informative way if the function was not found.
+  if (registerer == nullptr) {
+    MicroPrintf("Looking up symbol '%s' failed with error '%s'.",
+                registerer_name, SharedLibrary::GetError());
+    return false;
+  }
+
+  // Call the registerer with the resolver.
+  if (!registerer(resolver)) {
+    MicroPrintf(
+        "%s failed to register op. Check that total number of "
+        "ops doesn't exceed the maximum allowed by AllOpsResolver.",
+        registerer_name);
+    return false;
+  }
+
+  return true;
+}
+}  // namespace
 
 InterpreterWrapper::~InterpreterWrapper() {
   // We don't use a unique_ptr for the interpreter because we need to call its
   // destructor before we call Py_DECREF(model_). This ensures that the model
   // is still in scope when MicroGraph:FreeSubgraphs() is called. Otherwise,
   // a segmentation fault could occur.
-  delete interpreter_;
+  if (interpreter_ != nullptr) {
+    delete interpreter_;
+  }
 
   // Undo any references incremented
   Py_DECREF(model_);
 }
 
-InterpreterWrapper::InterpreterWrapper(PyObject* model_data,
-                                       size_t arena_size) {
+InterpreterWrapper::InterpreterWrapper(
+    PyObject* model_data, const std::vector<std::string>& registerers_by_name,
+    size_t arena_size) {
+  interpreter_ = nullptr;
+
   // `model_data` is used as a raw pointer beyond the scope of this
   // constructor, so we need to increment the reference count so that Python
   // doesn't destroy it during the lifetime of this interpreter.
@@ -65,6 +105,17 @@ InterpreterWrapper::InterpreterWrapper(PyObject* model_data,
   model_ = model_data;
   error_reporter_ = std::unique_ptr<ErrorReporter>(new MicroErrorReporter());
   memory_arena_ = std::unique_ptr<uint8_t[]>(new uint8_t[arena_size]);
+
+  for (const auto& registerer : registerers_by_name) {
+    if (!AddCustomOpRegistererByName(registerer.c_str(), &all_ops_resolver_)) {
+      char strbuf[128];
+      snprintf(strbuf, sizeof(strbuf),
+               "TFLM could not register custom op via %s", registerer.c_str());
+      PyErr_SetString(PyExc_RuntimeError, strbuf);
+      return;
+    }
+  }
+
   interpreter_ =
       new MicroInterpreter(model, all_ops_resolver_, memory_arena_.get(),
                            arena_size, error_reporter_.get());

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
@@ -25,7 +25,9 @@ namespace tflite {
 
 class InterpreterWrapper {
  public:
-  InterpreterWrapper(PyObject* model_data, size_t arena_size);
+  InterpreterWrapper(PyObject* model_data,
+                     const std::vector<std::string>& registerers_by_name,
+                     size_t arena_size);
   ~InterpreterWrapper();
 
   int Invoke();
@@ -36,7 +38,7 @@ class InterpreterWrapper {
   const PyObject* model_;
   std::unique_ptr<tflite::ErrorReporter> error_reporter_;
   std::unique_ptr<uint8_t[]> memory_arena_;
-  const tflite::AllOpsResolver all_ops_resolver_;
+  tflite::AllOpsResolver all_ops_resolver_;
   tflite::MicroInterpreter* interpreter_;
 };
 

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper_pybind.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper_pybind.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h"
 
@@ -24,9 +25,11 @@ PYBIND11_MODULE(interpreter_wrapper_pybind, m) {
   m.doc() = "TFLM interpreter";
 
   py::class_<InterpreterWrapper>(m, "InterpreterWrapper")
-      .def(py::init([](const py::bytes& data, size_t arena_size) {
-        return std::unique_ptr<InterpreterWrapper>(
-            new InterpreterWrapper(data.ptr(), arena_size));
+      .def(py::init([](const py::bytes& data,
+                       const std::vector<std::string>& registerers_by_name,
+                       size_t arena_size) {
+        return std::unique_ptr<InterpreterWrapper>(new InterpreterWrapper(
+            data.ptr(), registerers_by_name, arena_size));
       }))
       .def("Invoke", &InterpreterWrapper::Invoke)
       .def(

--- a/tensorflow/lite/micro/python/interpreter/src/shared_library.h
+++ b/tensorflow/lite/micro/python/interpreter/src/shared_library.h
@@ -1,0 +1,40 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This file is forked from TFLite's implementation in
+// //depot/google3/third_party/tensorflow/lite/shared_library.h and contains a
+// subset of it that's required by the TFLM interpreter. The Windows' ifdef is
+// removed because TFLM doesn't support Windows.
+
+#ifndef TENSORFLOW_LITE_MICRO_TOOLS_PYTHON_INTERPRETER_SHARED_LIBRARY_H_
+#define TENSORFLOW_LITE_MICRO_TOOLS_PYTHON_INTERPRETER_SHARED_LIBRARY_H_
+
+#include <dlfcn.h>
+
+namespace tflite {
+
+// SharedLibrary provides a uniform set of APIs across different platforms to
+// handle dynamic library operations
+class SharedLibrary {
+ public:
+  static inline void* GetSymbol(const char* symbol) {
+    return dlsym(RTLD_DEFAULT, symbol);
+  }
+  static inline const char* GetError() { return dlerror(); }
+};
+
+}  // namespace tflite
+
+#endif  // TENSORFLOW_LITE_MICRO_TOOLS_PYTHON_INTERPRETER_SHARED_LIBRARY_H_

--- a/tensorflow/lite/micro/python/interpreter/tests/interpreter_test.py
+++ b/tensorflow/lite/micro/python/interpreter/tests/interpreter_test.py
@@ -148,28 +148,29 @@ class ConvModelTests(test_util.TensorFlowTestCase):
     self.assertFalse(output_ref.alive)
 
   # TODO (b/240162715): Add a test case to register a custom OP
-  
+
   def testMalformedCustomOps(self):
     model_data = generate_test_models.generate_conv_model(False)
     custom_op_registerers = [("wrong", "format")]
-    with self.assertRaisesWithPredicateMatch(
-        ValueError, "must be a list of strings"):
-      interpreter = tflm_runtime.Interpreter.from_bytes(model_data,
-                                                        custom_op_registerers)
+    with self.assertRaisesWithPredicateMatch(ValueError,
+                                             "must be a list of strings"):
+      interpreter = tflm_runtime.Interpreter.from_bytes(
+          model_data, custom_op_registerers)
 
     custom_op_registerers = "WrongFormat"
-    with self.assertRaisesWithPredicateMatch(
-        ValueError, "must be a list of strings"):
-      interpreter = tflm_runtime.Interpreter.from_bytes(model_data,
-                                                        custom_op_registerers)
+    with self.assertRaisesWithPredicateMatch(ValueError,
+                                             "must be a list of strings"):
+      interpreter = tflm_runtime.Interpreter.from_bytes(
+          model_data, custom_op_registerers)
 
   def testNonExistentCustomOps(self):
     model_data = generate_test_models.generate_conv_model(False)
     custom_op_registerers = ["SomeRandomOp"]
     with self.assertRaisesWithPredicateMatch(
         SystemError, "returned a result with an error set"):
-      interpreter = tflm_runtime.Interpreter.from_bytes(model_data,
-                                                        custom_op_registerers)
+      interpreter = tflm_runtime.Interpreter.from_bytes(
+          model_data, custom_op_registerers)
+
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/lite/micro/python/interpreter/tests/interpreter_test.py
+++ b/tensorflow/lite/micro/python/interpreter/tests/interpreter_test.py
@@ -56,10 +56,10 @@ class ConvModelTests(test_util.TensorFlowTestCase):
       data_x = np.random.randint(-127, 127, self.input_shape, dtype=np.int8)
 
       # Run inference on TFLite
-      tflite_interpreter.set_tensor(tflite_input_details['index'], data_x)
+      tflite_interpreter.set_tensor(tflite_input_details["index"], data_x)
       tflite_interpreter.invoke()
       tflite_output = tflite_interpreter.get_tensor(
-          tflite_output_details['index'])
+          tflite_output_details["index"])
 
       # Run inference on TFLM
       tflm_interpreter.set_input(data_x, 0)
@@ -147,6 +147,29 @@ class ConvModelTests(test_util.TensorFlowTestCase):
     self.assertFalse(int_ref.alive)
     self.assertFalse(output_ref.alive)
 
+  # TODO (b/240162715): Add a test case to register a custom OP
+  
+  def testMalformedCustomOps(self):
+    model_data = generate_test_models.generate_conv_model(False)
+    custom_op_registerers = [("wrong", "format")]
+    with self.assertRaisesWithPredicateMatch(
+        ValueError, "must be a list of strings"):
+      interpreter = tflm_runtime.Interpreter.from_bytes(model_data,
+                                                        custom_op_registerers)
 
-if __name__ == '__main__':
+    custom_op_registerers = "WrongFormat"
+    with self.assertRaisesWithPredicateMatch(
+        ValueError, "must be a list of strings"):
+      interpreter = tflm_runtime.Interpreter.from_bytes(model_data,
+                                                        custom_op_registerers)
+
+  def testNonExistentCustomOps(self):
+    model_data = generate_test_models.generate_conv_model(False)
+    custom_op_registerers = ["SomeRandomOp"]
+    with self.assertRaisesWithPredicateMatch(
+        SystemError, "returned a result with an error set"):
+      interpreter = tflm_runtime.Interpreter.from_bytes(model_data,
+                                                        custom_op_registerers)
+
+if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
Allow users to pass in a list of strings to register custom ops. This approach is similar to TFLite Interpreter's approach to look up custom op symbols based on strings. 

BUG=b/236154921