### PR TITLE
Fix: broken link

### DIFF
--- a/tensorflow/lite/micro/examples/magic_wand/train/train_magic_wand_model.ipynb
+++ b/tensorflow/lite/micro/examples/magic_wand/train/train_magic_wand_model.ipynb
@@ -74,9 +74,9 @@
       "outputs": [],
       "source": [
         "# Clone the repository from GitHub\n",
-        "!git clone --depth 1 -q https://github.com/tensorflow/tensorflow\n",
+        "!git clone --depth 1 -q https://github.com/tensorflow/tflite-micro\n",
         "# Copy the training scripts into our workspace\n",
-        "!cp -r tensorflow/tensorflow/lite/micro/examples/magic_wand/train train"
+        "!cp -r tflite-micro/tensorflow/lite/micro/examples/magic_wand/train train"
       ]
     },
     {


### PR DESCRIPTION
This colab still had the old tensorflow/tensorflow github link for the tflite-micro examples. This PR fixes that link to the new (and working) tensorflow/tflite-micro github link.

BUG=doc cleanup