### PR TITLE
templating merge commit message

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,6 +15,9 @@ pull_request_rules:
         name: default
         require_branch_protection: true
         method: squash
+        commit_message_template: |
+          {{ title }}
+          {{ body  }}
 
   - name: remove ci:ready_to_merge label
     conditions:


### PR DESCRIPTION
Mergify merges show all the commits in a merge. This PR changes that to make the merge commit message the PR title and description.

BUG=https://issuetracker.google.com/issues/241138579