### PR TITLE
Cleanup on the flatbuffer update.

### DIFF
--- a/ci/sync_from_upstream_tf.sh
+++ b/ci/sync_from_upstream_tf.sh
@@ -29,16 +29,11 @@ cd "${ROOT_DIR}"
 
 # As part of the import from upstream TF, we generate the Python bindings for
 # the TfLite flatbuffer schema.
-
-bazel build tensorflow/lite/python:schema_py_generate
-# TODO(b/243588297): Copy will not let you replace the existing generated file.
-rm -rf tensorflow/lite/python/schema_py_generated.py
-/bin/cp bazel-bin/tensorflow/lite/python/schema_py_generate_generated.py tensorflow/lite/python/schema_py_generated.py
+bazel build tensorflow/lite/python:schema_py
+/bin/cp bazel-bin/tensorflow/lite/python/schema_py_generated.py tensorflow/lite/python/schema_py_generated.py
 
 # Also generate C++ bindings with flatc 1.12.0
-bazel build tensorflow/lite/schema:schema_fbs_generate_srcs
-# TODO(b/243588297): Copy will not let you replace the existing generated file.
-rm -rf tensorflow/lite/schema/schema_generated.h
+bazel build tensorflow/lite/schema:schema_fbs_srcs
 /bin/cp ./bazel-bin/tensorflow/lite/schema/schema_generated.h tensorflow/lite/schema/schema_generated.h
 
 rm -rf /tmp/tensorflow

--- a/ci/sync_from_upstream_tf.sh
+++ b/ci/sync_from_upstream_tf.sh
@@ -27,15 +27,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR=${SCRIPT_DIR}/..
 cd "${ROOT_DIR}"
 
-# As part of the import from upstream TF, we generate the Python bindings for
-# the TfLite flatbuffer schema.
-bazel build tensorflow/lite/python:schema_py
-/bin/cp bazel-bin/tensorflow/lite/python/schema_py_generated.py tensorflow/lite/python/schema_py_generated.py
-
-# Also generate C++ bindings with flatc 1.12.0
-bazel build tensorflow/lite/schema:schema_fbs_srcs
-/bin/cp ./bazel-bin/tensorflow/lite/schema/schema_generated.h tensorflow/lite/schema/schema_generated.h
-
 rm -rf /tmp/tensorflow
 
 git clone https://github.com/tensorflow/tensorflow.git --depth=1 /tmp/tensorflow
@@ -47,6 +38,15 @@ do
   mkdir -p $(dirname ${filepath})
   /bin/cp /tmp/tensorflow/${filepath} ${filepath}
 done
+
+# We are still generating and checking in the C++ and Python bindings for the TfLite
+# flatbuffer schema in the nightly sync to keep it working with the Makefiles.
+bazel build tensorflow/lite/python:schema_py
+/bin/cp bazel-bin/tensorflow/lite/python/schema_py_generated.py tensorflow/lite/python/schema_py_generated.py
+
+bazel build tensorflow/lite/schema:schema_fbs_srcs
+/bin/cp ./bazel-bin/tensorflow/lite/schema/schema_generated.h tensorflow/lite/schema/schema_generated.h
+
 
 # The shared TFL/TFLM python code uses a different bazel workspace in the two
 # repositories (TF and tflite-micro) which needs the import statements to be

--- a/tensorflow/lite/micro/tools/ci_build/test_code_style.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_code_style.sh
@@ -37,8 +37,6 @@ FIX_FORMAT_FLAG=${1}
 ############################################################
 # License Check
 ############################################################
-# TODO(b/243716132): schema_generated_with_reflective_type.h has been removed. 
-# No longer need this here, but removing it fails formatting (copyright_notice).
 tensorflow/lite/micro/tools/make/downloads/pigweed/pw_presubmit/py/pw_presubmit/pigweed_presubmit.py \
   tensorflow/lite/kernels/internal/reference/ \
   tensorflow/lite/micro/ \
@@ -46,7 +44,6 @@ tensorflow/lite/micro/tools/make/downloads/pigweed/pw_presubmit/py/pw_presubmit/
   -p copyright_notice \
   -e kernels/internal/reference/integer_ops/ \
   -e kernels/internal/reference/reference_ops.h \
-  -e tensorflow/lite/micro/python/tflite_size/src/schema_generated_with_reflective_type.h \
   -e python/schema_py_generated.py \
   -e tools/make/downloads \
   -e tools/make/targets/ecm3531 \
@@ -95,7 +92,6 @@ tensorflow/lite/micro/tools/make/downloads/pigweed/pw_presubmit/py/pw_presubmit/
   -e experimental \
   -e schema/schema_generated.h \
   -e schema/schema_utils.h \
-  -e tensorflow/lite/micro/python/tflite_size/src/schema_generated_with_reflective_type.h \
   -e "\.inc" \
   -e "\.md"
 

--- a/tensorflow/lite/python/BUILD
+++ b/tensorflow/lite/python/BUILD
@@ -1,31 +1,19 @@
 load("@flatbuffers//:build_defs.bzl", "flatbuffer_py_library")
 load("@tflm_pip_deps//:requirements.bzl", "requirement")
 
-# We are still using a checked in version of the python flatbuffer bindings
-# for the bazel build to keep it consistent with the Makefile build. And
-# the bazel target is called schema_py so that the shared TfLite/TFLM code
-# does not need any change.
-#
-# We have a second schema_py_generate bazel target so that TFLM can create
-# its own version of the bindings from schema.fbs. This is mostly used as part
-# of the nightly sync from upstream TF.
-
-# TODO(b/243587789): Update so we only need one schema_py target (which will
-# generate the schemas). May need to update some dependencies in BUILD files.
-
-flatbuffer_py_library(
-    name = "schema_py_generate",
-    srcs = ["//tensorflow/lite/schema:schema.fbs"],
+package(
+    default_visibility = [
+        "//visibility:public",
+    ],
+    licenses = ["notice"],
 )
 
-py_library(
+# We are still generating and checking in the python bindings in the 
+# nightly sync to keep it working with the Makefiles.
+
+flatbuffer_py_library(
     name = "schema_py",
-    srcs = ["schema_py_generated.py"],
-    srcs_version = "PY3",
-    visibility = ["//:__subpackages__"],
-    deps = [
-        requirement("flatbuffers"),
-    ],
+    srcs = ["//tensorflow/lite/schema:schema.fbs"],
 )
 
 py_library(

--- a/tensorflow/lite/python/BUILD
+++ b/tensorflow/lite/python/BUILD
@@ -8,9 +8,6 @@ package(
     licenses = ["notice"],
 )
 
-# We are still generating and checking in the python bindings in the
-# nightly sync to keep it working with the Makefiles.
-
 flatbuffer_py_library(
     name = "schema_py",
     srcs = ["//tensorflow/lite/schema:schema.fbs"],

--- a/tensorflow/lite/python/BUILD
+++ b/tensorflow/lite/python/BUILD
@@ -8,7 +8,7 @@ package(
     licenses = ["notice"],
 )
 
-# We are still generating and checking in the python bindings in the 
+# We are still generating and checking in the python bindings in the
 # nightly sync to keep it working with the Makefiles.
 
 flatbuffer_py_library(

--- a/tensorflow/lite/schema/BUILD
+++ b/tensorflow/lite/schema/BUILD
@@ -7,9 +7,8 @@ package(
     licenses = ["notice"],
 )
 
-# We are still generating and checking in the C++ bindings in the
-# nightly sync to keep it working with the Makefiles.
-
+# Note: when wanting to generate the schema_generated.h, you must build as:
+# bazel build schema_fbs_srcs.
 flatbuffer_cc_library(
     name = "schema_fbs",
     srcs = ["schema.fbs"],

--- a/tensorflow/lite/schema/BUILD
+++ b/tensorflow/lite/schema/BUILD
@@ -7,7 +7,7 @@ package(
     licenses = ["notice"],
 )
 
-# We are still generating and checking in the C++ bindings in the 
+# We are still generating and checking in the C++ bindings in the
 # nightly sync to keep it working with the Makefiles.
 
 flatbuffer_cc_library(

--- a/tensorflow/lite/schema/BUILD
+++ b/tensorflow/lite/schema/BUILD
@@ -7,28 +7,11 @@ package(
     licenses = ["notice"],
 )
 
-# We are still using a checked in version of the C++ flatbuffer bindings
-# for the bazel build to keep it consistent with the Makefile build. And
-# the bazel target is called schema_fbs so that the shared TfLite/TFLM code
-# does not need any change.
-#
-# We have a second schema_fbs_generate bazel target so that TFLM can create
-# its own version of the bindings from schema.fbs. This is mostly used as part
-# of the nightly sync from upstream TF.
-
-# TODO(b/243587789): Update so we only need one schema_fbs target (which will
-# generate the schemas). May need to update some dependencies in BUILD files.
-
-cc_library(
-    name = "schema_fbs",
-    hdrs = ["schema_generated.h"],
-    deps = [
-        "@flatbuffers//:runtime_cc",
-    ],
-)
+# We are still generating and checking in the C++ bindings in the 
+# nightly sync to keep it working with the Makefiles.
 
 flatbuffer_cc_library(
-    name = "schema_fbs_generate",
+    name = "schema_fbs",
     srcs = ["schema.fbs"],
 )
 


### PR DESCRIPTION
This is to cleanup some code after the latest flatbuffer version update PR.
* Update build targets in schema files to only have the original builds, :schema_fbs and :schema_py.
* Fix checking in of schema in nightly sync.
* Remove unneeded lines (of a deleted file) in copyright and license checks.


Bugs:
BUG= [243587789](https://buganizer.corp.google.com/issues/243587789)
BUG= [243588297](https://buganizer.corp.google.com/issues/243588297)
BUG= [243716132](https://buganizer.corp.google.com/issues/243716132)