### PR TITLE
Add virtual destructor to fix build error from `-Wnon-virtual-dtor`.

### DIFF
--- a/tensorflow/lite/micro/build_def.bzl
+++ b/tensorflow/lite/micro/build_def.bzl
@@ -2,6 +2,7 @@ def micro_copts():
     return [
         "-Wall",
         "-Werror",
+        "-Wnon-virtual-dtor",
         "-DFLATBUFFERS_LOCALE_INDEPENDENT=0",
     ]
 

--- a/tensorflow/lite/micro/micro_profiler_interface.h
+++ b/tensorflow/lite/micro/micro_profiler_interface.h
@@ -23,6 +23,8 @@ namespace tflite {
 // Interface class that the TFLM framework relies on for profiling.
 class MicroProfilerInterface {
  public:
+  virtual ~MicroProfilerInterface() {}
+
   // Marks the start of a new event and returns an event handle that can be used
   // to mark the end of the event via EndEvent.
   virtual uint32_t BeginEvent(const char* tag) = 0;

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -154,6 +154,7 @@ CC_WARNINGS := \
   -Wextra \
   -Wmissing-field-initializers \
   -Wstrict-aliasing \
+  -Wnon-virtual-dtor \
   -Wno-unused-parameter
 
 COMMON_FLAGS := \

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -154,7 +154,6 @@ CC_WARNINGS := \
   -Wextra \
   -Wmissing-field-initializers \
   -Wstrict-aliasing \
-  -Wnon-virtual-dtor \
   -Wno-unused-parameter
 
 COMMON_FLAGS := \
@@ -179,6 +178,7 @@ CXXFLAGS := \
   -fno-rtti \
   -fno-exceptions \
   -fno-threadsafe-statics \
+  -Wnon-virtual-dtor \
   $(COMMON_FLAGS)
 
 CCFLAGS := \


### PR DESCRIPTION
Without the current change, (and if we are building with `-Wnon-virtual-dtor`) we will get the following build error:

```
./tensorflow/lite/micro/micro_profiler_interface.h:24:7: error: 'class tflite::MicroProfilerInterface' has virtual functions and accessible non-virtual destructor [-Werror=non-virtual-dtor]
   24 | class MicroProfilerInterface {
      |       ^~~~~~~~~~~~~~~~~~~~~~
```

The `-Wnon-virtual-dtor` warning is applied to internal Google builds but not to the TFLM GitHub builds (prior to this PR) which is why the issue was not caught by the presubmit checks for #1376.

The current change updates the build flags for both bazel and make to add `-Wnon-virtual-dtor` and have the OSS and internal builds be more consistent.

Manually verified that with the new warning, we get the same error on Github as we do internally. And hence we have confidence that the fix here (which passes all the GitHub presubmits) will also pass the internal checks.

BUG=#1336
