### PR TITLE
changing to body_raw

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -17,7 +17,7 @@ pull_request_rules:
         method: squash
         commit_message_template: |
           {{ title }}
-          {{ body  }}
+          {{ body_raw  }}
 
   - name: remove ci:ready_to_merge label
     conditions:


### PR DESCRIPTION
Modifying the commit message template to use body_raw instead of the body attribute. This might repair the commit messages having only the PR title and not the description if the description is being mangled by the html/markdown filtering of the body attribute.

BUG=https://issuetracker.google.com/issues/241138579