### PR TITLE
Increase kMaxNumberOfAxis to support SUM operation for conformers.

### DIFF
--- a/tensorflow/lite/micro/kernels/reduce_common.cc
+++ b/tensorflow/lite/micro/kernels/reduce_common.cc
@@ -28,7 +28,7 @@ limitations under the License.
 
 namespace tflite {
 
-const int kMaxNumberOfAxis = 4;
+const int kMaxNumberOfAxis = 5;
 const int kMaxNumberOfReducedAxis = 2;
 
 TfLiteStatus PrepareSimple(TfLiteContext* context, TfLiteNode* node,


### PR DESCRIPTION
Conformers may use the SUM op with 5-dimensional axis.

BUG=#1331