### PR TITLE
Update TFLM examples to clean-up the usage of ErrorReporter

### DIFF
--- a/tensorflow/lite/micro/examples/hello_world/BUILD
+++ b/tensorflow/lite/micro/examples/hello_world/BUILD
@@ -43,8 +43,8 @@ cc_test(
     ],
     deps = [
         ":model",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro/testing:micro_test",
         "//tensorflow/lite/schema:schema_fbs",
@@ -62,7 +62,7 @@ cc_library(
     copts = micro_copts(),
     deps = [
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
+        "//tensorflow/lite/micro:micro_log",
     ],
 )
 
@@ -92,8 +92,8 @@ cc_binary(
         ":constants",
         ":model",
         ":output_handler",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:system_setup",
         "//tensorflow/lite/schema:schema_fbs",

--- a/tensorflow/lite/micro/examples/hello_world/hello_world_test.cc
+++ b/tensorflow/lite/micro/examples/hello_world/hello_world_test.cc
@@ -17,8 +17,8 @@ limitations under the License.
 
 #include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/examples/hello_world/hello_world_model_data.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
 #include "tensorflow/lite/schema/schema_generated.h"
 
@@ -29,17 +29,14 @@ TF_LITE_MICRO_TEST(LoadModelAndPerformInference) {
   float x = 0.0f;
   float y_true = sin(x);
 
-  // Set up logging
-  tflite::MicroErrorReporter micro_error_reporter;
-
   // Map the model into a usable data structure. This doesn't involve any
   // copying or parsing, it's a very lightweight operation.
   const tflite::Model* model = ::tflite::GetModel(g_hello_world_model_data);
   if (model->version() != TFLITE_SCHEMA_VERSION) {
-    TF_LITE_REPORT_ERROR(&micro_error_reporter,
-                         "Model provided is schema version %d not equal "
-                         "to supported version %d.\n",
-                         model->version(), TFLITE_SCHEMA_VERSION);
+    MicroPrintf(
+        "Model provided is schema version %d not equal "
+        "to supported version %d.\n",
+        model->version(), TFLITE_SCHEMA_VERSION);
   }
 
   // This pulls in all the operation implementations we need
@@ -50,7 +47,7 @@ TF_LITE_MICRO_TEST(LoadModelAndPerformInference) {
 
   // Build an interpreter to run the model with
   tflite::MicroInterpreter interpreter(model, resolver, tensor_arena,
-                                       kTensorArenaSize, &micro_error_reporter);
+                                       kTensorArenaSize);
   // Allocate memory from the tensor_arena for the model's tensors
   TF_LITE_MICRO_EXPECT_EQ(interpreter.AllocateTensors(), kTfLiteOk);
 

--- a/tensorflow/lite/micro/examples/hello_world/main_functions.cc
+++ b/tensorflow/lite/micro/examples/hello_world/main_functions.cc
@@ -19,14 +19,13 @@ limitations under the License.
 #include "tensorflow/lite/micro/examples/hello_world/constants.h"
 #include "tensorflow/lite/micro/examples/hello_world/hello_world_model_data.h"
 #include "tensorflow/lite/micro/examples/hello_world/output_handler.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/system_setup.h"
 #include "tensorflow/lite/schema/schema_generated.h"
 
 // Globals, used for compatibility with Arduino-style sketches.
 namespace {
-tflite::ErrorReporter* error_reporter = nullptr;
 const tflite::Model* model = nullptr;
 tflite::MicroInterpreter* interpreter = nullptr;
 TfLiteTensor* input = nullptr;
@@ -41,20 +40,14 @@ uint8_t tensor_arena[kTensorArenaSize];
 void setup() {
   tflite::InitializeTarget();
 
-  // Set up logging. Google style is to avoid globals or statics because of
-  // lifetime uncertainty, but since this has a trivial destructor it's okay.
-  // NOLINTNEXTLINE(runtime-global-variables)
-  static tflite::MicroErrorReporter micro_error_reporter;
-  error_reporter = &micro_error_reporter;
-
   // Map the model into a usable data structure. This doesn't involve any
   // copying or parsing, it's a very lightweight operation.
   model = tflite::GetModel(g_hello_world_model_data);
   if (model->version() != TFLITE_SCHEMA_VERSION) {
-    TF_LITE_REPORT_ERROR(error_reporter,
-                         "Model provided is schema version %d not equal "
-                         "to supported version %d.",
-                         model->version(), TFLITE_SCHEMA_VERSION);
+    MicroPrintf(
+        "Model provided is schema version %d not equal "
+        "to supported version %d.",
+        model->version(), TFLITE_SCHEMA_VERSION);
     return;
   }
 
@@ -64,13 +57,13 @@ void setup() {
 
   // Build an interpreter to run the model with.
   static tflite::MicroInterpreter static_interpreter(
-      model, resolver, tensor_arena, kTensorArenaSize, error_reporter);
+      model, resolver, tensor_arena, kTensorArenaSize);
   interpreter = &static_interpreter;
 
   // Allocate memory from the tensor_arena for the model's tensors.
   TfLiteStatus allocate_status = interpreter->AllocateTensors();
   if (allocate_status != kTfLiteOk) {
-    TF_LITE_REPORT_ERROR(error_reporter, "AllocateTensors() failed");
+    MicroPrintf("AllocateTensors() failed");
     return;
   }
 
@@ -100,8 +93,7 @@ void loop() {
   // Run inference, and report any error
   TfLiteStatus invoke_status = interpreter->Invoke();
   if (invoke_status != kTfLiteOk) {
-    TF_LITE_REPORT_ERROR(error_reporter, "Invoke failed on x: %f\n",
-                         static_cast<double>(x));
+    MicroPrintf("Invoke failed on x: %f\n", static_cast<double>(x));
     return;
   }
 
@@ -112,7 +104,7 @@ void loop() {
 
   // Output the results. A custom HandleOutput function can be implemented
   // for each supported hardware target.
-  HandleOutput(error_reporter, x, y);
+  HandleOutput(x, y);
 
   // Increment the inference_counter, and reset it if we have reached
   // the total number per cycle

--- a/tensorflow/lite/micro/examples/hello_world/output_handler.cc
+++ b/tensorflow/lite/micro/examples/hello_world/output_handler.cc
@@ -15,10 +15,10 @@ limitations under the License.
 
 #include "tensorflow/lite/micro/examples/hello_world/output_handler.h"
 
-void HandleOutput(tflite::ErrorReporter* error_reporter, float x_value,
-                  float y_value) {
+#include "tensorflow/lite/micro/micro_log.h"
+
+void HandleOutput(float x_value, float y_value) {
   // Log the current X and Y values
-  TF_LITE_REPORT_ERROR(error_reporter, "x_value: %f, y_value: %f\n",
-                       static_cast<double>(x_value),
-                       static_cast<double>(y_value));
+  MicroPrintf("x_value: %f, y_value: %f\n", static_cast<double>(x_value),
+              static_cast<double>(y_value));
 }

--- a/tensorflow/lite/micro/examples/hello_world/output_handler.h
+++ b/tensorflow/lite/micro/examples/hello_world/output_handler.h
@@ -17,10 +17,8 @@ limitations under the License.
 #define TENSORFLOW_LITE_MICRO_EXAMPLES_HELLO_WORLD_OUTPUT_HANDLER_H_
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 
 // Called by the main loop to produce some output based on the x and y values
-void HandleOutput(tflite::ErrorReporter* error_reporter, float x_value,
-                  float y_value);
+void HandleOutput(float x_value, float y_value);
 
 #endif  // TENSORFLOW_LITE_MICRO_EXAMPLES_HELLO_WORLD_OUTPUT_HANDLER_H_

--- a/tensorflow/lite/micro/examples/hello_world/output_handler_test.cc
+++ b/tensorflow/lite/micro/examples/hello_world/output_handler_test.cc
@@ -20,12 +20,10 @@ limitations under the License.
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestCallability) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
   // This will have external side-effects (like printing to the debug console
   // or lighting an LED) that are hard to observe, so the most we can do is
   // make sure the call doesn't crash.
-  HandleOutput(&micro_error_reporter, 0, 0);
+  HandleOutput(0, 0);
 }
 
 TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/examples/magic_wand/BUILD
+++ b/tensorflow/lite/micro/examples/magic_wand/BUILD
@@ -51,8 +51,8 @@ cc_test(
     deps = [
         ":magic_wand_model_data",
         ":sample_feature_data",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro/testing:micro_test",
         "//tensorflow/lite/schema:schema_fbs",
@@ -76,7 +76,6 @@ cc_library(
     ],
     deps = [
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
     ],
 )
 
@@ -88,7 +87,6 @@ cc_test(
     deps = [
         ":accelerometer_handler",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro/testing:micro_test",
@@ -131,7 +129,7 @@ cc_library(
     ],
     deps = [
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
+        "//tensorflow/lite/micro:micro_log",
     ],
 )
 
@@ -165,7 +163,6 @@ cc_binary(
         ":gesture_predictor",
         ":magic_wand_model_data",
         ":output_handler",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:system_setup",

--- a/tensorflow/lite/micro/examples/magic_wand/accelerometer_handler.cc
+++ b/tensorflow/lite/micro/examples/magic_wand/accelerometer_handler.cc
@@ -17,12 +17,9 @@ limitations under the License.
 
 int begin_index = 0;
 
-TfLiteStatus SetupAccelerometer(tflite::ErrorReporter* error_reporter) {
-  return kTfLiteOk;
-}
+TfLiteStatus SetupAccelerometer() { return kTfLiteOk; }
 
-bool ReadAccelerometer(tflite::ErrorReporter* error_reporter, float* input,
-                       int length) {
+bool ReadAccelerometer(float* input, int length) {
   begin_index += 3;
   // Reset begin_index to simulate behavior of loop buffer
   if (begin_index >= 600) begin_index = 0;

--- a/tensorflow/lite/micro/examples/magic_wand/accelerometer_handler.h
+++ b/tensorflow/lite/micro/examples/magic_wand/accelerometer_handler.h
@@ -19,11 +19,9 @@ limitations under the License.
 #define kChannelNumber 3
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 
 extern int begin_index;
-extern TfLiteStatus SetupAccelerometer(tflite::ErrorReporter* error_reporter);
-extern bool ReadAccelerometer(tflite::ErrorReporter* error_reporter,
-                              float* input, int length);
+extern TfLiteStatus SetupAccelerometer();
+extern bool ReadAccelerometer(float* input, int length);
 
 #endif  // TENSORFLOW_LITE_MICRO_EXAMPLES_MAGIC_WAND_ACCELEROMETER_HANDLER_H_

--- a/tensorflow/lite/micro/examples/magic_wand/accelerometer_handler_test.cc
+++ b/tensorflow/lite/micro/examples/magic_wand/accelerometer_handler_test.cc
@@ -18,28 +18,25 @@ limitations under the License.
 #include <string.h>
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
 
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestSetup) {
-  tflite::MicroErrorReporter micro_error_reporter;
-  TfLiteStatus setup_status = SetupAccelerometer(&micro_error_reporter);
+  TfLiteStatus setup_status = SetupAccelerometer();
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, setup_status);
 }
 
 TF_LITE_MICRO_TEST(TestAccelerometer) {
   float input[384] = {0.0};
-  tflite::MicroErrorReporter micro_error_reporter;
   // Test that the function returns false before insufficient data is available
-  bool inference_flag = ReadAccelerometer(&micro_error_reporter, input, 384);
+  bool inference_flag = ReadAccelerometer(input, 384);
   TF_LITE_MICRO_EXPECT_EQ(inference_flag, false);
 
   // Test that the function returns true once sufficient data is available to
   // fill the model's input buffer (128 sets of values)
   for (int i = 1; i <= 128; i++) {
-    inference_flag = ReadAccelerometer(&micro_error_reporter, input, 384);
+    inference_flag = ReadAccelerometer(input, 384);
   }
   TF_LITE_MICRO_EXPECT_EQ(inference_flag, true);
 }

--- a/tensorflow/lite/micro/examples/magic_wand/magic_wand_test.cc
+++ b/tensorflow/lite/micro/examples/magic_wand/magic_wand_test.cc
@@ -16,8 +16,8 @@ limitations under the License.
 #include "tensorflow/lite/micro/examples/magic_wand/magic_wand_model_data.h"
 #include "tensorflow/lite/micro/examples/magic_wand/ring_micro_features_data.h"
 #include "tensorflow/lite/micro/examples/magic_wand/slope_micro_features_data.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
 #include "tensorflow/lite/schema/schema_generated.h"
@@ -25,17 +25,14 @@ limitations under the License.
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(LoadModelAndPerformInference) {
-  // Set up logging
-  tflite::MicroErrorReporter micro_error_reporter;
-
   // Map the model into a usable data structure. This doesn't involve any
   // copying or parsing, it's a very lightweight operation.
   const tflite::Model* model = ::tflite::GetModel(g_magic_wand_model_data);
   if (model->version() != TFLITE_SCHEMA_VERSION) {
-    TF_LITE_REPORT_ERROR(&micro_error_reporter,
-                         "Model provided is schema version %d not equal "
-                         "to supported version %d.\n",
-                         model->version(), TFLITE_SCHEMA_VERSION);
+    MicroPrintf(
+        "Model provided is schema version %d not equal "
+        "to supported version %d.\n",
+        model->version(), TFLITE_SCHEMA_VERSION);
   }
 
   // Pull in only the operation implementations we need.
@@ -57,8 +54,7 @@ TF_LITE_MICRO_TEST(LoadModelAndPerformInference) {
 
   // Build an interpreter to run the model with
   tflite::MicroInterpreter interpreter(model, micro_op_resolver, tensor_arena,
-                                       tensor_arena_size,
-                                       &micro_error_reporter);
+                                       tensor_arena_size);
 
   // Allocate memory from the tensor_arena for the model's tensors
   interpreter.AllocateTensors();
@@ -79,7 +75,7 @@ TF_LITE_MICRO_TEST(LoadModelAndPerformInference) {
 
   // Provide an input value
   const float* ring_features_data = g_ring_micro_f9643d42_nohash_4_data;
-  TF_LITE_REPORT_ERROR(&micro_error_reporter, "%d", input->bytes);
+  MicroPrintf("%d", input->bytes);
   for (size_t i = 0; i < (input->bytes / sizeof(float)); ++i) {
     input->data.f[i] = ring_features_data[i];
   }
@@ -87,7 +83,7 @@ TF_LITE_MICRO_TEST(LoadModelAndPerformInference) {
   // Run the model on this input and check that it succeeds
   TfLiteStatus invoke_status = interpreter.Invoke();
   if (invoke_status != kTfLiteOk) {
-    TF_LITE_REPORT_ERROR(&micro_error_reporter, "Invoke failed\n");
+    MicroPrintf("Invoke failed\n");
   }
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, invoke_status);
 
@@ -124,7 +120,7 @@ TF_LITE_MICRO_TEST(LoadModelAndPerformInference) {
   // Run the model on this "Slope" input.
   invoke_status = interpreter.Invoke();
   if (invoke_status != kTfLiteOk) {
-    TF_LITE_REPORT_ERROR(&micro_error_reporter, "Invoke failed\n");
+    MicroPrintf("Invoke failed\n");
   }
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, invoke_status);
 

--- a/tensorflow/lite/micro/examples/magic_wand/main_functions.cc
+++ b/tensorflow/lite/micro/examples/magic_wand/main_functions.cc
@@ -20,15 +20,14 @@ limitations under the License.
 #include "tensorflow/lite/micro/examples/magic_wand/gesture_predictor.h"
 #include "tensorflow/lite/micro/examples/magic_wand/magic_wand_model_data.h"
 #include "tensorflow/lite/micro/examples/magic_wand/output_handler.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 #include "tensorflow/lite/micro/system_setup.h"
 #include "tensorflow/lite/schema/schema_generated.h"
 
 // Globals, used for compatibility with Arduino-style sketches.
 namespace {
-tflite::ErrorReporter* error_reporter = nullptr;
 const tflite::Model* model = nullptr;
 tflite::MicroInterpreter* interpreter = nullptr;
 TfLiteTensor* model_input = nullptr;
@@ -45,19 +44,14 @@ uint8_t tensor_arena[kTensorArenaSize];
 void setup() {
   tflite::InitializeTarget();
 
-  // Set up logging. Google style is to avoid globals or statics because of
-  // lifetime uncertainty, but since this has a trivial destructor it's okay.
-  static tflite::MicroErrorReporter micro_error_reporter;  // NOLINT
-  error_reporter = &micro_error_reporter;
-
   // Map the model into a usable data structure. This doesn't involve any
   // copying or parsing, it's a very lightweight operation.
   model = tflite::GetModel(g_magic_wand_model_data);
   if (model->version() != TFLITE_SCHEMA_VERSION) {
-    TF_LITE_REPORT_ERROR(error_reporter,
-                         "Model provided is schema version %d not equal "
-                         "to supported version %d.",
-                         model->version(), TFLITE_SCHEMA_VERSION);
+    MicroPrintf(
+        "Model provided is schema version %d not equal "
+        "to supported version %d.",
+        model->version(), TFLITE_SCHEMA_VERSION);
     return;
   }
 
@@ -75,7 +69,7 @@ void setup() {
 
   // Build an interpreter to run the model with.
   static tflite::MicroInterpreter static_interpreter(
-      model, micro_op_resolver, tensor_arena, kTensorArenaSize, error_reporter);
+      model, micro_op_resolver, tensor_arena, kTensorArenaSize);
   interpreter = &static_interpreter;
 
   // Allocate memory from the tensor_arena for the model's tensors.
@@ -87,36 +81,33 @@ void setup() {
       (model_input->dims->data[1] != 128) ||
       (model_input->dims->data[2] != kChannelNumber) ||
       (model_input->type != kTfLiteFloat32)) {
-    TF_LITE_REPORT_ERROR(error_reporter,
-                         "Bad input tensor parameters in model");
+    MicroPrintf("Bad input tensor parameters in model");
     return;
   }
 
   input_length = model_input->bytes / sizeof(float);
 
-  TfLiteStatus setup_status = SetupAccelerometer(error_reporter);
+  TfLiteStatus setup_status = SetupAccelerometer();
   if (setup_status != kTfLiteOk) {
-    TF_LITE_REPORT_ERROR(error_reporter, "Set up failed\n");
+    MicroPrintf("Set up failed\n");
   }
 }
 
 void loop() {
   // Attempt to read new data from the accelerometer.
-  bool got_data =
-      ReadAccelerometer(error_reporter, model_input->data.f, input_length);
+  bool got_data = ReadAccelerometer(model_input->data.f, input_length);
   // If there was no new data, wait until next time.
   if (!got_data) return;
 
   // Run inference, and report any error.
   TfLiteStatus invoke_status = interpreter->Invoke();
   if (invoke_status != kTfLiteOk) {
-    TF_LITE_REPORT_ERROR(error_reporter, "Invoke failed on index: %d\n",
-                         begin_index);
+    MicroPrintf("Invoke failed on index: %d\n", begin_index);
     return;
   }
   // Analyze the results to obtain a prediction
   int gesture_index = PredictGesture(interpreter->output(0)->data.f);
 
   // Produce an output
-  HandleOutput(error_reporter, gesture_index);
+  HandleOutput(gesture_index);
 }

--- a/tensorflow/lite/micro/examples/magic_wand/output_handler.cc
+++ b/tensorflow/lite/micro/examples/magic_wand/output_handler.cc
@@ -15,23 +15,22 @@ limitations under the License.
 
 #include "tensorflow/lite/micro/examples/magic_wand/output_handler.h"
 
-void HandleOutput(tflite::ErrorReporter* error_reporter, int kind) {
+#include "tensorflow/lite/micro/micro_log.h"
+
+void HandleOutput(int kind) {
   // light (red: wing, blue: ring, green: slope)
   if (kind == 0) {
-    TF_LITE_REPORT_ERROR(
-        error_reporter,
+    MicroPrintf(
         "WING:\n\r*         *         *\n\r *       * *       "
         "*\n\r  *     *   *     *\n\r   *   *     *   *\n\r    * *       "
         "* *\n\r     *         *\n\r");
   } else if (kind == 1) {
-    TF_LITE_REPORT_ERROR(
-        error_reporter,
+    MicroPrintf(
         "RING:\n\r          *\n\r       *     *\n\r     *         *\n\r "
         "   *           *\n\r     *         *\n\r       *     *\n\r      "
         "    *\n\r");
   } else if (kind == 2) {
-    TF_LITE_REPORT_ERROR(
-        error_reporter,
+    MicroPrintf(
         "SLOPE:\n\r        *\n\r       *\n\r      *\n\r     *\n\r    "
         "*\n\r   *\n\r  *\n\r * * * * * * * *\n\r");
   }

--- a/tensorflow/lite/micro/examples/magic_wand/output_handler.h
+++ b/tensorflow/lite/micro/examples/magic_wand/output_handler.h
@@ -17,8 +17,7 @@ limitations under the License.
 #define TENSORFLOW_LITE_MICRO_EXAMPLES_MAGIC_WAND_OUTPUT_HANDLER_H_
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 
-void HandleOutput(tflite::ErrorReporter* error_reporter, int kind);
+void HandleOutput(int kind);
 
 #endif  // TENSORFLOW_LITE_MICRO_EXAMPLES_MAGIC_WAND_OUTPUT_HANDLER_H_

--- a/tensorflow/lite/micro/examples/magic_wand/output_handler_test.cc
+++ b/tensorflow/lite/micro/examples/magic_wand/output_handler_test.cc
@@ -20,11 +20,10 @@ limitations under the License.
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestCallability) {
-  tflite::MicroErrorReporter micro_error_reporter;
-  HandleOutput(&micro_error_reporter, 0);
-  HandleOutput(&micro_error_reporter, 1);
-  HandleOutput(&micro_error_reporter, 2);
-  HandleOutput(&micro_error_reporter, 3);
+  HandleOutput(0);
+  HandleOutput(1);
+  HandleOutput(2);
+  HandleOutput(3);
 }
 
 TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/examples/memory_footprint/BUILD
+++ b/tensorflow/lite/micro/examples/memory_footprint/BUILD
@@ -46,7 +46,6 @@ cc_binary(
     deps = [
         ":simple_add_model_data",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_profiler",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:system_setup",

--- a/tensorflow/lite/micro/examples/micro_speech/BUILD
+++ b/tensorflow/lite/micro/examples/micro_speech/BUILD
@@ -108,8 +108,8 @@ cc_test(
     ],
     deps = [
         ":micro_speech_model_data",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro/examples/micro_speech/micro_features:micro_features_test_data",
         "//tensorflow/lite/micro/testing:micro_test",
@@ -164,7 +164,7 @@ cc_library(
     deps = [
         ":simple_model_settings",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
+        "//tensorflow/lite/micro:micro_log",
     ],
 )
 
@@ -179,8 +179,8 @@ cc_test(
         ":simple_features_generator_test_data",
         ":simple_model_settings",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro/testing:micro_test",
     ],
 )
@@ -196,7 +196,7 @@ cc_library(
     deps = [
         ":simple_model_settings",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
+        "//tensorflow/lite/micro:micro_log",
     ],
 )
 
@@ -211,8 +211,8 @@ cc_test(
         ":simple_features_generator_test_data",
         ":simple_model_settings",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro/testing:micro_test",
     ],
 )
@@ -227,7 +227,6 @@ cc_library(
     ],
     deps = [
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro/examples/micro_speech/micro_features:micro_model_settings",
     ],
 )
@@ -243,7 +242,6 @@ cc_library(
     deps = [
         ":audio_large_sample_test_data",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro/examples/micro_speech/micro_features:micro_model_settings",
     ],
 )
@@ -256,7 +254,6 @@ cc_test(
     deps = [
         ":audio_provider",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
         "//tensorflow/lite/micro/examples/micro_speech/micro_features:micro_model_settings",
         "//tensorflow/lite/micro/testing:micro_test",
@@ -272,7 +269,6 @@ cc_test(
         ":audio_large_sample_test_data",
         ":audio_provider_mock",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
         "//tensorflow/lite/micro/examples/micro_speech/micro_features:micro_model_settings",
         "//tensorflow/lite/micro/testing:micro_test",
@@ -290,7 +286,7 @@ cc_library(
     deps = [
         ":audio_provider",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro/examples/micro_speech/micro_features:micro_features_generator",
         "//tensorflow/lite/micro/examples/micro_speech/micro_features:micro_model_settings",
     ],
@@ -305,7 +301,6 @@ cc_test(
         ":audio_provider",
         ":feature_provider",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
         "//tensorflow/lite/micro/examples/micro_speech/micro_features:micro_model_settings",
         "//tensorflow/lite/micro/testing:micro_test",
@@ -323,7 +318,7 @@ cc_library(
     deps = [
         ":audio_provider_mock",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro/examples/micro_speech/micro_features:micro_features_generator",
         "//tensorflow/lite/micro/examples/micro_speech/micro_features:micro_model_settings",
     ],
@@ -341,7 +336,6 @@ cc_test(
     deps = [
         ":feature_provider_mock",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
         "//tensorflow/lite/micro/examples/micro_speech/micro_features:micro_features_test_data",
         "//tensorflow/lite/micro/examples/micro_speech/micro_features:micro_model_settings",
@@ -359,7 +353,7 @@ cc_library(
     ],
     deps = [
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro/examples/micro_speech/micro_features:micro_model_settings",
     ],
 )
@@ -375,8 +369,8 @@ cc_test(
     deps = [
         ":recognize_commands",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:test_helpers",
         "//tensorflow/lite/micro/testing:micro_test",
     ],
@@ -392,7 +386,7 @@ cc_library(
     ],
     deps = [
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
+        "//tensorflow/lite/micro:micro_log",
     ],
 )
 
@@ -404,7 +398,6 @@ cc_test(
     deps = [
         ":command_responder",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
         "//tensorflow/lite/micro/testing:micro_test",
     ],
@@ -423,8 +416,8 @@ cc_binary(
         ":feature_provider",
         ":micro_speech_model_data",
         ":recognize_commands",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:system_setup",
         "//tensorflow/lite/micro/examples/micro_speech/micro_features:micro_model_settings",
@@ -445,7 +438,6 @@ cc_binary(
         ":feature_provider",
         ":micro_speech_model_data",
         ":recognize_commands",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:system_setup",

--- a/tensorflow/lite/micro/examples/micro_speech/audio_provider.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/audio_provider.cc
@@ -22,8 +22,7 @@ int16_t g_dummy_audio_data[kMaxAudioSampleSize];
 int32_t g_latest_audio_timestamp = 0;
 }  // namespace
 
-TfLiteStatus GetAudioSamples(tflite::ErrorReporter* error_reporter,
-                             int start_ms, int duration_ms,
+TfLiteStatus GetAudioSamples(int start_ms, int duration_ms,
                              int* audio_samples_size, int16_t** audio_samples) {
   for (int i = 0; i < kMaxAudioSampleSize; ++i) {
     g_dummy_audio_data[i] = 0;

--- a/tensorflow/lite/micro/examples/micro_speech/audio_provider.h
+++ b/tensorflow/lite/micro/examples/micro_speech/audio_provider.h
@@ -17,7 +17,6 @@ limitations under the License.
 #define TENSORFLOW_LITE_MICRO_EXAMPLES_MICRO_SPEECH_AUDIO_PROVIDER_H_
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 
 // This is an abstraction around an audio source like a microphone, and is
 // expected to return 16-bit PCM sample data for a given point in time. The
@@ -29,8 +28,7 @@ limitations under the License.
 // The reference implementation can have no platform-specific dependencies, so
 // it just returns an array filled with zeros. For real applications, you should
 // ensure there's a specialized implementation that accesses hardware APIs.
-TfLiteStatus GetAudioSamples(tflite::ErrorReporter* error_reporter,
-                             int start_ms, int duration_ms,
+TfLiteStatus GetAudioSamples(int start_ms, int duration_ms,
                              int* audio_samples_size, int16_t** audio_samples);
 
 // Returns the time that audio data was last captured in milliseconds. There's

--- a/tensorflow/lite/micro/examples/micro_speech/audio_provider_mock.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/audio_provider_mock.cc
@@ -23,8 +23,7 @@ int16_t g_dummy_audio_data[kMaxAudioSampleSize];
 int32_t g_latest_audio_timestamp = 0;
 }  // namespace
 
-TfLiteStatus GetAudioSamples(tflite::ErrorReporter* error_reporter,
-                             int start_ms, int duration_ms,
+TfLiteStatus GetAudioSamples(int start_ms, int duration_ms,
                              int* audio_samples_size, int16_t** audio_samples) {
   const int yes_start = (0 * kAudioSampleFrequency) / 1000;
   const int yes_end = (1000 * kAudioSampleFrequency) / 1000;

--- a/tensorflow/lite/micro/examples/micro_speech/audio_provider_mock_test.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/audio_provider_mock_test.cc
@@ -20,19 +20,15 @@ limitations under the License.
 #include "tensorflow/lite/micro/examples/micro_speech/micro_features/micro_model_settings.h"
 #include "tensorflow/lite/micro/examples/micro_speech/testdata/no_1000ms_audio_data.h"
 #include "tensorflow/lite/micro/examples/micro_speech/testdata/yes_1000ms_audio_data.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
 
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestAudioProviderMock) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
   int audio_samples_size = 0;
   int16_t* audio_samples = nullptr;
-  TfLiteStatus get_status =
-      GetAudioSamples(&micro_error_reporter, 0, kFeatureSliceDurationMs,
-                      &audio_samples_size, &audio_samples);
+  TfLiteStatus get_status = GetAudioSamples(
+      0, kFeatureSliceDurationMs, &audio_samples_size, &audio_samples);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, get_status);
   TF_LITE_MICRO_EXPECT_LE(audio_samples_size, kMaxAudioSampleSize);
   TF_LITE_MICRO_EXPECT(audio_samples != nullptr);
@@ -40,9 +36,8 @@ TF_LITE_MICRO_TEST(TestAudioProviderMock) {
     TF_LITE_MICRO_EXPECT_EQ(g_yes_1000ms_audio_data[i], audio_samples[i]);
   }
 
-  get_status =
-      GetAudioSamples(&micro_error_reporter, 500, kFeatureSliceDurationMs,
-                      &audio_samples_size, &audio_samples);
+  get_status = GetAudioSamples(500, kFeatureSliceDurationMs,
+                               &audio_samples_size, &audio_samples);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, get_status);
   TF_LITE_MICRO_EXPECT_LE(audio_samples_size, kMaxAudioSampleSize);
   TF_LITE_MICRO_EXPECT(audio_samples != nullptr);
@@ -51,9 +46,8 @@ TF_LITE_MICRO_TEST(TestAudioProviderMock) {
                             audio_samples[i]);
   }
 
-  get_status =
-      GetAudioSamples(&micro_error_reporter, 1500, kFeatureSliceDurationMs,
-                      &audio_samples_size, &audio_samples);
+  get_status = GetAudioSamples(1500, kFeatureSliceDurationMs,
+                               &audio_samples_size, &audio_samples);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, get_status);
   TF_LITE_MICRO_EXPECT_LE(audio_samples_size, kMaxAudioSampleSize);
   TF_LITE_MICRO_EXPECT(audio_samples != nullptr);
@@ -61,9 +55,8 @@ TF_LITE_MICRO_TEST(TestAudioProviderMock) {
     TF_LITE_MICRO_EXPECT_EQ(0, audio_samples[i]);
   }
 
-  get_status =
-      GetAudioSamples(&micro_error_reporter, 12250, kFeatureSliceDurationMs,
-                      &audio_samples_size, &audio_samples);
+  get_status = GetAudioSamples(12250, kFeatureSliceDurationMs,
+                               &audio_samples_size, &audio_samples);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, get_status);
   TF_LITE_MICRO_EXPECT_LE(audio_samples_size, kMaxAudioSampleSize);
   TF_LITE_MICRO_EXPECT(audio_samples != nullptr);

--- a/tensorflow/lite/micro/examples/micro_speech/audio_provider_test.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/audio_provider_test.cc
@@ -19,19 +19,15 @@ limitations under the License.
 
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/examples/micro_speech/micro_features/micro_model_settings.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
 
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestAudioProvider) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
   int audio_samples_size = 0;
   int16_t* audio_samples = nullptr;
-  TfLiteStatus get_status =
-      GetAudioSamples(&micro_error_reporter, 0, kFeatureSliceDurationMs,
-                      &audio_samples_size, &audio_samples);
+  TfLiteStatus get_status = GetAudioSamples(
+      0, kFeatureSliceDurationMs, &audio_samples_size, &audio_samples);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, get_status);
   TF_LITE_MICRO_EXPECT_LE(audio_samples_size, kMaxAudioSampleSize);
   TF_LITE_MICRO_EXPECT(audio_samples != nullptr);

--- a/tensorflow/lite/micro/examples/micro_speech/command_responder.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/command_responder.cc
@@ -15,14 +15,14 @@ limitations under the License.
 
 #include "tensorflow/lite/micro/examples/micro_speech/command_responder.h"
 
+#include "tensorflow/lite/micro/micro_log.h"
+
 // The default implementation writes out the name of the recognized command
 // to the error console. Real applications will want to take some custom
 // action instead, and should implement their own versions of this function.
-void RespondToCommand(tflite::ErrorReporter* error_reporter,
-                      int32_t current_time, const char* found_command,
+void RespondToCommand(int32_t current_time, const char* found_command,
                       uint8_t score, bool is_new_command) {
   if (is_new_command) {
-    TF_LITE_REPORT_ERROR(error_reporter, "Heard %s (%d) @%dms", found_command,
-                         score, current_time);
+    MicroPrintf("Heard %s (%d) @%dms", found_command, score, current_time);
   }
 }

--- a/tensorflow/lite/micro/examples/micro_speech/command_responder.h
+++ b/tensorflow/lite/micro/examples/micro_speech/command_responder.h
@@ -19,14 +19,12 @@ limitations under the License.
 #define TENSORFLOW_LITE_MICRO_EXAMPLES_MICRO_SPEECH_COMMAND_RESPONDER_H_
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 
 // Called every time the results of an audio recognition run are available. The
 // human-readable name of any recognized command is in the `found_command`
 // argument, `score` has the numerical confidence, and `is_new_command` is set
 // if the previous command was different to this one.
-void RespondToCommand(tflite::ErrorReporter* error_reporter,
-                      int32_t current_time, const char* found_command,
+void RespondToCommand(int32_t current_time, const char* found_command,
                       uint8_t score, bool is_new_command);
 
 #endif  // TENSORFLOW_LITE_MICRO_EXAMPLES_MICRO_SPEECH_COMMAND_RESPONDER_H_

--- a/tensorflow/lite/micro/examples/micro_speech/command_responder_test.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/command_responder_test.cc
@@ -20,12 +20,10 @@ limitations under the License.
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestCallability) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
   // This will have external side-effects (like printing to the debug console
   // or lighting an LED) that are hard to observe, so the most we can do is
   // make sure the call doesn't crash.
-  RespondToCommand(&micro_error_reporter, 0, "foo", 0, true);
+  RespondToCommand(0, "foo", 0, true);
 }
 
 TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/examples/micro_speech/feature_provider.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/feature_provider.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/examples/micro_speech/audio_provider.h"
 #include "tensorflow/lite/micro/examples/micro_speech/micro_features/micro_features_generator.h"
 #include "tensorflow/lite/micro/examples/micro_speech/micro_features/micro_model_settings.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 FeatureProvider::FeatureProvider(int feature_size, int8_t* feature_data)
     : feature_size_(feature_size),
@@ -31,13 +32,12 @@ FeatureProvider::FeatureProvider(int feature_size, int8_t* feature_data)
 
 FeatureProvider::~FeatureProvider() {}
 
-TfLiteStatus FeatureProvider::PopulateFeatureData(
-    tflite::ErrorReporter* error_reporter, int32_t last_time_in_ms,
-    int32_t time_in_ms, int* how_many_new_slices) {
+TfLiteStatus FeatureProvider::PopulateFeatureData(int32_t last_time_in_ms,
+                                                  int32_t time_in_ms,
+                                                  int* how_many_new_slices) {
   if (feature_size_ != kFeatureElementCount) {
-    TF_LITE_REPORT_ERROR(error_reporter,
-                         "Requested feature_data_ size %d doesn't match %d",
-                         feature_size_, kFeatureElementCount);
+    MicroPrintf("Requested feature_data_ size %d doesn't match %d",
+                feature_size_, kFeatureElementCount);
     return kTfLiteError;
   }
 
@@ -49,7 +49,7 @@ TfLiteStatus FeatureProvider::PopulateFeatureData(
   int slices_needed = current_step - last_step;
   // If this is the first call, make sure we don't use any cached information.
   if (is_first_run_) {
-    TfLiteStatus init_status = InitializeMicroFeatures(error_reporter);
+    TfLiteStatus init_status = InitializeMicroFeatures();
     if (init_status != kTfLiteOk) {
       return init_status;
     }
@@ -97,20 +97,19 @@ TfLiteStatus FeatureProvider::PopulateFeatureData(
       int16_t* audio_samples = nullptr;
       int audio_samples_size = 0;
       // TODO(petewarden): Fix bug that leads to non-zero slice_start_ms
-      GetAudioSamples(error_reporter, (slice_start_ms > 0 ? slice_start_ms : 0),
+      GetAudioSamples((slice_start_ms > 0 ? slice_start_ms : 0),
                       kFeatureSliceDurationMs, &audio_samples_size,
                       &audio_samples);
       if (audio_samples_size < kMaxAudioSampleSize) {
-        TF_LITE_REPORT_ERROR(error_reporter,
-                             "Audio data size %d too small, want %d",
-                             audio_samples_size, kMaxAudioSampleSize);
+        MicroPrintf("Audio data size %d too small, want %d", audio_samples_size,
+                    kMaxAudioSampleSize);
         return kTfLiteError;
       }
       int8_t* new_slice_data = feature_data_ + (new_slice * kFeatureSliceSize);
       size_t num_samples_read;
       TfLiteStatus generate_status = GenerateMicroFeatures(
-          error_reporter, audio_samples, audio_samples_size, kFeatureSliceSize,
-          new_slice_data, &num_samples_read);
+          audio_samples, audio_samples_size, kFeatureSliceSize, new_slice_data,
+          &num_samples_read);
       if (generate_status != kTfLiteOk) {
         return generate_status;
       }

--- a/tensorflow/lite/micro/examples/micro_speech/feature_provider.h
+++ b/tensorflow/lite/micro/examples/micro_speech/feature_provider.h
@@ -17,7 +17,6 @@ limitations under the License.
 #define TENSORFLOW_LITE_MICRO_EXAMPLES_MICRO_SPEECH_FEATURE_PROVIDER_H_
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 
 // Binds itself to an area of memory intended to hold the input features for an
 // audio-recognition neural network model, and fills that data area with the
@@ -37,8 +36,7 @@ class FeatureProvider {
 
   // Fills the feature data with information from audio inputs, and returns how
   // many feature slices were updated.
-  TfLiteStatus PopulateFeatureData(tflite::ErrorReporter* error_reporter,
-                                   int32_t last_time_in_ms, int32_t time_in_ms,
+  TfLiteStatus PopulateFeatureData(int32_t last_time_in_ms, int32_t time_in_ms,
                                    int* how_many_new_slices);
 
  private:

--- a/tensorflow/lite/micro/examples/micro_speech/feature_provider_mock_test.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/feature_provider_mock_test.cc
@@ -18,21 +18,17 @@ limitations under the License.
 #include "tensorflow/lite/micro/examples/micro_speech/micro_features/micro_model_settings.h"
 #include "tensorflow/lite/micro/examples/micro_speech/micro_features/no_micro_features_data.h"
 #include "tensorflow/lite/micro/examples/micro_speech/micro_features/yes_micro_features_data.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
 
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestFeatureProviderMockYes) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
   int8_t feature_data[kFeatureElementCount];
   FeatureProvider feature_provider(kFeatureElementCount, feature_data);
 
   int how_many_new_slices = 0;
   TfLiteStatus populate_status = feature_provider.PopulateFeatureData(
-      &micro_error_reporter, /* last_time_in_ms= */ 0, /* time_in_ms= */ 970,
-      &how_many_new_slices);
+      /* last_time_in_ms= */ 0, /* time_in_ms= */ 970, &how_many_new_slices);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, populate_status);
   TF_LITE_MICRO_EXPECT_EQ(kFeatureSliceCount, how_many_new_slices);
 
@@ -43,14 +39,12 @@ TF_LITE_MICRO_TEST(TestFeatureProviderMockYes) {
 }
 
 TF_LITE_MICRO_TEST(TestFeatureProviderMockNo) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
   int8_t feature_data[kFeatureElementCount];
   FeatureProvider feature_provider(kFeatureElementCount, feature_data);
 
   int how_many_new_slices = 0;
   TfLiteStatus populate_status = feature_provider.PopulateFeatureData(
-      &micro_error_reporter, /* last_time_in_ms= */ 4000,
+      /* last_time_in_ms= */ 4000,
       /* time_in_ms= */ 4970, &how_many_new_slices);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, populate_status);
   TF_LITE_MICRO_EXPECT_EQ(kFeatureSliceCount, how_many_new_slices);

--- a/tensorflow/lite/micro/examples/micro_speech/feature_provider_test.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/feature_provider_test.cc
@@ -17,21 +17,17 @@ limitations under the License.
 
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/examples/micro_speech/micro_features/micro_model_settings.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
 
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestFeatureProvider) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
   int8_t feature_data[kFeatureElementCount];
   FeatureProvider feature_provider(kFeatureElementCount, feature_data);
 
   int how_many_new_slices = 0;
   TfLiteStatus populate_status = feature_provider.PopulateFeatureData(
-      &micro_error_reporter, /* last_time_in_ms= */ 0, /* time_in_ms= */ 10000,
-      &how_many_new_slices);
+      /* last_time_in_ms= */ 0, /* time_in_ms= */ 10000, &how_many_new_slices);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, populate_status);
   TF_LITE_MICRO_EXPECT_EQ(kFeatureSliceCount, how_many_new_slices);
 }

--- a/tensorflow/lite/micro/examples/micro_speech/main_functions.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/main_functions.cc
@@ -21,15 +21,14 @@ limitations under the License.
 #include "tensorflow/lite/micro/examples/micro_speech/micro_features/micro_model_settings.h"
 #include "tensorflow/lite/micro/examples/micro_speech/micro_speech_model_data.h"
 #include "tensorflow/lite/micro/examples/micro_speech/recognize_commands.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 #include "tensorflow/lite/micro/system_setup.h"
 #include "tensorflow/lite/schema/schema_generated.h"
 
 // Globals, used for compatibility with Arduino-style sketches.
 namespace {
-tflite::ErrorReporter* error_reporter = nullptr;
 const tflite::Model* model = nullptr;
 tflite::MicroInterpreter* interpreter = nullptr;
 TfLiteTensor* model_input = nullptr;
@@ -50,20 +49,14 @@ int8_t* model_input_buffer = nullptr;
 void setup() {
   tflite::InitializeTarget();
 
-  // Set up logging. Google style is to avoid globals or statics because of
-  // lifetime uncertainty, but since this has a trivial destructor it's okay.
-  // NOLINTNEXTLINE(runtime-global-variables)
-  static tflite::MicroErrorReporter micro_error_reporter;
-  error_reporter = &micro_error_reporter;
-
   // Map the model into a usable data structure. This doesn't involve any
   // copying or parsing, it's a very lightweight operation.
   model = tflite::GetModel(g_micro_speech_model_data);
   if (model->version() != TFLITE_SCHEMA_VERSION) {
-    TF_LITE_REPORT_ERROR(error_reporter,
-                         "Model provided is schema version %d not equal "
-                         "to supported version %d.",
-                         model->version(), TFLITE_SCHEMA_VERSION);
+    MicroPrintf(
+        "Model provided is schema version %d not equal "
+        "to supported version %d.",
+        model->version(), TFLITE_SCHEMA_VERSION);
     return;
   }
 
@@ -75,7 +68,7 @@ void setup() {
   //
   // tflite::AllOpsResolver resolver;
   // NOLINTNEXTLINE(runtime-global-variables)
-  static tflite::MicroMutableOpResolver<4> micro_op_resolver(error_reporter);
+  static tflite::MicroMutableOpResolver<4> micro_op_resolver;
   if (micro_op_resolver.AddDepthwiseConv2D() != kTfLiteOk) {
     return;
   }
@@ -91,13 +84,13 @@ void setup() {
 
   // Build an interpreter to run the model with.
   static tflite::MicroInterpreter static_interpreter(
-      model, micro_op_resolver, tensor_arena, kTensorArenaSize, error_reporter);
+      model, micro_op_resolver, tensor_arena, kTensorArenaSize);
   interpreter = &static_interpreter;
 
   // Allocate memory from the tensor_arena for the model's tensors.
   TfLiteStatus allocate_status = interpreter->AllocateTensors();
   if (allocate_status != kTfLiteOk) {
-    TF_LITE_REPORT_ERROR(error_reporter, "AllocateTensors() failed");
+    MicroPrintf("AllocateTensors() failed");
     return;
   }
 
@@ -107,8 +100,7 @@ void setup() {
       (model_input->dims->data[1] !=
        (kFeatureSliceCount * kFeatureSliceSize)) ||
       (model_input->type != kTfLiteInt8)) {
-    TF_LITE_REPORT_ERROR(error_reporter,
-                         "Bad input tensor parameters in model");
+    MicroPrintf("Bad input tensor parameters in model");
     return;
   }
   model_input_buffer = model_input->data.int8;
@@ -120,7 +112,7 @@ void setup() {
                                                  feature_buffer);
   feature_provider = &static_feature_provider;
 
-  static RecognizeCommands static_recognizer(error_reporter);
+  static RecognizeCommands static_recognizer;
   recognizer = &static_recognizer;
 
   previous_time = 0;
@@ -132,9 +124,9 @@ void loop() {
   const int32_t current_time = LatestAudioTimestamp();
   int how_many_new_slices = 0;
   TfLiteStatus feature_status = feature_provider->PopulateFeatureData(
-      error_reporter, previous_time, current_time, &how_many_new_slices);
+      previous_time, current_time, &how_many_new_slices);
   if (feature_status != kTfLiteOk) {
-    TF_LITE_REPORT_ERROR(error_reporter, "Feature generation failed");
+    MicroPrintf("Feature generation failed");
     return;
   }
   previous_time = current_time;
@@ -152,7 +144,7 @@ void loop() {
   // Run the model on the spectrogram input and make sure it succeeds.
   TfLiteStatus invoke_status = interpreter->Invoke();
   if (invoke_status != kTfLiteOk) {
-    TF_LITE_REPORT_ERROR(error_reporter, "Invoke failed");
+    MicroPrintf("Invoke failed");
     return;
   }
 
@@ -165,13 +157,11 @@ void loop() {
   TfLiteStatus process_status = recognizer->ProcessLatestResults(
       output, current_time, &found_command, &score, &is_new_command);
   if (process_status != kTfLiteOk) {
-    TF_LITE_REPORT_ERROR(error_reporter,
-                         "RecognizeCommands::ProcessLatestResults() failed");
+    MicroPrintf("RecognizeCommands::ProcessLatestResults() failed");
     return;
   }
   // Do something based on the recognized command. The default implementation
   // just prints to the error console, but you should replace this with your
   // own function for a real application.
-  RespondToCommand(error_reporter, current_time, found_command, score,
-                   is_new_command);
+  RespondToCommand(current_time, found_command, score, is_new_command);
 }

--- a/tensorflow/lite/micro/examples/micro_speech/micro_features/BUILD
+++ b/tensorflow/lite/micro/examples/micro_speech/micro_features/BUILD
@@ -45,7 +45,7 @@ cc_library(
         ":micro_model_settings",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/experimental/microfrontend/lib:frontend",
-        "//tensorflow/lite/micro:micro_error_reporter",
+        "//tensorflow/lite/micro:micro_log",
     ],
 )
 
@@ -75,8 +75,8 @@ cc_test(
         ":micro_features_generator_test_data",
         ":micro_model_settings",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro/examples/micro_speech:audio_sample_test_data",
         "//tensorflow/lite/micro/testing:micro_test",
     ],

--- a/tensorflow/lite/micro/examples/micro_speech/micro_features/micro_features_generator.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/micro_features/micro_features_generator.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/lite/experimental/microfrontend/lib/frontend.h"
 #include "tensorflow/lite/experimental/microfrontend/lib/frontend_util.h"
 #include "tensorflow/lite/micro/examples/micro_speech/micro_features/micro_model_settings.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace {
 
@@ -29,7 +30,7 @@ bool g_is_first_time = true;
 
 }  // namespace
 
-TfLiteStatus InitializeMicroFeatures(tflite::ErrorReporter* error_reporter) {
+TfLiteStatus InitializeMicroFeatures() {
   FrontendConfig config;
   config.window.size_ms = kFeatureSliceDurationMs;
   config.window.step_size_ms = kFeatureSliceStrideMs;
@@ -49,7 +50,7 @@ TfLiteStatus InitializeMicroFeatures(tflite::ErrorReporter* error_reporter) {
   config.log_scale.scale_shift = 6;
   if (!FrontendPopulateState(&config, &g_micro_features_state,
                              kAudioSampleFrequency)) {
-    TF_LITE_REPORT_ERROR(error_reporter, "FrontendPopulateState() failed");
+    MicroPrintf("FrontendPopulateState() failed");
     return kTfLiteError;
   }
   g_is_first_time = true;
@@ -64,8 +65,7 @@ void SetMicroFeaturesNoiseEstimates(const uint32_t* estimate_presets) {
   }
 }
 
-TfLiteStatus GenerateMicroFeatures(tflite::ErrorReporter* error_reporter,
-                                   const int16_t* input, int input_size,
+TfLiteStatus GenerateMicroFeatures(const int16_t* input, int input_size,
                                    int output_size, int8_t* output,
                                    size_t* num_samples_read) {
   const int16_t* frontend_input;

--- a/tensorflow/lite/micro/examples/micro_speech/micro_features/micro_features_generator.h
+++ b/tensorflow/lite/micro/examples/micro_speech/micro_features/micro_features_generator.h
@@ -17,15 +17,13 @@ limitations under the License.
 #define TENSORFLOW_LITE_MICRO_EXAMPLES_MICRO_SPEECH_MICRO_FEATURES_MICRO_FEATURES_GENERATOR_H_
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 
 // Sets up any resources needed for the feature generation pipeline.
-TfLiteStatus InitializeMicroFeatures(tflite::ErrorReporter* error_reporter);
+TfLiteStatus InitializeMicroFeatures();
 
 // Converts audio sample data into a more compact form that's appropriate for
 // feeding into a neural network.
-TfLiteStatus GenerateMicroFeatures(tflite::ErrorReporter* error_reporter,
-                                   const int16_t* input, int input_size,
+TfLiteStatus GenerateMicroFeatures(const int16_t* input, int input_size,
                                    int output_size, int8_t* output,
                                    size_t* num_samples_read);
 

--- a/tensorflow/lite/micro/examples/micro_speech/micro_features/micro_features_generator_test.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/micro_features/micro_features_generator_test.cc
@@ -20,7 +20,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/examples/micro_speech/micro_features/yes_feature_data_slice.h"
 #include "tensorflow/lite/micro/examples/micro_speech/testdata/no_30ms_audio_data.h"
 #include "tensorflow/lite/micro/examples/micro_speech/testdata/yes_30ms_audio_data.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
 
 // This is a test-only API, not exposed in any public headers, so declare it.
@@ -29,10 +29,7 @@ void SetMicroFeaturesNoiseEstimates(const uint32_t* estimate_presets);
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestMicroFeaturesGeneratorYes) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
-  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
-                          InitializeMicroFeatures(&micro_error_reporter));
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, InitializeMicroFeatures());
 
   // The micro features pipeline retains state from previous calls to help
   // estimate the background noise. Unfortunately this makes it harder to
@@ -51,7 +48,7 @@ TF_LITE_MICRO_TEST(TestMicroFeaturesGeneratorYes) {
   int8_t yes_calculated_data[g_yes_feature_data_slice_size];
   size_t num_samples_read;
   TfLiteStatus yes_status = GenerateMicroFeatures(
-      &micro_error_reporter, g_yes_30ms_audio_data, g_yes_30ms_audio_data_size,
+      g_yes_30ms_audio_data, g_yes_30ms_audio_data_size,
       g_yes_feature_data_slice_size, yes_calculated_data, &num_samples_read);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, yes_status);
 
@@ -60,17 +57,13 @@ TF_LITE_MICRO_TEST(TestMicroFeaturesGeneratorYes) {
     const int actual = yes_calculated_data[i];
     TF_LITE_MICRO_EXPECT_EQ(expected, actual);
     if (expected != actual) {
-      TF_LITE_REPORT_ERROR(&micro_error_reporter,
-                           "Expected value %d but found %d", expected, actual);
+      MicroPrintf("Expected value %d but found %d", expected, actual);
     }
   }
 }
 
 TF_LITE_MICRO_TEST(TestMicroFeaturesGeneratorNo) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
-  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
-                          InitializeMicroFeatures(&micro_error_reporter));
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, InitializeMicroFeatures());
   // As we did for the previous features, set known good noise state
   // parameters.
   const uint32_t no_estimate_presets[] = {
@@ -85,7 +78,7 @@ TF_LITE_MICRO_TEST(TestMicroFeaturesGeneratorNo) {
   int8_t no_calculated_data[g_no_feature_data_slice_size];
   size_t num_samples_read;
   TfLiteStatus no_status = GenerateMicroFeatures(
-      &micro_error_reporter, g_no_30ms_audio_data, g_no_30ms_audio_data_size,
+      g_no_30ms_audio_data, g_no_30ms_audio_data_size,
       g_no_feature_data_slice_size, no_calculated_data, &num_samples_read);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, no_status);
 
@@ -94,8 +87,7 @@ TF_LITE_MICRO_TEST(TestMicroFeaturesGeneratorNo) {
     const int actual = no_calculated_data[i];
     TF_LITE_MICRO_EXPECT_EQ(expected, actual);
     if (expected != actual) {
-      TF_LITE_REPORT_ERROR(&micro_error_reporter,
-                           "Expected value %d but found %d", expected, actual);
+      MicroPrintf("Expected value %d but found %d", expected, actual);
     }
   }
 }

--- a/tensorflow/lite/micro/examples/micro_speech/micro_speech_test.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/micro_speech_test.cc
@@ -16,8 +16,8 @@ limitations under the License.
 #include "tensorflow/lite/micro/examples/micro_speech/micro_features/no_micro_features_data.h"
 #include "tensorflow/lite/micro/examples/micro_speech/micro_features/yes_micro_features_data.h"
 #include "tensorflow/lite/micro/examples/micro_speech/micro_speech_model_data.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
 #include "tensorflow/lite/schema/schema_generated.h"
@@ -25,17 +25,14 @@ limitations under the License.
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestInvoke) {
-  // Set up logging.
-  tflite::MicroErrorReporter micro_error_reporter;
-
   // Map the model into a usable data structure. This doesn't involve any
   // copying or parsing, it's a very lightweight operation.
   const tflite::Model* model = ::tflite::GetModel(g_micro_speech_model_data);
   if (model->version() != TFLITE_SCHEMA_VERSION) {
-    TF_LITE_REPORT_ERROR(&micro_error_reporter,
-                         "Model provided is schema version %d not equal "
-                         "to supported version %d.\n",
-                         model->version(), TFLITE_SCHEMA_VERSION);
+    MicroPrintf(
+        "Model provided is schema version %d not equal "
+        "to supported version %d.\n",
+        model->version(), TFLITE_SCHEMA_VERSION);
   }
 
   // Pull in only the operation implementations we need.
@@ -65,8 +62,7 @@ TF_LITE_MICRO_TEST(TestInvoke) {
 
   // Build an interpreter to run the model with.
   tflite::MicroInterpreter interpreter(model, micro_op_resolver, tensor_arena,
-                                       tensor_arena_size,
-                                       &micro_error_reporter);
+                                       tensor_arena_size);
   interpreter.AllocateTensors();
 
   // Get information about the memory area to use for the model's input.
@@ -89,7 +85,7 @@ TF_LITE_MICRO_TEST(TestInvoke) {
   // Run the model on this input and make sure it succeeds.
   TfLiteStatus invoke_status = interpreter.Invoke();
   if (invoke_status != kTfLiteOk) {
-    TF_LITE_REPORT_ERROR(&micro_error_reporter, "Invoke failed\n");
+    MicroPrintf("Invoke failed\n");
   }
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, invoke_status);
 
@@ -125,7 +121,7 @@ TF_LITE_MICRO_TEST(TestInvoke) {
   // Run the model on this "No" input.
   invoke_status = interpreter.Invoke();
   if (invoke_status != kTfLiteOk) {
-    TF_LITE_REPORT_ERROR(&micro_error_reporter, "Invoke failed\n");
+    MicroPrintf("Invoke failed\n");
   }
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, invoke_status);
 
@@ -146,7 +142,7 @@ TF_LITE_MICRO_TEST(TestInvoke) {
   TF_LITE_MICRO_EXPECT_GT(no_score, unknown_score);
   TF_LITE_MICRO_EXPECT_GT(no_score, yes_score);
 
-  TF_LITE_REPORT_ERROR(&micro_error_reporter, "Ran successfully\n");
+  MicroPrintf("Ran successfully\n");
 }
 
 TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/examples/micro_speech/recognize_commands.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/recognize_commands.cc
@@ -17,17 +17,17 @@ limitations under the License.
 
 #include <limits>
 
-RecognizeCommands::RecognizeCommands(tflite::ErrorReporter* error_reporter,
-                                     int32_t average_window_duration_ms,
+#include "tensorflow/lite/micro/micro_log.h"
+
+RecognizeCommands::RecognizeCommands(int32_t average_window_duration_ms,
                                      uint8_t detection_threshold,
                                      int32_t suppression_ms,
                                      int32_t minimum_count)
-    : error_reporter_(error_reporter),
-      average_window_duration_ms_(average_window_duration_ms),
+    : average_window_duration_ms_(average_window_duration_ms),
       detection_threshold_(detection_threshold),
       suppression_ms_(suppression_ms),
       minimum_count_(minimum_count),
-      previous_results_(error_reporter) {
+      previous_results_() {
   previous_top_label_ = "silence";
   previous_top_label_time_ = std::numeric_limits<int32_t>::min();
 }
@@ -38,8 +38,7 @@ TfLiteStatus RecognizeCommands::ProcessLatestResults(
   if ((latest_results->dims->size != 2) ||
       (latest_results->dims->data[0] != 1) ||
       (latest_results->dims->data[1] != kCategoryCount)) {
-    TF_LITE_REPORT_ERROR(
-        error_reporter_,
+    MicroPrintf(
         "The results for recognition should contain %d elements, but there are "
         "%d in an %d-dimensional shape",
         kCategoryCount, latest_results->dims->data[1],
@@ -48,8 +47,7 @@ TfLiteStatus RecognizeCommands::ProcessLatestResults(
   }
 
   if (latest_results->type != kTfLiteInt8) {
-    TF_LITE_REPORT_ERROR(
-        error_reporter_,
+    MicroPrintf(
         "The results for recognition should be int8_t elements, but are %d",
         latest_results->type);
     return kTfLiteError;
@@ -57,8 +55,7 @@ TfLiteStatus RecognizeCommands::ProcessLatestResults(
 
   if ((!previous_results_.empty()) &&
       (current_time_ms < previous_results_.front().time_)) {
-    TF_LITE_REPORT_ERROR(
-        error_reporter_,
+    MicroPrintf(
         "Results must be fed in increasing time order, but received a "
         "timestamp of %d that was earlier than the previous one of %d",
         current_time_ms, previous_results_.front().time_);

--- a/tensorflow/lite/micro/examples/micro_speech/recognize_commands_test.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/recognize_commands_test.cc
@@ -21,9 +21,7 @@ limitations under the License.
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(PreviousResultsQueueBasic) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
-  PreviousResultsQueue queue(&micro_error_reporter);
+  PreviousResultsQueue queue;
   TF_LITE_MICRO_EXPECT_EQ(0, queue.size());
 
   int8_t scores_a[4] = {0, 0, 0, 1};
@@ -52,9 +50,7 @@ TF_LITE_MICRO_TEST(PreviousResultsQueueBasic) {
 }
 
 TF_LITE_MICRO_TEST(PreviousResultsQueuePushPop) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
-  PreviousResultsQueue queue(&micro_error_reporter);
+  PreviousResultsQueue queue;
   TF_LITE_MICRO_EXPECT_EQ(0, queue.size());
 
   for (int i = 0; i < 123; ++i) {
@@ -71,9 +67,7 @@ TF_LITE_MICRO_TEST(PreviousResultsQueuePushPop) {
 }
 
 TF_LITE_MICRO_TEST(RecognizeCommandsTestBasic) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
-  RecognizeCommands recognize_commands(&micro_error_reporter);
+  RecognizeCommands recognize_commands;
 
   const int8_t result_data[] = {127, -128, -128, -128};
   int result_dims[] = {2, 1, 4};
@@ -90,9 +84,7 @@ TF_LITE_MICRO_TEST(RecognizeCommandsTestBasic) {
 }
 
 TF_LITE_MICRO_TEST(RecognizeCommandsTestFindCommands) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
-  RecognizeCommands recognize_commands(&micro_error_reporter, 1000, 51);
+  RecognizeCommands recognize_commands(1000, 51);
 
   const int8_t yes_data[] = {-128, -128, 127, -128};
   int yes_dims[] = {2, 1, 4};
@@ -150,9 +142,7 @@ TF_LITE_MICRO_TEST(RecognizeCommandsTestFindCommands) {
 }
 
 TF_LITE_MICRO_TEST(RecognizeCommandsTestBadInputLength) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
-  RecognizeCommands recognize_commands(&micro_error_reporter, 1000, 51);
+  RecognizeCommands recognize_commands(1000, 51);
 
   const int8_t bad_data[] = {-128, -128, 127};
   int bad_dims[] = {2, 1, 3};
@@ -168,9 +158,7 @@ TF_LITE_MICRO_TEST(RecognizeCommandsTestBadInputLength) {
 }
 
 TF_LITE_MICRO_TEST(RecognizeCommandsTestBadInputTimes) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
-  RecognizeCommands recognize_commands(&micro_error_reporter, 1000, 51);
+  RecognizeCommands recognize_commands(1000, 51);
 
   const int8_t result_data[] = {-128, -128, 127, -128};
   int result_dims[] = {2, 1, 4};
@@ -190,9 +178,7 @@ TF_LITE_MICRO_TEST(RecognizeCommandsTestBadInputTimes) {
 }
 
 TF_LITE_MICRO_TEST(RecognizeCommandsTestTooFewInputs) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
-  RecognizeCommands recognize_commands(&micro_error_reporter, 1000, 51);
+  RecognizeCommands recognize_commands(1000, 51);
 
   const int8_t result_data[] = {-128, -128, 127, -128};
   int result_dims[] = {2, 1, 4};

--- a/tensorflow/lite/micro/examples/micro_speech/simple_features/CMSIS/simple_features_generator.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/simple_features/CMSIS/simple_features_generator.cc
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include "tensorflow/lite/micro/examples/micro_speech/simple_features/simple_features_generator.h"
 
+#include "tensorflow/lite/micro/micro_log.h"
+
 extern "C" {
 #define IFFT_FLAG_R 0
 #define BIT_REVERSE_FLAG 1
@@ -42,18 +44,15 @@ constexpr int kOutputSize =
     ((kInputSize / 2) + (kAverageWindowSize - 1)) / kAverageWindowSize;
 }  // namespace
 
-TfLiteStatus GenerateSimpleFeatures(tflite::ErrorReporter* error_reporter,
-                                    const int16_t* input, int input_size,
+TfLiteStatus GenerateSimpleFeatures(const int16_t* input, int input_size,
                                     int output_size, uint8_t* output) {
   if (input_size > kInputSize) {
-    TF_LITE_REPORT_ERROR(error_reporter, "Input size %d larger than %d",
-                         input_size, kInputSize);
+    MicroPrintf("Input size %d larger than %d", input_size, kInputSize);
     return kTfLiteError;
   }
   if (output_size != kOutputSize) {
-    TF_LITE_REPORT_ERROR(error_reporter,
-                         "Requested output size %d doesn't match %d",
-                         output_size, kOutputSize);
+    MicroPrintf("Requested output size %d doesn't match %d", output_size,
+                kOutputSize);
     return kTfLiteError;
   }
 

--- a/tensorflow/lite/micro/examples/micro_speech/simple_features/fixed_point/simple_features_generator.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/simple_features/fixed_point/simple_features_generator.cc
@@ -32,6 +32,7 @@ limitations under the License.
 #include <cmath>
 
 #include "tensorflow/lite/micro/examples/micro_speech/simple_features/simple_model_settings.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace {
 
@@ -118,19 +119,17 @@ void CalculatePeriodicHann(int window_length, int16_t* window_function) {
 
 }  // namespace
 
-TfLiteStatus GenerateSimpleFeatures(tflite::ErrorReporter* error_reporter,
-                                    const int16_t* input, int input_size,
+TfLiteStatus GenerateSimpleFeatures(const int16_t* input, int input_size,
                                     int output_size, uint8_t* output) {
   // Ensure our input and output data arrays are valid.
   if (input_size > kMaxAudioSampleSize) {
-    TF_LITE_REPORT_ERROR(error_reporter, "Input size %d larger than %d",
-                         input_size, kMaxAudioSampleSize);
+    MicroPrintf("Input size %d larger than %d", input_size,
+                kMaxAudioSampleSize);
     return kTfLiteError;
   }
   if (output_size != kFeatureSliceSize) {
-    TF_LITE_REPORT_ERROR(error_reporter,
-                         "Requested output size %d doesn't match %d",
-                         output_size, kFeatureSliceSize);
+    MicroPrintf("Requested output size %d doesn't match %d", output_size,
+                kFeatureSliceSize);
     return kTfLiteError;
   }
 

--- a/tensorflow/lite/micro/examples/micro_speech/simple_features/simple_features_generator.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/simple_features/simple_features_generator.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include <cmath>
 
 #include "tensorflow/lite/micro/examples/micro_speech/simple_features/simple_model_settings.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace {
 
@@ -73,19 +74,17 @@ void CalculatePeriodicHann(int window_length, float* window_function) {
 
 }  // namespace
 
-TfLiteStatus GenerateSimpleFeatures(tflite::ErrorReporter* error_reporter,
-                                    const int16_t* input, int input_size,
+TfLiteStatus GenerateSimpleFeatures(const int16_t* input, int input_size,
                                     int output_size, uint8_t* output) {
   // Ensure our input and output data arrays are valid.
   if (input_size > kMaxAudioSampleSize) {
-    TF_LITE_REPORT_ERROR(error_reporter, "Input size %d larger than %d",
-                         input_size, kMaxAudioSampleSize);
+    MicroPrintf("Input size %d larger than %d", input_size,
+                kMaxAudioSampleSize);
     return kTfLiteError;
   }
   if (output_size != kFeatureSliceSize) {
-    TF_LITE_REPORT_ERROR(error_reporter,
-                         "Requested output size %d doesn't match %d",
-                         output_size, kFeatureSliceSize);
+    MicroPrintf("Requested output size %d doesn't match %d", output_size,
+                kFeatureSliceSize);
     return kTfLiteError;
   }
 

--- a/tensorflow/lite/micro/examples/micro_speech/simple_features/simple_features_generator.h
+++ b/tensorflow/lite/micro/examples/micro_speech/simple_features/simple_features_generator.h
@@ -17,15 +17,13 @@ limitations under the License.
 #define TENSORFLOW_LITE_MICRO_EXAMPLES_MICRO_SPEECH_SIMPLE_FEATURES_SIMPLE_FEATURES_GENERATOR_H_
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 
 // Converts audio sample data into a more compact form that's appropriate for
 // feeding into a neural network. There are reference implementations that use
 // both floating point and fixed point available, but because the calculations
 // involved can be time-consuming, it's recommended that you use or write
 // specialized versions for your platform.
-TfLiteStatus GenerateSimpleFeatures(tflite::ErrorReporter* error_reporter,
-                                    const int16_t* input, int input_size,
+TfLiteStatus GenerateSimpleFeatures(const int16_t* input, int input_size,
                                     int output_size, uint8_t* output);
 
 #endif  // TENSORFLOW_LITE_MICRO_EXAMPLES_MICRO_SPEECH_SIMPLE_FEATURES_SIMPLE_FEATURES_GENERATOR_H_

--- a/tensorflow/lite/micro/examples/micro_speech/simple_features/simple_features_generator_test.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/simple_features/simple_features_generator_test.cc
@@ -20,17 +20,15 @@ limitations under the License.
 #include "tensorflow/lite/micro/examples/micro_speech/simple_features/yes_power_spectrum_data.h"
 #include "tensorflow/lite/micro/examples/micro_speech/testdata/no_30ms_audio_data.h"
 #include "tensorflow/lite/micro/examples/micro_speech/testdata/yes_30ms_audio_data.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
 
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestSimpleFeaturesGenerator) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
   uint8_t yes_calculated_data[g_yes_power_spectrum_data_size];
   TfLiteStatus yes_status = GenerateSimpleFeatures(
-      &micro_error_reporter, g_yes_30ms_audio_data, g_yes_30ms_audio_data_size,
+      g_yes_30ms_audio_data, g_yes_30ms_audio_data_size,
       g_yes_power_spectrum_data_size, yes_calculated_data);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, yes_status);
 
@@ -38,24 +36,22 @@ TF_LITE_MICRO_TEST(TestSimpleFeaturesGenerator) {
     TF_LITE_MICRO_EXPECT_EQ(g_yes_power_spectrum_data[i],
                             yes_calculated_data[i]);
     if (g_yes_power_spectrum_data[i] != yes_calculated_data[i]) {
-      TF_LITE_REPORT_ERROR(
-          &micro_error_reporter, "Expected value %d but found %d",
-          g_yes_power_spectrum_data[i], yes_calculated_data[i]);
+      MicroPrintf("Expected value %d but found %d",
+                  g_yes_power_spectrum_data[i], yes_calculated_data[i]);
     }
   }
 
   uint8_t no_calculated_data[g_yes_power_spectrum_data_size];
-  TfLiteStatus no_status = GenerateSimpleFeatures(
-      &micro_error_reporter, g_no_30ms_audio_data, g_no_30ms_audio_data_size,
-      g_no_power_spectrum_data_size, no_calculated_data);
+  TfLiteStatus no_status =
+      GenerateSimpleFeatures(g_no_30ms_audio_data, g_no_30ms_audio_data_size,
+                             g_no_power_spectrum_data_size, no_calculated_data);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, no_status);
 
   for (int i = 0; i < g_no_power_spectrum_data_size; ++i) {
     TF_LITE_MICRO_EXPECT_EQ(g_no_power_spectrum_data[i], no_calculated_data[i]);
     if (g_no_power_spectrum_data[i] != no_calculated_data[i]) {
-      TF_LITE_REPORT_ERROR(&micro_error_reporter,
-                           "Expected value %d but found %d",
-                           g_no_power_spectrum_data[i], no_calculated_data[i]);
+      MicroPrintf("Expected value %d but found %d", g_no_power_spectrum_data[i],
+                  no_calculated_data[i]);
     }
   }
 }

--- a/tensorflow/lite/micro/examples/network_tester/network_tester_test.cc
+++ b/tensorflow/lite/micro/examples/network_tester/network_tester_test.cc
@@ -17,8 +17,8 @@ limitations under the License.
 #include "tensorflow/lite/micro/examples/network_tester/expected_output_data.h"
 #include "tensorflow/lite/micro/examples/network_tester/input_data.h"
 #include "tensorflow/lite/micro/examples/network_tester/network_model.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
 #include "tensorflow/lite/schema/schema_generated.h"
@@ -80,29 +80,27 @@ void check_output_elem(TfLiteTensor* output, const T* expected_output,
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestInvoke) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
 #ifdef ETHOS_U
   const tflite::Model* model = ::tflite::GetModel(g_person_detect_model_data);
 #else
   const tflite::Model* model = ::tflite::GetModel(network_model);
 #endif
   if (model->version() != TFLITE_SCHEMA_VERSION) {
-    TF_LITE_REPORT_ERROR(&micro_error_reporter,
-                         "Model provided is schema version %d not equal "
-                         "to supported version %d.\n",
-                         model->version(), TFLITE_SCHEMA_VERSION);
+    MicroPrintf(
+        "Model provided is schema version %d not equal "
+        "to supported version %d.\n",
+        model->version(), TFLITE_SCHEMA_VERSION);
     return kTfLiteError;
   }
 
   tflite::AllOpsResolver resolver;
 
-  tflite::MicroInterpreter interpreter(
-      model, resolver, tensor_arena, TENSOR_ARENA_SIZE, &micro_error_reporter);
+  tflite::MicroInterpreter interpreter(model, resolver, tensor_arena,
+                                       TENSOR_ARENA_SIZE);
 
   TfLiteStatus allocate_status = interpreter.AllocateTensors();
   if (allocate_status != kTfLiteOk) {
-    TF_LITE_REPORT_ERROR(&micro_error_reporter, "Tensor allocation failed\n");
+    MicroPrintf("Tensor allocation failed\n");
     return kTfLiteError;
   }
 
@@ -117,7 +115,7 @@ TF_LITE_MICRO_TEST(TestInvoke) {
     }
     TfLiteStatus invoke_status = interpreter.Invoke();
     if (invoke_status != kTfLiteOk) {
-      TF_LITE_REPORT_ERROR(&micro_error_reporter, "Invoke failed\n");
+      MicroPrintf("Invoke failed\n");
       return kTfLiteError;
     }
     TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, invoke_status);
@@ -148,7 +146,7 @@ TF_LITE_MICRO_TEST(TestInvoke) {
     }
 #endif
   }
-  TF_LITE_REPORT_ERROR(&micro_error_reporter, "Ran successfully\n");
+  MicroPrintf("Ran successfully\n");
 }
 
 TF_LITE_MICRO_TESTS_END


### PR DESCRIPTION
This PR updates some of the TFLM examples to remove the usage of ErrorReporter as per the changes made to the TFLM Framework API in https://github.com/tensorflow/tflite-micro/pull/1415; replaces TF_LITE_REPORT_ERROR with MicroPrintf.

BUG=http://b/192091017, http://b/245802069