### PR TITLE
Update the apply_cirun workflow to only trigger on a synchronize event.

### DIFF
--- a/.github/workflows/apply_cirun.yml
+++ b/.github/workflows/apply_cirun.yml
@@ -1,16 +1,13 @@
 # Apply ci:run on the following conditions:
-#   1. ci:ready_to_merge is added to a PR (e.g. on review approval). This makes
-#      it so that a review approval is sufficient to get all the CI machinery
-#      going and have the PR be merged (if all the tests pass).
-#
-#   2. PR is updated by mergify[bot] and ci:ready_to_merge is already a label on the PR. This
-#      allows mergify to update the PR and keep the merging process moving
-#      along.
+#   1. PR is updated by mergify[bot] and ci:ready_to_merge is already a label on
+#   the PR. This allows mergify to update the PR and keep the merging process
+#   moving along.
 #
 # And removes ci:ready_to_merge if the pr is updated by anyone other than mergify[bot].
+
 on:
   pull_request_target:
-    types: [labeled, synchronize]
+    types: [synchronize]
 
 jobs:
   apply-label:


### PR DESCRIPTION
With https://github.com/tensorflow/tflite-micro/pull/1424, we are triggering all the workflows directly from the `ci:ready_to_merge_label`.

As a result, we no longer need to apply ci:run from a pull_request:labeled event.

Additionally, with the apply_cirun workflow in its current form, when a reviewer adds the `ci:ready_to_merge` label the workflow ends up removing it which interferes with the merge queue.

The correct behavior is to only automatically apply ci:run on a synchronize event (when the event comes from mergify).

BUG=http://b/246664234
