### PR TITLE
Add reset function into the python wrapper

### DIFF
--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
@@ -133,6 +133,8 @@ InterpreterWrapper::InterpreterWrapper(
 
 int InterpreterWrapper::Invoke() { return interpreter_->Invoke(); }
 
+int InterpreterWrapper::Reset() { return interpreter_->Reset(); }
+
 // 1. Check that tensor and input array are safe to access
 // 2. Verify that input array metadata matches tensor metadata
 // 3. Copy input buffer into target input tensor

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
@@ -31,6 +31,7 @@ class InterpreterWrapper {
   ~InterpreterWrapper();
 
   int Invoke();
+  int Reset();
   void SetInputTensor(PyObject* data, size_t index);
   PyObject* GetOutputTensor(size_t index);
 

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper_pybind.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper_pybind.cc
@@ -32,6 +32,7 @@ PYBIND11_MODULE(interpreter_wrapper_pybind, m) {
             data.ptr(), registerers_by_name, arena_size));
       }))
       .def("Invoke", &InterpreterWrapper::Invoke)
+      .def("Reset", &InterpreterWrapper::Reset)
       .def(
           "SetInputTensor",
           [](InterpreterWrapper& self, py::handle& x, size_t index) {

--- a/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
+++ b/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
@@ -86,6 +86,19 @@ class Interpreter(object):
     """
     return self._interpreter.Invoke()
 
+  def reset(self):
+    """Reset the model state to be what you would expect when the interpreter is first
+    created. i.e. after Init and Prepare is called for the very first time.
+
+    This should be called after invoke stateful model like LSTM.
+
+    Returns:
+      Status code of the C++ invoke function. A RuntimeError will be raised as
+      well upon any error.
+    """
+
+    return self._interpreter.Reset()
+
   def set_input(self, input_data, index):
     """Set input data into input tensor.
 

--- a/tensorflow/lite/micro/python/interpreter/tests/interpreter_test.py
+++ b/tensorflow/lite/micro/python/interpreter/tests/interpreter_test.py
@@ -73,10 +73,6 @@ class ConvModelTests(test_util.TensorFlowTestCase):
       # TODO: Remove tolerance when the bug is fixed.
       self.assertAllLessEqual((tflite_output - tflm_output), 1)
 
-      # Reset the model state
-      tflm_interpreter.reset()
-      tflite_interpreter.reset_all_variables()
-
   def testModelFromFileAndBufferEqual(self):
     model_data = generate_test_models.generate_conv_model(True, self.filename)
 

--- a/tensorflow/lite/micro/python/interpreter/tests/interpreter_test.py
+++ b/tensorflow/lite/micro/python/interpreter/tests/interpreter_test.py
@@ -73,6 +73,10 @@ class ConvModelTests(test_util.TensorFlowTestCase):
       # TODO: Remove tolerance when the bug is fixed.
       self.assertAllLessEqual((tflite_output - tflm_output), 1)
 
+      # Reset the model state
+      tflm_interpreter.reset()
+      tflite_interpreter.reset_all_variables()
+
   def testModelFromFileAndBufferEqual(self):
     model_data = generate_test_models.generate_conv_model(True, self.filename)
 


### PR DESCRIPTION
Some models such as LSTM are stateful, which requires state reset after each inference. This PR adds the model reset function, which has already been implemented in C++, into the TFLM python interpreter. 

BUG=http://b/244330968