### PR TITLE
Refresh README getting-help for non-TFLM issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,11 @@ The following resources may also be useful:
 
 1.  SIG Micro [gitter chat room](https://gitter.im/tensorflow/sig-micro).
 
-1. For questions that are not specific to inference with TFLM (for example
-   model conversion and quantization) please use the following resources:
-   * Send an email to the [TfLite Mailing List](https://groups.google.com/a/tensorflow.org/g/tflite)
-   * Create a [TensorFlow Lite Converter Issue](https://github.com/tensorflow/tensorflow/issues/new?assignees=&labels=TFLiteConverter&template=60-tflite-converter-issue.md)
-   * Create an issue in the [model optimization toolkit](https://github.com/tensorflow/model-optimization) GitHub repository
-
+1. For questions that are not specific to TFLM, please consult the broader TensorFlow project, e.g.:
+   * Create a topic on the [TensorFlow Discourse forum](https://discuss.tensorflow.org)
+   * Send an email to the [TensorFlow Lite mailing list](https://groups.google.com/a/tensorflow.org/g/tflite)
+   * Create a [TensorFlow issue](https://github.com/tensorflow/tensorflow/issues/new/choose)
+   * Create a [Model Optimization Toolkit](https://github.com/tensorflow/model-optimization) issue
 
 # Additional Documentation
 


### PR DESCRIPTION
Add the forum as the first option, avoid linking to a specific
upstream issue template, and copy-edit for consistency.

BUG=improve docs.