### PR TITLE
Xtensa workflow changes to run the xtensa tests from '/opt' directory  instead of '/' directory.

### DIFF
--- a/.github/workflows/xtensa.yml
+++ b/.github/workflows/xtensa.yml
@@ -38,7 +38,9 @@ jobs:
       - run: |
           rm -rf .git
           echo ${{ secrets.TFLM_BOT_PACKAGE_READ_TOKEN }} | docker login ghcr.io -u tflm-bot --password-stdin
-          docker run --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa:0.1 /opt/tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_fusion_f1.sh
+          docker run --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa:0.1 \
+          /bin/bash -c \
+          "cd /opt && tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_fusion_f1.sh EXTERNAL tflite-micro/"
 
   hifi5_unit_tests:
     runs-on: ubuntu-latest
@@ -57,7 +59,9 @@ jobs:
       - run: |
           rm -rf .git
           echo ${{ secrets.TFLM_BOT_PACKAGE_READ_TOKEN }} | docker login ghcr.io -u tflm-bot --password-stdin
-          docker run --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa:0.1 /opt/tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi5.sh
+          docker run --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa:0.1 \
+          /bin/bash -c \
+          "cd /opt && tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi5.sh tflite-micro/"
 
   vision_p6_presubmit:
     runs-on: ubuntu-latest
@@ -75,7 +79,9 @@ jobs:
       - run: |
           rm -rf .git
           echo ${{ secrets.TFLM_BOT_PACKAGE_READ_TOKEN }} | docker login ghcr.io -u tflm-bot --password-stdin
-          docker run --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa:0.1 /opt/tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_vision_p6.sh
+          docker run --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa:0.1 \
+          /bin/bash -c \
+          "cd /opt && tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_vision_p6.sh RUN_NO_TESTS tflite-micro/"
 
   vision_p6_unit_tests:
     runs-on: ubuntu-latest
@@ -92,7 +98,9 @@ jobs:
       - run: |
           rm -rf .git
           echo ${{ secrets.TFLM_BOT_PACKAGE_READ_TOKEN }} | docker login ghcr.io -u tflm-bot --password-stdin
-          docker run --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa:0.1 /opt/tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_vision_p6.sh RUN_TESTS
+          docker run --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa:0.1 \
+          /bin/bash -c
+          "cd /opt && tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_vision_p6.sh RUN_TESTS tflite-micro/"
 
   hifi_3z_unit_tests:
     runs-on: ubuntu-latest
@@ -109,5 +117,7 @@ jobs:
       - run: |
           rm -rf .git
           echo ${{ secrets.TFLM_BOT_PACKAGE_READ_TOKEN }} | docker login ghcr.io -u tflm-bot --password-stdin
-          docker run --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa:0.1 /opt/tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi3z.sh
+          docker run --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa:0.1 \
+          /bin/bash -c \
+          "cd /opt && tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi3z.sh EXTERNAL tflite-micro/"
 


### PR DESCRIPTION
At present, when we run the xtensa tests from the docker container, we run the test from root (/) directory. In the scripts, we then find out the current directory for the script and then jump to tflite-micro/ directory and run the rest of the commands from that directory( like we run a bunch of make commands from tflite-micro). 

This PR is aiming to simplify that process and make it more aligned with the google3 build system. In this modified xtensa.yml, we are jumping inside the /opt directory and running the test scripts. Now through the docker command, we can pass in additional parameters to the test scripts so that the script can use those parameters to run the make commands relative to the /opt directory.

A follow up PR will have all the xtensa test scripts to contain all the changes that are required to use these parameters. 

BUG=http://b/244204467