### PR TITLE
Fixes to handle enums in constexpr after clang change.

### DIFF
--- a/tensorflow/lite/micro/kernels/circular_buffer_test.cc
+++ b/tensorflow/lite/micro/kernels/circular_buffer_test.cc
@@ -29,7 +29,7 @@ namespace {
 constexpr int kRunPeriod = 2;
 
 // TODO(b/149795762): Add this to TfLiteStatus enum.
-constexpr TfLiteStatus kTfLiteAbort = static_cast<TfLiteStatus>(-9);
+const TfLiteStatus kTfLiteAbort = static_cast<TfLiteStatus>(-9);
 
 }  // namespace
 }  // namespace testing


### PR DESCRIPTION
Change constexpr to const due to Clang update not allowing constexpr value of enum to be more than declared in enum definition.

Clang is restricting the use of out of range values for constexpr enums.  For
enums without a type, their range is only large enough to hold all their values.
For instance, if an enum only has 6 elements without specified values, then the
enum is 3 bits wide, allowing only the values from 0 to 7.  Any numbers outside
that cannot be used in constexpr initialization of an enum value.  In practice,
enums this small would be stored in a larger type, such as an int.  These
changes are the smallest changes to keep the code compiling with this change
in the compiler.  One of the following changes is make:

1) Use const instead of constexpr.  This possibly defers the computation until
run time instead of compile time.
2) Give an underlying type by using scoped enum.  This allows the range of the
enum to be larger without having to specify a large enum element.
3) Use a different, in range value.
4) Use a different type.

These are just quick fixes to keep the code compiling when new compilers are
released.  A different, but more involved change, may be needed.

BUG=[241286585](https://b.corp.google.com/issues/241286585)
https://critique.corp.google.com/cl/465462713
