### PR TITLE
Fix TF 1.x deprecation speech training notebook

### DIFF
--- a/tensorflow/lite/micro/examples/micro_speech/train/train_micro_speech_model.ipynb
+++ b/tensorflow/lite/micro/examples/micro_speech/train/train_micro_speech_model.ipynb
@@ -175,7 +175,8 @@
         "colab": {}
       },
       "source": [
-        "%tensorflow_version 1.x\n",
+        "!pip uninstall -y tensorflow\n",
+        "!pip install tensorflow-cpu==1.15\n",
         "import tensorflow as tf"
       ],
       "execution_count": null,


### PR DESCRIPTION
Google Colabs removed support for the `%tensorflow 1.x` directive in August 2022. This notebook still relies on 1.x functionality, and isn't easy to adapt, as noted in #1426, so I've suggested a change that switches to the 1.15 CPU version of the framework. This doesn't take advantage of the GPU, so it's a bit slower, but only increases the time to about two hours instead of one in my experiments, so I think it's the least-worst option.