### PR TITLE
Update TFLM examples, kernels and integration tests to clean-up the usage of ErrorReporter 

### DIFF
--- a/tensorflow/lite/micro/examples/person_detection/BUILD
+++ b/tensorflow/lite/micro/examples/person_detection/BUILD
@@ -76,8 +76,8 @@ cc_test(
         ":person_detect_model_data",
         ":simple_images_test_data",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro/testing:micro_test",
         "//tensorflow/lite/schema:schema_fbs",
@@ -95,7 +95,6 @@ cc_library(
     deps = [
         ":model_settings",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
     ],
 )
 
@@ -108,7 +107,6 @@ cc_test(
         ":image_provider",
         ":model_settings",
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro/testing:micro_test",
     ],
 )
@@ -123,7 +121,7 @@ cc_library(
     ],
     deps = [
         "//tensorflow/lite/c:common",
-        "//tensorflow/lite/micro:micro_error_reporter",
+        "//tensorflow/lite/micro:micro_log",
     ],
 )
 
@@ -150,8 +148,8 @@ cc_binary(
         ":image_provider",
         ":model_settings",
         ":person_detect_model_data",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:system_setup",
         "//tensorflow/lite/schema:schema_fbs",

--- a/tensorflow/lite/micro/examples/person_detection/detection_responder.cc
+++ b/tensorflow/lite/micro/examples/person_detection/detection_responder.cc
@@ -15,11 +15,12 @@ limitations under the License.
 
 #include "tensorflow/lite/micro/examples/person_detection/detection_responder.h"
 
+#include "tensorflow/lite/micro/micro_log.h"
+
 // This dummy implementation writes person and no person scores to the error
 // console. Real applications will want to take some custom action instead, and
 // should implement their own versions of this function.
-void RespondToDetection(tflite::ErrorReporter* error_reporter,
-                        int8_t person_score, int8_t no_person_score) {
-  TF_LITE_REPORT_ERROR(error_reporter, "person score:%d no person score %d",
-                       person_score, no_person_score);
+void RespondToDetection(int8_t person_score, int8_t no_person_score) {
+  MicroPrintf("person score:%d no person score %d", person_score,
+              no_person_score);
 }

--- a/tensorflow/lite/micro/examples/person_detection/detection_responder.h
+++ b/tensorflow/lite/micro/examples/person_detection/detection_responder.h
@@ -20,7 +20,6 @@ limitations under the License.
 #define TENSORFLOW_LITE_MICRO_EXAMPLES_PERSON_DETECTION_DETECTION_RESPONDER_H_
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 
 // Called every time the results of a person detection run are available. The
 // `person_score` has the numerical confidence that the captured image contains
@@ -28,7 +27,6 @@ limitations under the License.
 // does not contain a person. Typically if person_score > no person score, the
 // image is considered to contain a person.  This threshold may be adjusted for
 // particular applications.
-void RespondToDetection(tflite::ErrorReporter* error_reporter,
-                        int8_t person_score, int8_t no_person_score);
+void RespondToDetection(int8_t person_score, int8_t no_person_score);
 
 #endif  // TENSORFLOW_LITE_MICRO_EXAMPLES_PERSON_DETECTION_DETECTION_RESPONDER_H_

--- a/tensorflow/lite/micro/examples/person_detection/detection_responder_test.cc
+++ b/tensorflow/lite/micro/examples/person_detection/detection_responder_test.cc
@@ -20,13 +20,11 @@ limitations under the License.
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestCallability) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
   // This will have external side-effects (like printing to the debug console
   // or lighting an LED) that are hard to observe, so the most we can do is
   // make sure the call doesn't crash.
-  RespondToDetection(&micro_error_reporter, -100, 100);
-  RespondToDetection(&micro_error_reporter, 100, 50);
+  RespondToDetection(-100, 100);
+  RespondToDetection(100, 50);
 }
 
 TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/examples/person_detection/image_provider.cc
+++ b/tensorflow/lite/micro/examples/person_detection/image_provider.cc
@@ -17,8 +17,8 @@ limitations under the License.
 
 #include "tensorflow/lite/micro/examples/person_detection/model_settings.h"
 
-TfLiteStatus GetImage(tflite::ErrorReporter* error_reporter, int image_width,
-                      int image_height, int channels, int8_t* image_data) {
+TfLiteStatus GetImage(int image_width, int image_height, int channels,
+                      int8_t* image_data) {
   for (int i = 0; i < image_width * image_height * channels; ++i) {
     image_data[i] = 0;
   }

--- a/tensorflow/lite/micro/examples/person_detection/image_provider.h
+++ b/tensorflow/lite/micro/examples/person_detection/image_provider.h
@@ -17,7 +17,6 @@ limitations under the License.
 #define TENSORFLOW_LITE_MICRO_EXAMPLES_PERSON_DETECTION_IMAGE_PROVIDER_H_
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 
 // This is an abstraction around an image source like a camera, and is
 // expected to return 8-bit sample data.  The assumption is that this will be
@@ -33,7 +32,7 @@ limitations under the License.
 // The reference implementation can have no platform-specific dependencies, so
 // it just returns a static image. For real applications, you should
 // ensure there's a specialized implementation that accesses hardware APIs.
-TfLiteStatus GetImage(tflite::ErrorReporter* error_reporter, int image_width,
-                      int image_height, int channels, int8_t* image_data);
+TfLiteStatus GetImage(int image_width, int image_height, int channels,
+                      int8_t* image_data);
 
 #endif  // TENSORFLOW_LITE_MICRO_EXAMPLES_PERSON_DETECTION_IMAGE_PROVIDER_H_

--- a/tensorflow/lite/micro/examples/person_detection/image_provider_test.cc
+++ b/tensorflow/lite/micro/examples/person_detection/image_provider_test.cc
@@ -19,17 +19,14 @@ limitations under the License.
 
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/examples/person_detection/model_settings.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
 
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestImageProvider) {
-  tflite::MicroErrorReporter micro_error_reporter;
-
   int8_t image_data[kMaxImageSize];
-  TfLiteStatus get_status = GetImage(&micro_error_reporter, kNumCols, kNumRows,
-                                     kNumChannels, image_data);
+  TfLiteStatus get_status =
+      GetImage(kNumCols, kNumRows, kNumChannels, image_data);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, get_status);
 
   // Make sure we can read all of the returned memory locations.

--- a/tensorflow/lite/micro/examples/person_detection/main_functions.cc
+++ b/tensorflow/lite/micro/examples/person_detection/main_functions.cc
@@ -18,8 +18,8 @@ limitations under the License.
 #include "tensorflow/lite/micro/examples/person_detection/detection_responder.h"
 #include "tensorflow/lite/micro/examples/person_detection/image_provider.h"
 #include "tensorflow/lite/micro/examples/person_detection/model_settings.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 #include "tensorflow/lite/micro/models/person_detect_model_data.h"
 #include "tensorflow/lite/micro/system_setup.h"
@@ -27,7 +27,6 @@ limitations under the License.
 
 // Globals, used for compatibility with Arduino-style sketches.
 namespace {
-tflite::ErrorReporter* error_reporter = nullptr;
 const tflite::Model* model = nullptr;
 tflite::MicroInterpreter* interpreter = nullptr;
 TfLiteTensor* input = nullptr;
@@ -48,20 +47,14 @@ static uint8_t tensor_arena[kTensorArenaSize];
 void setup() {
   tflite::InitializeTarget();
 
-  // Set up logging. Google style is to avoid globals or statics because of
-  // lifetime uncertainty, but since this has a trivial destructor it's okay.
-  // NOLINTNEXTLINE(runtime-global-variables)
-  static tflite::MicroErrorReporter micro_error_reporter;
-  error_reporter = &micro_error_reporter;
-
   // Map the model into a usable data structure. This doesn't involve any
   // copying or parsing, it's a very lightweight operation.
   model = tflite::GetModel(g_person_detect_model_data);
   if (model->version() != TFLITE_SCHEMA_VERSION) {
-    TF_LITE_REPORT_ERROR(error_reporter,
-                         "Model provided is schema version %d not equal "
-                         "to supported version %d.",
-                         model->version(), TFLITE_SCHEMA_VERSION);
+    MicroPrintf(
+        "Model provided is schema version %d not equal "
+        "to supported version %d.",
+        model->version(), TFLITE_SCHEMA_VERSION);
     return;
   }
 
@@ -84,13 +77,13 @@ void setup() {
   // Build an interpreter to run the model with.
   // NOLINTNEXTLINE(runtime-global-variables)
   static tflite::MicroInterpreter static_interpreter(
-      model, micro_op_resolver, tensor_arena, kTensorArenaSize, error_reporter);
+      model, micro_op_resolver, tensor_arena, kTensorArenaSize);
   interpreter = &static_interpreter;
 
   // Allocate memory from the tensor_arena for the model's tensors.
   TfLiteStatus allocate_status = interpreter->AllocateTensors();
   if (allocate_status != kTfLiteOk) {
-    TF_LITE_REPORT_ERROR(error_reporter, "AllocateTensors() failed");
+    MicroPrintf("AllocateTensors() failed");
     return;
   }
 
@@ -101,14 +94,14 @@ void setup() {
 // The name of this function is important for Arduino compatibility.
 void loop() {
   // Get image from provider.
-  if (kTfLiteOk != GetImage(error_reporter, kNumCols, kNumRows, kNumChannels,
-                            input->data.int8)) {
-    TF_LITE_REPORT_ERROR(error_reporter, "Image capture failed.");
+  if (kTfLiteOk !=
+      GetImage(kNumCols, kNumRows, kNumChannels, input->data.int8)) {
+    MicroPrintf("Image capture failed.");
   }
 
   // Run the model on this input and make sure it succeeds.
   if (kTfLiteOk != interpreter->Invoke()) {
-    TF_LITE_REPORT_ERROR(error_reporter, "Invoke failed.");
+    MicroPrintf("Invoke failed.");
   }
 
   TfLiteTensor* output = interpreter->output(0);
@@ -116,5 +109,5 @@ void loop() {
   // Process the inference results.
   int8_t person_score = output->data.uint8[kPersonIndex];
   int8_t no_person_score = output->data.uint8[kNotAPersonIndex];
-  RespondToDetection(error_reporter, person_score, no_person_score);
+  RespondToDetection(person_score, no_person_score);
 }

--- a/tensorflow/lite/micro/examples/person_detection/person_detection_test.cc
+++ b/tensorflow/lite/micro/examples/person_detection/person_detection_test.cc
@@ -17,8 +17,8 @@ limitations under the License.
 #include "tensorflow/lite/micro/examples/person_detection/model_settings.h"
 #include "tensorflow/lite/micro/examples/person_detection/testdata/no_person_image_data.h"
 #include "tensorflow/lite/micro/examples/person_detection/testdata/person_image_data.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 #include "tensorflow/lite/micro/models/person_detect_model_data.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
@@ -35,17 +35,14 @@ uint8_t tensor_arena[tensor_arena_size];
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestInvoke) {
-  // Set up logging.
-  tflite::MicroErrorReporter micro_error_reporter;
-
   // Map the model into a usable data structure. This doesn't involve any
   // copying or parsing, it's a very lightweight operation.
   const tflite::Model* model = ::tflite::GetModel(g_person_detect_model_data);
   if (model->version() != TFLITE_SCHEMA_VERSION) {
-    TF_LITE_REPORT_ERROR(&micro_error_reporter,
-                         "Model provided is schema version %d not equal "
-                         "to supported version %d.\n",
-                         model->version(), TFLITE_SCHEMA_VERSION);
+    MicroPrintf(
+        "Model provided is schema version %d not equal "
+        "to supported version %d.\n",
+        model->version(), TFLITE_SCHEMA_VERSION);
   }
 
   // Pull in only the operation implementations we need.
@@ -63,8 +60,7 @@ TF_LITE_MICRO_TEST(TestInvoke) {
 
   // Build an interpreter to run the model with.
   tflite::MicroInterpreter interpreter(model, micro_op_resolver, tensor_arena,
-                                       tensor_arena_size,
-                                       &micro_error_reporter);
+                                       tensor_arena_size);
   interpreter.AllocateTensors();
 
   // Get information about the memory area to use for the model's input.
@@ -86,7 +82,7 @@ TF_LITE_MICRO_TEST(TestInvoke) {
   // Run the model on this input and make sure it succeeds.
   TfLiteStatus invoke_status = interpreter.Invoke();
   if (invoke_status != kTfLiteOk) {
-    TF_LITE_REPORT_ERROR(&micro_error_reporter, "Invoke failed\n");
+    MicroPrintf("Invoke failed\n");
   }
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, invoke_status);
 
@@ -101,9 +97,8 @@ TF_LITE_MICRO_TEST(TestInvoke) {
   // Make sure that the expected "Person" score is higher than the other class.
   int8_t person_score = output->data.int8[kPersonIndex];
   int8_t no_person_score = output->data.int8[kNotAPersonIndex];
-  TF_LITE_REPORT_ERROR(&micro_error_reporter,
-                       "person data.  person score: %d, no person score: %d\n",
-                       person_score, no_person_score);
+  MicroPrintf("person data.  person score: %d, no person score: %d\n",
+              person_score, no_person_score);
   TF_LITE_MICRO_EXPECT_GT(person_score, no_person_score);
 
   memcpy(input->data.int8, g_no_person_image_data, input->bytes);
@@ -111,7 +106,7 @@ TF_LITE_MICRO_TEST(TestInvoke) {
   // Run the model on this "No Person" input.
   invoke_status = interpreter.Invoke();
   if (invoke_status != kTfLiteOk) {
-    TF_LITE_REPORT_ERROR(&micro_error_reporter, "Invoke failed\n");
+    MicroPrintf("Invoke failed\n");
   }
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, invoke_status);
 
@@ -126,13 +121,11 @@ TF_LITE_MICRO_TEST(TestInvoke) {
   // Make sure that the expected "No Person" score is higher.
   person_score = output->data.int8[kPersonIndex];
   no_person_score = output->data.int8[kNotAPersonIndex];
-  TF_LITE_REPORT_ERROR(
-      &micro_error_reporter,
-      "no person data.  person score: %d, no person score: %d\n", person_score,
-      no_person_score);
+  MicroPrintf("no person data.  person score: %d, no person score: %d\n",
+              person_score, no_person_score);
   TF_LITE_MICRO_EXPECT_GT(no_person_score, person_score);
 
-  TF_LITE_REPORT_ERROR(&micro_error_reporter, "Ran successfully\n");
+  MicroPrintf("Ran successfully\n");
 }
 
 TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/integration_tests/seanet/add/BUILD
+++ b/tensorflow/lite/micro/integration_tests/seanet/add/BUILD
@@ -982,8 +982,8 @@ cc_binary(
     copts = micro_copts(),
     deps = [
         ":models_and_testdata",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:micro_resource_variable",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:recording_allocators",

--- a/tensorflow/lite/micro/integration_tests/seanet/add/integration_tests.cc
+++ b/tensorflow/lite/micro/integration_tests/seanet/add/integration_tests.cc
@@ -85,7 +85,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/integration_tests/seanet/add/add9_input0_int16_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/add/add9_input1_int16_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/add/add9_model_data.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_profiler.h"
 #include "tensorflow/lite/micro/recording_micro_allocator.h"
 #include "tensorflow/lite/micro/recording_micro_interpreter.h"
@@ -107,8 +107,7 @@ void RunModel(const uint8_t* model, const int16_t* input0,
   MicroProfiler profiler;
 
   MicroInterpreter interpreter(GetModel(model), AllOpsResolver(), tensor_arena,
-                               kTensorArenaSize, GetMicroErrorReporter(),
-                               nullptr, &profiler);
+                               kTensorArenaSize, nullptr, &profiler);
   interpreter.AllocateTensors();
   TfLiteTensor* input0_tensor = interpreter.input(0);
   TF_LITE_MICRO_EXPECT_EQ(input0_tensor->bytes, input0_size * sizeof(int16_t));

--- a/tensorflow/lite/micro/integration_tests/seanet/conv/BUILD
+++ b/tensorflow/lite/micro/integration_tests/seanet/conv/BUILD
@@ -954,8 +954,8 @@ cc_test(
     copts = micro_copts(),
     deps = [
         ":models_and_testdata",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:micro_resource_variable",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:recording_allocators",

--- a/tensorflow/lite/micro/integration_tests/seanet/conv/integration_tests.cc
+++ b/tensorflow/lite/micro/integration_tests/seanet/conv/integration_tests.cc
@@ -83,7 +83,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/integration_tests/seanet/conv/conv9_golden_int16_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/conv/conv9_input_int16_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/conv/conv9_model_data.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_profiler.h"
 #include "tensorflow/lite/micro/recording_micro_allocator.h"
 #include "tensorflow/lite/micro/recording_micro_interpreter.h"
@@ -104,8 +104,7 @@ void RunModel(const uint8_t* model, const int16_t* input,
   MicroProfiler profiler;
   AllOpsResolver resolver;
   MicroInterpreter interpreter(GetModel(model), resolver, tensor_arena,
-                               kTensorArenaSize, GetMicroErrorReporter(),
-                               nullptr, &profiler);
+                               kTensorArenaSize, nullptr, &profiler);
   interpreter.AllocateTensors();
 
   TfLiteTensor* input_tensor = interpreter.input(0);

--- a/tensorflow/lite/micro/integration_tests/seanet/leaky_relu/BUILD
+++ b/tensorflow/lite/micro/integration_tests/seanet/leaky_relu/BUILD
@@ -996,8 +996,8 @@ cc_binary(
     copts = micro_copts(),
     deps = [
         ":models_and_testdata",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:micro_resource_variable",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:recording_allocators",

--- a/tensorflow/lite/micro/integration_tests/seanet/leaky_relu/integration_tests.cc
+++ b/tensorflow/lite/micro/integration_tests/seanet/leaky_relu/integration_tests.cc
@@ -86,7 +86,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/integration_tests/seanet/leaky_relu/leaky_relu9_golden_int16_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/leaky_relu/leaky_relu9_input0_int16_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/leaky_relu/leaky_relu9_model_data.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_profiler.h"
 #include "tensorflow/lite/micro/recording_micro_allocator.h"
 #include "tensorflow/lite/micro/recording_micro_interpreter.h"
@@ -107,8 +107,7 @@ void RunModel(const uint8_t* model, const int16_t* input0,
   MicroProfiler profiler;
 
   MicroInterpreter interpreter(GetModel(model), AllOpsResolver(), tensor_arena,
-                               kTensorArenaSize, GetMicroErrorReporter(),
-                               nullptr, &profiler);
+                               kTensorArenaSize, nullptr, &profiler);
   interpreter.AllocateTensors();
   TfLiteTensor* input0_tensor = interpreter.input(0);
   TF_LITE_MICRO_EXPECT_EQ(input0_tensor->bytes, input0_size * sizeof(int16_t));

--- a/tensorflow/lite/micro/integration_tests/seanet/pad/BUILD
+++ b/tensorflow/lite/micro/integration_tests/seanet/pad/BUILD
@@ -828,8 +828,8 @@ cc_test(
     copts = micro_copts(),
     deps = [
         ":models_and_testdata",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:micro_resource_variable",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:recording_allocators",

--- a/tensorflow/lite/micro/integration_tests/seanet/pad/integration_tests.cc
+++ b/tensorflow/lite/micro/integration_tests/seanet/pad/integration_tests.cc
@@ -74,7 +74,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/integration_tests/seanet/pad/pad9_golden_int16_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/pad/pad9_input0_int16_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/pad/pad9_model_data.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_profiler.h"
 #include "tensorflow/lite/micro/recording_micro_allocator.h"
 #include "tensorflow/lite/micro/recording_micro_interpreter.h"
@@ -96,8 +96,7 @@ void RunModel(const uint8_t* model, const int16_t* input0,
   AllOpsResolver op_resolver;
 
   MicroInterpreter interpreter(GetModel(model), op_resolver, tensor_arena,
-                               kTensorArenaSize, GetMicroErrorReporter(),
-                               nullptr, &profiler);
+                               kTensorArenaSize, nullptr, &profiler);
   interpreter.AllocateTensors();
   TfLiteTensor* input_tensor0 = interpreter.input(0);
   TF_LITE_MICRO_EXPECT_EQ(input_tensor0->bytes, input0_size * sizeof(int16_t));

--- a/tensorflow/lite/micro/integration_tests/seanet/quantize/BUILD
+++ b/tensorflow/lite/micro/integration_tests/seanet/quantize/BUILD
@@ -114,8 +114,8 @@ cc_test(
     copts = micro_copts(),
     deps = [
         ":models_and_testdata",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:micro_resource_variable",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:recording_allocators",

--- a/tensorflow/lite/micro/integration_tests/seanet/quantize/integration_tests.cc
+++ b/tensorflow/lite/micro/integration_tests/seanet/quantize/integration_tests.cc
@@ -23,7 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/integration_tests/seanet/quantize/quantize1_golden_int32_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/quantize/quantize1_input0_int16_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/quantize/quantize1_model_data.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_profiler.h"
 #include "tensorflow/lite/micro/recording_micro_allocator.h"
 #include "tensorflow/lite/micro/recording_micro_interpreter.h"
@@ -46,8 +46,7 @@ void RunModel(const uint8_t* model, const inputT* input0,
   AllOpsResolver op_resolver;
 
   MicroInterpreter interpreter(GetModel(model), op_resolver, tensor_arena,
-                               kTensorArenaSize, GetMicroErrorReporter(),
-                               nullptr, &profiler);
+                               kTensorArenaSize, nullptr, &profiler);
   interpreter.AllocateTensors();
   TfLiteTensor* input_tensor0 = interpreter.input(0);
   TF_LITE_MICRO_EXPECT_EQ(input_tensor0->bytes, input0_size * sizeof(inputT));

--- a/tensorflow/lite/micro/integration_tests/seanet/strided_slice/BUILD
+++ b/tensorflow/lite/micro/integration_tests/seanet/strided_slice/BUILD
@@ -1458,8 +1458,8 @@ cc_binary(
     copts = micro_copts(),
     deps = [
         ":models_and_testdata",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:micro_resource_variable",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:recording_allocators",

--- a/tensorflow/lite/micro/integration_tests/seanet/strided_slice/integration_tests.cc
+++ b/tensorflow/lite/micro/integration_tests/seanet/strided_slice/integration_tests.cc
@@ -119,7 +119,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/integration_tests/seanet/strided_slice/strided_slice9_golden_int16_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/strided_slice/strided_slice9_input0_int16_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/strided_slice/strided_slice9_model_data.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_profiler.h"
 #include "tensorflow/lite/micro/recording_micro_allocator.h"
 #include "tensorflow/lite/micro/recording_micro_interpreter.h"
@@ -140,8 +140,7 @@ void RunModel(const uint8_t* model, const int16_t* input0,
   MicroProfiler profiler;
 
   MicroInterpreter interpreter(GetModel(model), AllOpsResolver(), tensor_arena,
-                               kTensorArenaSize, GetMicroErrorReporter(),
-                               nullptr, &profiler);
+                               kTensorArenaSize, nullptr, &profiler);
   interpreter.AllocateTensors();
   TfLiteTensor* input0_tensor = interpreter.input(0);
   TF_LITE_MICRO_EXPECT_EQ(input0_tensor->bytes, input0_size * sizeof(int16_t));

--- a/tensorflow/lite/micro/integration_tests/seanet/sub/BUILD
+++ b/tensorflow/lite/micro/integration_tests/seanet/sub/BUILD
@@ -310,8 +310,8 @@ cc_binary(
     copts = micro_copts(),
     deps = [
         ":models_and_testdata",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:micro_resource_variable",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:recording_allocators",

--- a/tensorflow/lite/micro/integration_tests/seanet/sub/integration_tests.cc
+++ b/tensorflow/lite/micro/integration_tests/seanet/sub/integration_tests.cc
@@ -37,7 +37,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/integration_tests/seanet/sub/sub4_input0_int16_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/sub/sub4_input1_int16_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/sub/sub4_model_data.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_profiler.h"
 #include "tensorflow/lite/micro/recording_micro_allocator.h"
 #include "tensorflow/lite/micro/recording_micro_interpreter.h"
@@ -59,8 +59,7 @@ void RunModel(const uint8_t* model, const int16_t* input0,
   MicroProfiler profiler;
 
   MicroInterpreter interpreter(GetModel(model), AllOpsResolver(), tensor_arena,
-                               kTensorArenaSize, GetMicroErrorReporter(),
-                               nullptr, &profiler);
+                               kTensorArenaSize, nullptr, &profiler);
   interpreter.AllocateTensors();
   TfLiteTensor* input0_tensor = interpreter.input(0);
   TF_LITE_MICRO_EXPECT_EQ(input0_tensor->bytes, input0_size * sizeof(int16_t));

--- a/tensorflow/lite/micro/integration_tests/seanet/transpose_conv/BUILD
+++ b/tensorflow/lite/micro/integration_tests/seanet/transpose_conv/BUILD
@@ -310,8 +310,8 @@ cc_binary(
     copts = micro_copts(),
     deps = [
         ":models_and_testdata",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:micro_resource_variable",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:recording_allocators",

--- a/tensorflow/lite/micro/integration_tests/seanet/transpose_conv/integration_tests.cc
+++ b/tensorflow/lite/micro/integration_tests/seanet/transpose_conv/integration_tests.cc
@@ -37,7 +37,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/integration_tests/seanet/transpose_conv/transpose_conv4_input0_int32_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/transpose_conv/transpose_conv4_input1_int16_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/transpose_conv/transpose_conv4_model_data.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_profiler.h"
 #include "tensorflow/lite/micro/recording_micro_allocator.h"
 #include "tensorflow/lite/micro/recording_micro_interpreter.h"
@@ -60,8 +60,7 @@ void RunModel(const uint8_t* model, const int32_t* input0,
   AllOpsResolver op_resolver;
 
   MicroInterpreter interpreter(GetModel(model), op_resolver, tensor_arena,
-                               kTensorArenaSize, GetMicroErrorReporter(),
-                               nullptr, &profiler);
+                               kTensorArenaSize, nullptr, &profiler);
   interpreter.AllocateTensors();
   TfLiteTensor* input0_tensor = interpreter.input(0);
   TF_LITE_MICRO_EXPECT_EQ(input0_tensor->bytes, input0_size * sizeof(int32_t));

--- a/tensorflow/lite/micro/integration_tests/templates/BUILD.mako
+++ b/tensorflow/lite/micro/integration_tests/templates/BUILD.mako
@@ -77,8 +77,8 @@ cc_test(
     copts = micro_copts(),
     deps = [
         ":models_and_testdata",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:micro_resource_variable",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:recording_allocators",

--- a/tensorflow/lite/micro/integration_tests/templates/integration_tests_cc.mako
+++ b/tensorflow/lite/micro/integration_tests/templates/integration_tests_cc.mako
@@ -17,7 +17,7 @@ limitations under the License.
 
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/all_ops_resolver.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_profiler.h"
 #include "tensorflow/lite/micro/recording_micro_allocator.h"
 #include "tensorflow/lite/micro/recording_micro_interpreter.h"
@@ -52,7 +52,7 @@ void RunModel(const uint8_t* model,
   AllOpsResolver op_resolver;
 
   MicroInterpreter interpreter(GetModel(model), op_resolver, tensor_arena,
-                               kTensorArenaSize, GetMicroErrorReporter(),
+                               kTensorArenaSize,
                                nullptr, &profiler);
   interpreter.AllocateTensors();
 % for input_idx, input in enumerate(inputs):

--- a/tensorflow/lite/micro/kernels/activations.cc
+++ b/tensorflow/lite/micro/kernels/activations.cc
@@ -24,7 +24,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/kernels/add.cc
+++ b/tensorflow/lite/micro/kernels/add.cc
@@ -26,7 +26,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/add.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/memory_helpers.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/add_n.cc
+++ b/tensorflow/lite/micro/kernels/add_n.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/arc_mli/add.cc
+++ b/tensorflow/lite/micro/kernels/arc_mli/add.cc
@@ -33,6 +33,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/arc_mli/scratch_buffers.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/memory_helpers.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/arc_mli/conv.cc
+++ b/tensorflow/lite/micro/kernels/arc_mli/conv.cc
@@ -30,6 +30,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/arc_mli/scratch_buf_mgr.h"
 #include "tensorflow/lite/micro/kernels/arc_mli/scratch_buffers.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/arc_mli/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/arc_mli/depthwise_conv.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/arc_mli/scratch_buf_mgr.h"
 #include "tensorflow/lite/micro/kernels/arc_mli/scratch_buffers.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/arc_mli/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/arc_mli/fully_connected.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/arc_mli/scratch_buf_mgr.h"
 #include "tensorflow/lite/micro/kernels/arc_mli/scratch_buffers.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/arc_mli/mli_interface.cc
+++ b/tensorflow/lite/micro/kernels/arc_mli/mli_interface.cc
@@ -17,7 +17,7 @@ limitations under the License.
 
 #include <math.h>
 
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/arc_mli/mli_interface_mli_20.cc
+++ b/tensorflow/lite/micro/kernels/arc_mli/mli_interface_mli_20.cc
@@ -16,7 +16,7 @@ limitations under the License.
 #include <math.h>
 
 #include "mli_interface.h"  // NOLINT
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/arc_mli/mli_tf_utils.h
+++ b/tensorflow/lite/micro/kernels/arc_mli/mli_tf_utils.h
@@ -21,7 +21,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/common.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 #define KRNL_C_DIM_NHWC 0  // output channels
 

--- a/tensorflow/lite/micro/kernels/arc_mli/pooling.cc
+++ b/tensorflow/lite/micro/kernels/arc_mli/pooling.cc
@@ -26,6 +26,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/arc_mli/scratch_buf_mgr.h"
 #include "tensorflow/lite/micro/kernels/arc_mli/scratch_buffers.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/arg_min_max.cc
+++ b/tensorflow/lite/micro/kernels/arg_min_max.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/micro_utils.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/assign_variable.cc
+++ b/tensorflow/lite/micro/kernels/assign_variable.cc
@@ -23,8 +23,8 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/memory_helpers.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/micro_graph.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_resource_variable.h"
 #include "tensorflow/lite/schema/schema_generated.h"
 

--- a/tensorflow/lite/micro/kernels/batch_to_space_nd.cc
+++ b/tensorflow/lite/micro/kernels/batch_to_space_nd.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/kernels/cast.cc
+++ b/tensorflow/lite/micro/kernels/cast.cc
@@ -17,7 +17,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/ceva/conv.cc
+++ b/tensorflow/lite/micro/kernels/ceva/conv.cc
@@ -27,6 +27,8 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/ceva/ceva_tflm_lib.h"
 #include "tensorflow/lite/micro/kernels/conv.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
+
 #ifdef MCPS_MEASUREMENT
 #include "tensorflow/lite/micro/kernels/ceva/mcps_macros.h"
 #endif

--- a/tensorflow/lite/micro/kernels/ceva/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/ceva/depthwise_conv.cc
@@ -28,6 +28,8 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/ceva/ceva_tflm_lib.h"
 #include "tensorflow/lite/micro/kernels/depthwise_conv.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
+
 #ifdef MCPS_MEASUREMENT
 #include "tensorflow/lite/micro/kernels/ceva/mcps_macros.h"
 #endif

--- a/tensorflow/lite/micro/kernels/ceva/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/ceva/fully_connected.cc
@@ -25,6 +25,8 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/ceva/ceva_tflm_lib.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
+
 // #define MCPS_MEASUREMENT
 #ifdef MCPS_MEASUREMENT
 #include "tensorflow/lite/micro/kernels/ceva/mcps_macros.h"

--- a/tensorflow/lite/micro/kernels/ceva/logistic.cc
+++ b/tensorflow/lite/micro/kernels/ceva/logistic.cc
@@ -27,6 +27,8 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/ceva/ceva_tflm_lib.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/logistic.h"
+#include "tensorflow/lite/micro/micro_log.h"
+
 #ifdef MCPS_MEASUREMENT
 #include "tensorflow/lite/micro/kernels/ceva/mcps_macros.h"
 #endif

--- a/tensorflow/lite/micro/kernels/ceva/softmax.cc
+++ b/tensorflow/lite/micro/kernels/ceva/softmax.cc
@@ -26,6 +26,8 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/ceva/ceva_tflm_lib.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/softmax.h"
+#include "tensorflow/lite/micro/micro_log.h"
+
 #ifdef MCPS_MEASUREMENT
 #include "tensorflow/lite/micro/kernels/ceva/mcps_macros.h"
 #endif

--- a/tensorflow/lite/micro/kernels/circular_buffer.cc
+++ b/tensorflow/lite/micro/kernels/circular_buffer.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/flatbuffer_utils.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 /*
  * The circular buffer custom operator is used to implement strided streaming

--- a/tensorflow/lite/micro/kernels/cmsis_nn/add.cc
+++ b/tensorflow/lite/micro/kernels/cmsis_nn/add.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/memory_helpers.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/cmsis_nn/conv.cc
+++ b/tensorflow/lite/micro/kernels/cmsis_nn/conv.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/padding.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/cmsis_nn/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/cmsis_nn/depthwise_conv.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/padding.h"
 #include "tensorflow/lite/micro/kernels/conv.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/cmsis_nn/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/cmsis_nn/fully_connected.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/cmsis_nn/mul.cc
+++ b/tensorflow/lite/micro/kernels/cmsis_nn/mul.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/mul.h"
 #include "tensorflow/lite/micro/memory_helpers.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/cmsis_nn/pooling.cc
+++ b/tensorflow/lite/micro/kernels/cmsis_nn/pooling.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/pooling.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/cmsis_nn/softmax.cc
+++ b/tensorflow/lite/micro/kernels/cmsis_nn/softmax.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/cmsis_nn/svdf.cc
+++ b/tensorflow/lite/micro/kernels/cmsis_nn/svdf.cc
@@ -26,7 +26,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/activation_utils.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/kernels/comparisons.cc
+++ b/tensorflow/lite/micro/kernels/comparisons.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/concatenation.cc
+++ b/tensorflow/lite/micro/kernels/concatenation.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/conv.cc
+++ b/tensorflow/lite/micro/kernels/conv.cc
@@ -25,7 +25,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/padding.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/cumsum.cc
+++ b/tensorflow/lite/micro/kernels/cumsum.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/depth_to_space.cc
+++ b/tensorflow/lite/micro/kernels/depth_to_space.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/depthwise_conv.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/padding.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/dequantize.cc
+++ b/tensorflow/lite/micro/kernels/dequantize.cc
@@ -24,7 +24,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/dequantize.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/div.cc
+++ b/tensorflow/lite/micro/kernels/div.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/elementwise.cc
+++ b/tensorflow/lite/micro/kernels/elementwise.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/kernels/elu.cc
+++ b/tensorflow/lite/micro/kernels/elu.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/ethos_u/ethosu.cc
+++ b/tensorflow/lite/micro/kernels/ethos_u/ethosu.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/micro_context.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/exp.cc
+++ b/tensorflow/lite/micro/kernels/exp.cc
@@ -19,7 +19,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/expand_dims.cc
+++ b/tensorflow/lite/micro/kernels/expand_dims.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/kernels/fill.cc
+++ b/tensorflow/lite/micro/kernels/fill.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/floor_div.cc
+++ b/tensorflow/lite/micro/kernels/floor_div.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/kernels/floor_mod.cc
+++ b/tensorflow/lite/micro/kernels/floor_mod.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 // OLD-TODO(b/117523611): We should factor out a binary_op and put binary ops

--- a/tensorflow/lite/micro/kernels/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/fully_connected.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/gather.cc
+++ b/tensorflow/lite/micro/kernels/gather.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/kernels/gather_nd.cc
+++ b/tensorflow/lite/micro/kernels/gather_nd.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/kernels/hard_swish.cc
+++ b/tensorflow/lite/micro/kernels/hard_swish.cc
@@ -25,7 +25,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/hard_swish.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/kernels/if_test.cc
+++ b/tensorflow/lite/micro/kernels/if_test.cc
@@ -114,12 +114,10 @@ TF_LITE_MICRO_TEST(IfShouldInvokeSubgraphConditionTrue) {
   const tflite::Model* model =
       tflite::testing::GetSimpleModelWithSubgraphsAndIf();
   tflite::MicroMutableOpResolver<3> resolver;
-  tflite::MicroErrorReporter reporter;
   resolver.AddIf();
   resolver.AddAdd();
   resolver.AddMul();
-  tflite::MicroInterpreter interpreter(model, resolver, arena, kArenaSize,
-                                       &reporter);
+  tflite::MicroInterpreter interpreter(model, resolver, arena, kArenaSize);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, interpreter.AllocateTensors());
   TfLiteTensor* condition = interpreter.input(0);
   TfLiteTensor* input1 = interpreter.input(1);
@@ -144,12 +142,10 @@ TF_LITE_MICRO_TEST(IfShouldInvokeSubgraphConditionFalse) {
   const tflite::Model* model =
       tflite::testing::GetSimpleModelWithSubgraphsAndIf();
   tflite::MicroMutableOpResolver<3> resolver;
-  tflite::MicroErrorReporter reporter;
   resolver.AddIf();
   resolver.AddAdd();
   resolver.AddMul();
-  tflite::MicroInterpreter interpreter(model, resolver, arena, kArenaSize,
-                                       &reporter);
+  tflite::MicroInterpreter interpreter(model, resolver, arena, kArenaSize);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, interpreter.AllocateTensors());
   TfLiteTensor* condition = interpreter.input(0);
   TfLiteTensor* input1 = interpreter.input(1);
@@ -176,9 +172,7 @@ TF_LITE_MICRO_TEST(IfShouldNotOverwriteTensorAcrossSubgraphs) {
 
   tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
   op_resolver.AddIf();
-  tflite::MicroErrorReporter reporter;
-  tflite::MicroInterpreter interpreter(model, op_resolver, arena, kArenaSize,
-                                       &reporter);
+  tflite::MicroInterpreter interpreter(model, op_resolver, arena, kArenaSize);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, interpreter.AllocateTensors());
 
   TfLiteTensor* condition = interpreter.input(0);

--- a/tensorflow/lite/micro/kernels/kernel_runner.cc
+++ b/tensorflow/lite/micro/kernels/kernel_runner.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/arena_allocator/single_arena_buffer_allocator.h"
 #include "tensorflow/lite/micro/micro_arena_constants.h"
 #include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 
 namespace tflite {
@@ -39,8 +40,7 @@ KernelRunner::KernelRunner(const TfLiteRegistration& registration,
                            TfLiteIntArray* inputs, TfLiteIntArray* outputs,
                            void* builtin_data, TfLiteIntArray* intermediates)
     : registration_(registration),
-      allocator_(SingleArenaBufferAllocator::Create(GetMicroErrorReporter(),
-                                                    kKernelRunnerBuffer_,
+      allocator_(SingleArenaBufferAllocator::Create(kKernelRunnerBuffer_,
                                                     kKernelRunnerBufferSize_)),
       mock_micro_graph_(allocator_),
       fake_micro_context_(tensors, allocator_, &mock_micro_graph_) {

--- a/tensorflow/lite/micro/kernels/kernel_util.cc
+++ b/tensorflow/lite/micro/kernels/kernel_util.cc
@@ -17,7 +17,7 @@ limitations under the License.
 
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/memory_helpers.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace micro {

--- a/tensorflow/lite/micro/kernels/kernel_util.h
+++ b/tensorflow/lite/micro/kernels/kernel_util.h
@@ -24,7 +24,6 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/micro/micro_context.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 
 namespace tflite {
 namespace micro {

--- a/tensorflow/lite/micro/kernels/l2_pool_2d.cc
+++ b/tensorflow/lite/micro/kernels/l2_pool_2d.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/padding.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/l2norm.cc
+++ b/tensorflow/lite/micro/kernels/l2norm.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/reference/l2normalization.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/leaky_relu.cc
+++ b/tensorflow/lite/micro/kernels/leaky_relu.cc
@@ -22,7 +22,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/leaky_relu.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/log_softmax.cc
+++ b/tensorflow/lite/micro/kernels/log_softmax.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/logistic.cc
+++ b/tensorflow/lite/micro/kernels/logistic.cc
@@ -25,7 +25,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/logistic.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/maximum_minimum.cc
+++ b/tensorflow/lite/micro/kernels/maximum_minimum.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/mul.cc
+++ b/tensorflow/lite/micro/kernels/mul.cc
@@ -24,7 +24,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/memory_helpers.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/neg.cc
+++ b/tensorflow/lite/micro/kernels/neg.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/pack.cc
+++ b/tensorflow/lite/micro/kernels/pack.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/pad.cc
+++ b/tensorflow/lite/micro/kernels/pad.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/pooling.cc
+++ b/tensorflow/lite/micro/kernels/pooling.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/pooling.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/prelu.cc
+++ b/tensorflow/lite/micro/kernels/prelu.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/prelu.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/quantize_common.cc
+++ b/tensorflow/lite/micro/kernels/quantize_common.cc
@@ -23,7 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/quantize.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/kernels/read_variable.cc
+++ b/tensorflow/lite/micro/kernels/read_variable.cc
@@ -23,8 +23,8 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/memory_helpers.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/micro_graph.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_resource_variable.h"
 #include "tensorflow/lite/schema/schema_generated.h"
 

--- a/tensorflow/lite/micro/kernels/reduce_common.cc
+++ b/tensorflow/lite/micro/kernels/reduce_common.cc
@@ -23,7 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/reduce.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/kernels/resize_bilinear.cc
+++ b/tensorflow/lite/micro/kernels/resize_bilinear.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/kernels/resize_nearest_neighbor.cc
+++ b/tensorflow/lite/micro/kernels/resize_nearest_neighbor.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/select.cc
+++ b/tensorflow/lite/micro/kernels/select.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/shape.cc
+++ b/tensorflow/lite/micro/kernels/shape.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/memory_helpers.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/kernels/slice.cc
+++ b/tensorflow/lite/micro/kernels/slice.cc
@@ -20,7 +20,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/softmax.cc
+++ b/tensorflow/lite/micro/kernels/softmax.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/space_to_batch_nd.cc
+++ b/tensorflow/lite/micro/kernels/space_to_batch_nd.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/kernels/space_to_depth.cc
+++ b/tensorflow/lite/micro/kernels/space_to_depth.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/split.cc
+++ b/tensorflow/lite/micro/kernels/split.cc
@@ -18,7 +18,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/split_v.cc
+++ b/tensorflow/lite/micro/kernels/split_v.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/squared_difference.cc
+++ b/tensorflow/lite/micro/kernels/squared_difference.cc
@@ -19,7 +19,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/micro_context.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/squeeze.cc
+++ b/tensorflow/lite/micro/kernels/squeeze.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/memory_helpers.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/strided_slice.cc
+++ b/tensorflow/lite/micro/kernels/strided_slice.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/sub.cc
+++ b/tensorflow/lite/micro/kernels/sub.cc
@@ -27,7 +27,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/svdf.cc
+++ b/tensorflow/lite/micro/kernels/svdf.cc
@@ -26,7 +26,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/activation_utils.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/kernels/tanh.cc
+++ b/tensorflow/lite/micro/kernels/tanh.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/kernels/transpose.cc
+++ b/tensorflow/lite/micro/kernels/transpose.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/transpose_conv.cc
+++ b/tensorflow/lite/micro/kernels/transpose_conv.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/padding.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/unidirectional_sequence_lstm.cc
+++ b/tensorflow/lite/micro/kernels/unidirectional_sequence_lstm.cc
@@ -26,7 +26,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/lstm_eval.h"
 #include "tensorflow/lite/micro/kernels/lstm_shared.h"
 #include "tensorflow/lite/micro/kernels/micro_tensor_utils.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/unpack.cc
+++ b/tensorflow/lite/micro/kernels/unpack.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/var_handle.cc
+++ b/tensorflow/lite/micro/kernels/var_handle.cc
@@ -23,8 +23,8 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/memory_helpers.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/micro_graph.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_resource_variable.h"
 #include "tensorflow/lite/schema/schema_generated.h"
 

--- a/tensorflow/lite/micro/kernels/vexriscv/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/vexriscv/depthwise_conv.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/padding.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/while_test.cc
+++ b/tensorflow/lite/micro/kernels/while_test.cc
@@ -33,12 +33,10 @@ TF_LITE_MICRO_TEST(WhileShouldNeverInvokeConditionFalse) {
   const tflite::Model* model =
       tflite::testing::GetSimpleModelWithSubgraphsAndWhile();
   tflite::MicroMutableOpResolver<3> resolver;
-  tflite::MicroErrorReporter reporter;
   resolver.AddWhile();
   resolver.AddAdd();
   resolver.AddLess();
-  tflite::MicroInterpreter interpreter(model, resolver, arena, kArenaSize,
-                                       &reporter);
+  tflite::MicroInterpreter interpreter(model, resolver, arena, kArenaSize);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, interpreter.AllocateTensors());
   TfLiteTensor* input0 = interpreter.input(0);
   TfLiteTensor* input1 = interpreter.input(1);
@@ -60,12 +58,10 @@ TF_LITE_MICRO_TEST(WhileShouldInvokeOnce) {
   const tflite::Model* model =
       tflite::testing::GetSimpleModelWithSubgraphsAndWhile();
   tflite::MicroMutableOpResolver<3> resolver;
-  tflite::MicroErrorReporter reporter;
   resolver.AddWhile();
   resolver.AddAdd();
   resolver.AddLess();
-  tflite::MicroInterpreter interpreter(model, resolver, arena, kArenaSize,
-                                       &reporter);
+  tflite::MicroInterpreter interpreter(model, resolver, arena, kArenaSize);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, interpreter.AllocateTensors());
   TfLiteTensor* input0 = interpreter.input(0);
   TfLiteTensor* input1 = interpreter.input(1);

--- a/tensorflow/lite/micro/kernels/xtensa/add.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/add.cc
@@ -27,7 +27,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa_add.h"
 #include "tensorflow/lite/micro/memory_helpers.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/xtensa/conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa_conv.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/xtensa/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/fully_connected.cc
@@ -26,6 +26,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa_fully_connected.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/xtensa/leaky_relu.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/leaky_relu.cc
@@ -23,7 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/leaky_relu.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/xtensa/logistic.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/logistic.cc
@@ -26,7 +26,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/logistic.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/xtensa/pad.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/pad.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa_pad.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/xtensa/pooling.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/pooling.cc
@@ -21,7 +21,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/pooling.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa_pooling.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/xtensa/quantize.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/quantize.cc
@@ -23,7 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/quantize.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/kernels/xtensa/softmax.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/softmax.cc
@@ -26,6 +26,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa_softmax.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/xtensa/softmax_int8_int16.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/softmax_int8_int16.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/softmax.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa_softmax.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/xtensa/strided_slice.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/strided_slice.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/xtensa/sub.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/sub.cc
@@ -27,7 +27,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 

--- a/tensorflow/lite/micro/kernels/xtensa/svdf.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/svdf.cc
@@ -27,7 +27,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/activation_utils.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/xtensa/transpose_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/transpose_conv.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/padding.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/xtensa/unidirectional_sequence_lstm.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/unidirectional_sequence_lstm.cc
@@ -27,7 +27,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/xtensa/lstm_eval.h"
 #include "tensorflow/lite/micro/kernels/xtensa/lstm_shared.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 // TODO(b/230666079): Flatten the namespace to match the builtin kernel
 // implementation

--- a/tensorflow/lite/micro/kernels/zeros_like.cc
+++ b/tensorflow/lite/micro/kernels/zeros_like.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/python/interpreter/src/BUILD
+++ b/tensorflow/lite/micro/python/interpreter/src/BUILD
@@ -23,7 +23,6 @@ pybind_library(
         "shared_library.h",
     ],
     deps = [
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
         "//tensorflow/lite/micro:op_resolvers",
     ],

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
@@ -24,9 +24,7 @@ limitations under the License.
 #include <pybind11/pybind11.h>
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/core/api/error_reporter.h"
 #include "tensorflow/lite/micro/all_ops_resolver.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
 #include "tensorflow/lite/micro/python/interpreter/src/numpy_utils.h"
 #include "tensorflow/lite/micro/python/interpreter/src/pybind11_lib.h"
@@ -223,7 +221,6 @@ InterpreterWrapper::InterpreterWrapper(
 
   const Model* model = GetModel(buf);
   model_ = model_data;
-  error_reporter_ = std::unique_ptr<ErrorReporter>(new MicroErrorReporter());
   memory_arena_ = std::unique_ptr<uint8_t[]>(new uint8_t[arena_size]);
 
   for (const auto& registerer : registerers_by_name) {
@@ -235,9 +232,8 @@ InterpreterWrapper::InterpreterWrapper(
     }
   }
 
-  interpreter_ =
-      new MicroInterpreter(model, all_ops_resolver_, memory_arena_.get(),
-                           arena_size, error_reporter_.get());
+  interpreter_ = new MicroInterpreter(model, all_ops_resolver_,
+                                      memory_arena_.get(), arena_size);
 
   TfLiteStatus status = interpreter_->AllocateTensors();
   if (status != kTfLiteOk) {

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include <Python.h>
 
-#include "tensorflow/lite/core/api/error_reporter.h"
 #include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
 
@@ -39,7 +38,6 @@ class InterpreterWrapper {
 
  private:
   const PyObject* model_;
-  std::unique_ptr<tflite::ErrorReporter> error_reporter_;
   std::unique_ptr<uint8_t[]> memory_arena_;
   tflite::AllOpsResolver all_ops_resolver_;
   tflite::MicroInterpreter* interpreter_;

--- a/tensorflow/lite/micro/testing/BUILD
+++ b/tensorflow/lite/micro/testing/BUILD
@@ -38,8 +38,8 @@ cc_library(
     deps = [
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/core/api",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:micro_utils",
         "//tensorflow/lite/micro:system_setup",
         "//tensorflow/lite/micro:test_helpers",

--- a/tensorflow/lite/micro/testing/micro_test.h
+++ b/tensorflow/lite/micro/testing/micro_test.h
@@ -14,8 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 // An ultra-lightweight testing framework designed for use with microcontroller
-// applications. Its only dependency is on TensorFlow Lite's ErrorReporter
-// interface, where log messages are output. This is designed to be usable even
+// applications. This is designed to be usable even
 // when no standard C or C++ libraries are available, and without any dynamic
 // memory allocation or reliance on global constructors.
 //
@@ -35,8 +34,7 @@ limitations under the License.
 // ----------------------------------------------------------------------------
 // If you compile this for your platform, you'll get a normal binary that you
 // should be able to run. Executing it will output logging information like this
-// to stderr (or whatever equivalent is available and written to by
-// ErrorReporter):
+// to stderr:
 // ----------------------------------------------------------------------------
 // Testing SomeTest
 // 1/1 tests passed
@@ -57,7 +55,7 @@ limitations under the License.
 #include <type_traits>
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/system_setup.h"
 
 namespace micro_test {

--- a/tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver/templates/BUILD.mako
+++ b/tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver/templates/BUILD.mako
@@ -77,8 +77,8 @@ cc_test(
     deps = [
         ":gen_micro_op_resolver",
         ":models_and_testdata",
-        "//tensorflow/lite/micro:micro_error_reporter",
         "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:micro_resource_variable",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:recording_allocators",

--- a/tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver/templates/micro_mutable_op_resolver_test.cc.mako
+++ b/tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver/templates/micro_mutable_op_resolver_test.cc.mako
@@ -19,7 +19,7 @@ limitations under the License.
 
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/all_ops_resolver.h"
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_profiler.h"
 #include "tensorflow/lite/micro/recording_micro_allocator.h"
 #include "tensorflow/lite/micro/recording_micro_interpreter.h"
@@ -52,7 +52,7 @@ void RunModel(const uint8_t* model,
   tflite::MicroMutableOpResolver<kNumberOperators> op_resolver = get_resolver();
 
   MicroInterpreter interpreter(GetModel(model), op_resolver, tensor_arena,
-                               kTensorArenaSize, GetMicroErrorReporter(),
+                               kTensorArenaSize,
                                nullptr, &profiler);
   interpreter.AllocateTensors();
 #if VERIFY_OUTPUT

--- a/third_party/hexagon/fully_connected.cc
+++ b/third_party/hexagon/fully_connected.cc
@@ -53,6 +53,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "third_party/hexagon/hexagon_fully_connected.h"
 #include "third_party/hexagon/hexagon_tflm_translation_fully_connected.h"
 

--- a/third_party/hexagon/svdf.cc
+++ b/third_party/hexagon/svdf.cc
@@ -53,6 +53,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/activation_utils.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 #include "third_party/hexagon/hexagon_svdf.h"
 #include "third_party/hexagon/hexagon_tflm_translation_svdf.h"

--- a/third_party/xtensa/examples/pytorch_to_tflite/pytorch_to_tflite_test.cc
+++ b/third_party/xtensa/examples/pytorch_to_tflite/pytorch_to_tflite_test.cc
@@ -36,7 +36,7 @@ limitations under the License.
  * */
 #include <tensorflow/lite/micro/all_ops_resolver.h>
 
-#include "tensorflow/lite/micro/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
 #include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
@@ -49,18 +49,15 @@ TF_LITE_MICRO_TESTS_BEGIN
 #if defined(HIFI5)
 
 TF_LITE_MICRO_TEST(TestInvoke) {
-  // Set up logging.
-  tflite::MicroErrorReporter micro_error_reporter;
-
   // Map the model into a usable data structure. This doesn't involve any
   // copying or parsing, it's a very lightweight operation.
   const tflite::Model* model =
       ::tflite::GetModel(g_mobilenet_v2_quantized_1x3x224x224_model_data);
   if (model->version() != TFLITE_SCHEMA_VERSION) {
-    TF_LITE_REPORT_ERROR(&micro_error_reporter,
-                         "Model provided is schema version %d not equal "
-                         "to supported version %d.\n",
-                         model->version(), TFLITE_SCHEMA_VERSION);
+    MicroPrintf(
+        "Model provided is schema version %d not equal "
+        "to supported version %d.\n",
+        model->version(), TFLITE_SCHEMA_VERSION);
   }
 
   // Pull in only the operation implementations we need.
@@ -77,7 +74,7 @@ TF_LITE_MICRO_TEST(TestInvoke) {
 
   // Build an interpreter to run the model with.
   tflite::MicroInterpreter interpreter(
-      model, resolver, tensor_arena, tensor_arena_size, &micro_error_reporter);
+      model, resolver, tensor_arena, tensor_arena_size);
   interpreter.AllocateTensors();
 
   // Get information about the memory area to use for the model's input.
@@ -92,18 +89,13 @@ TF_LITE_MICRO_TEST(TestInvoke) {
   TF_LITE_MICRO_EXPECT_EQ(224, input->dims->data[3]);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteInt8, input->type);
   // Make sure the input has the properties we expect.
-  TF_LITE_REPORT_ERROR(&micro_error_reporter, "input->dims->size:%d",
-                       input->dims->size);
-  TF_LITE_REPORT_ERROR(&micro_error_reporter, "input->dims->data[0]:%d",
-                       input->dims->data[0]);
-  TF_LITE_REPORT_ERROR(&micro_error_reporter, "input->dims->data[1]:%d",
-                       input->dims->data[1]);
-  TF_LITE_REPORT_ERROR(&micro_error_reporter, "input->dims->data[2]:%d",
-                       input->dims->data[2]);
-  TF_LITE_REPORT_ERROR(&micro_error_reporter, "input->dims->data[3]:%d",
-                       input->dims->data[3]);
-  TF_LITE_REPORT_ERROR(&micro_error_reporter, "input->type:%d", input->type);
-  TF_LITE_REPORT_ERROR(&micro_error_reporter, "input->bytes:%d", input->bytes);
+  MicroPrintf("input->dims->size:%d", input->dims->size);
+  MicroPrintf("input->dims->data[0]:%d", input->dims->data[0]);
+  MicroPrintf("input->dims->data[1]:%d", input->dims->data[1]);
+  MicroPrintf("input->dims->data[2]:%d", input->dims->data[2]);
+  MicroPrintf("input->dims->data[3]:%d", input->dims->data[3]);
+  MicroPrintf("input->type:%d", input->type);
+  MicroPrintf("input->bytes:%d", input->bytes);
 
   // Copy an image with a person into the memory area used for the input.
   TFLITE_DCHECK_EQ(input->bytes,
@@ -113,7 +105,7 @@ TF_LITE_MICRO_TEST(TestInvoke) {
   // Run the model on this input and make sure it succeeds.
   TfLiteStatus invoke_status = interpreter.Invoke();
   if (invoke_status != kTfLiteOk) {
-    TF_LITE_REPORT_ERROR(&micro_error_reporter, "Invoke failed\n");
+    MicroPrintf("Invoke failed\n");
   }
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, invoke_status);
 
@@ -124,13 +116,10 @@ TF_LITE_MICRO_TEST(TestInvoke) {
   TF_LITE_MICRO_EXPECT_EQ(1, output->dims->data[0]);
   TF_LITE_MICRO_EXPECT_EQ(1000, output->dims->data[1]);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteInt8, output->type);
-  TF_LITE_REPORT_ERROR(&micro_error_reporter, "output->dims->size:%d",
-                       output->dims->size);
-  TF_LITE_REPORT_ERROR(&micro_error_reporter, "output->dims->data[0]:%d",
-                       output->dims->data[0]);
-  TF_LITE_REPORT_ERROR(&micro_error_reporter, "output->dims->data[1]:%d",
-                       output->dims->data[1]);
-  TF_LITE_REPORT_ERROR(&micro_error_reporter, "output->type:%d", output->type);
+  MicroPrintf("output->dims->size:%d", output->dims->size);
+  MicroPrintf("output->dims->data[0]:%d", output->dims->data[0]);
+  MicroPrintf("output->dims->data[1]:%d", output->dims->data[1]);
+  MicroPrintf("output->type:%d", output->type);
 
   int label_index = 0;
   int label_confidence = -257;
@@ -140,11 +129,10 @@ TF_LITE_MICRO_TEST(TestInvoke) {
       label_confidence = output->data.int8[i];
     }
   }
-  TF_LITE_REPORT_ERROR(&micro_error_reporter, "Label index:%d\t", label_index);
-  TF_LITE_REPORT_ERROR(&micro_error_reporter, "Confidence:%d",
-                       label_confidence);
+  MicroPrintf("Label index:%d\t", label_index);
+  MicroPrintf("Confidence:%d", label_confidence);
 
-  TF_LITE_REPORT_ERROR(&micro_error_reporter, "Ran successfully\n");
+  MicroPrintf("Ran successfully\n");
 }
 #endif  // defined(HIFI5)
 


### PR DESCRIPTION
This PR updates remainder of the TFLM examples, all the kernels and integration tests to remove the usage of ErrorReporter as per the changes made to the TFLM Framework API in https://github.com/tensorflow/tflite-micro/pull/1415; replaces TF_LITE_REPORT_ERROR with MicroPrintf.

BUG=http://b/192091017, http://b/245802069