### PR TITLE
python: fix problems with extension module build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,6 +39,7 @@ http_archive(
   name = "pybind11_bazel",
   strip_prefix = "pybind11_bazel-72cbbf1fbc830e487e3012862b7b720001b70672",
   urls = ["https://github.com/pybind/pybind11_bazel/archive/72cbbf1fbc830e487e3012862b7b720001b70672.zip"],
+  sha256 = "fec6281e4109115c5157ca720b8fe20c8f655f773172290b03f57353c11869c2",
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,4 +49,4 @@ http_archive(
 )
 
 load("@pybind11_bazel//:python_configure.bzl", "python_configure")
-python_configure(name = "local_config_python")
+python_configure(name = "local_config_python", python_version = "3")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -45,8 +45,9 @@ http_archive(
 http_archive(
   name = "pybind11",
   build_file = "@pybind11_bazel//:pybind11.BUILD",
-  strip_prefix = "pybind11-master",
-  urls = ["https://github.com/pybind/pybind11/archive/refs/heads/master.tar.gz"],
+  strip_prefix = "pybind11-2.10.0",
+  urls = ["https://github.com/pybind/pybind11/archive/refs/tags/v2.10.0.tar.gz"],
+  sha256 = "eacf582fa8f696227988d08cfc46121770823839fe9e301a20fbce67e7cd70ec",
 )
 
 load("@pybind11_bazel//:python_configure.bzl", "python_configure")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,3 +50,11 @@ http_archive(
 
 load("@pybind11_bazel//:python_configure.bzl", "python_configure")
 python_configure(name = "local_config_python", python_version = "3")
+
+load("@tflm_pip_deps//:requirements.bzl", "requirement")
+load("@//tensorflow/lite/micro/python:py_cc_headers.bzl", "tflm_py_cc_headers")
+tflm_py_cc_headers(
+    name = "numpy_headers",
+    py_library = requirement("numpy"),
+    include_prefix = "numpy/core/include",
+)

--- a/ci/Dockerfile.micro
+++ b/ci/Dockerfile.micro
@@ -47,8 +47,6 @@ RUN pip install matplotlib
 RUN pip install six
 
 # The following is necessary to build the Python interpreter
-# `PYTHON_BIN_PATH` is used by the pybind_library() bazel rule
-RUN export PYTHON_BIN_PATH=$(which python)
 RUN apt install -y python-numpy
 
 # Install Renode test dependencies

--- a/ci/Dockerfile.micro
+++ b/ci/Dockerfile.micro
@@ -46,9 +46,6 @@ RUN pip install matplotlib
 
 RUN pip install six
 
-# The following is necessary to build the Python interpreter
-RUN apt install -y python-numpy
-
 # Install Renode test dependencies
 RUN pip install pyyaml requests psutil robotframework==4.0.1
 

--- a/tensorflow/lite/micro/python/interpreter/src/BUILD
+++ b/tensorflow/lite/micro/python/interpreter/src/BUILD
@@ -25,6 +25,7 @@ pybind_library(
     deps = [
         "//tensorflow/lite/micro:micro_framework",
         "//tensorflow/lite/micro:op_resolvers",
+        "@numpy_headers",
     ],
 )
 

--- a/tensorflow/lite/micro/python/py_cc_headers.bzl
+++ b/tensorflow/lite/micro/python/py_cc_headers.bzl
@@ -1,0 +1,109 @@
+"Repository rule for creating a repository with the C headers of a Python package."
+
+# This extends the standard @rules_python rules to expose the C headers
+# contained in some Python packages like NumPy. It extends @rules_python rather
+# than duplicating the download mechanism, and to ensure the versions of Python
+# packages used throughout the WWORKSPACE are consistent. Exposing the headers
+# could conceivably become a build-in feature of @rules_python at some point.
+
+def _find_headers(ctx, py_library, include_prefix):
+    # Find the path to the headers within the @rules_python repository for the Python
+    # package `py_library`.
+
+    # WARNING: To get a flesystem path via ctx.path(), its argument must be a
+    # label to a non-generated file. ctx.path() does not work on non-file
+    # A standard technique for finding the path to a repository (see,
+    # e.g., rules_go) is to use the repository's BUILD file; however, the exact
+    # name of the build file is an implementation detail of @rules.python.
+    build = py_library.relative(":BUILD.bazel")
+    path = ctx.path(build).dirname
+
+    # Append the include_prefix, if any. get_child() needs one component at a
+    # time.
+    if include_prefix:
+        for c in include_prefix.split("/"):
+            path = path.get_child(c)
+
+    return path
+
+def _tflm_py_cc_headers_impl(ctx):
+    # Create a repository with the directory tree:
+    #     repository/
+    #               |- _include --> @rules_python//package/[include_prefix]
+    #               \_ BUILD
+
+    # Symlink to the headers within the @rules_python repository
+    src = _find_headers(ctx, ctx.attr.py_library, ctx.attr.include_prefix)
+    destdir = "_include"
+    ctx.symlink(src, destdir)
+
+    # Write a BUILD file publishing a cc_library() target for the headers.
+    BUILD = """\
+cc_library(
+    name = "%s",
+    hdrs = glob(["%s/**/*.h"], allow_empty=False),
+    includes = ["%s"],
+    visibility = ["@//tensorflow/lite/micro:__subpackages__"],
+)
+""" % (ctx.attr.name, destdir, destdir)
+    ctx.file("BUILD", content = BUILD, executable = False)
+
+tflm_py_cc_headers = repository_rule(
+    implementation = _tflm_py_cc_headers_impl,
+    local = True,
+    attrs = {
+        "py_library": attr.label(mandatory = True),
+        "include_prefix": attr.string(mandatory = False),
+    },
+)
+"""Repository rule for creating an external repository `name` with the C
+headers from a Python package published as a `py_library` target by
+@rules_python. The top-level Bazel package in the repository provides a
+cc_library target named `name` (the default target of the package) for use
+as a dependency in targets building against the headers.
+
+Use the optional `include_prefix` to base headers at a subdirectory of the
+Python package rather than its root. E.g., numpy's headers are in
+`numpy/core/include/numpy/header.h` relative to the root of the numpy package.
+Use `include_prefix = "numpy/core/include"` to include headers as `#include
+<numpy/header.h>` instead of `#include <numpy/core/include/numpy/header.h>`
+
+For example, to use the headers from NumPy:
+
+1. Add Python dependencies (numpy is named in requirements.txt) to an external
+repository named `tflm_pip_deps` via @rules_python in the WORKSPACE:
+```
+    load("@rules_python//python:pip.bzl", "pip_install")
+    pip_install(
+       name = "tflm_pip_deps",
+       requirements = "//third_party:requirements.txt",
+    )
+```
+
+2. Use the repository rule `tflm_py_cc_headers` in the WORKSPACE to create an
+external repository with a target `@numpy_headers:numpy_headers`, passing the
+py_library target from @tflm_pip_deps obtained via requirement() and an
+`include_prefix` based on an examination of the package and the desired #include
+paths in our C code:
+```
+    load("@tflm_pip_deps//:requirements.bzl", "requirement")
+    load("@//tensorflow/lite/micro/python:py_cc_headers.bzl", "tflm_py_cc_headers")
+    tflm_py_cc_headers(
+        name = "numpy_headers",
+        py_library = requirement("numpy"),
+        include_prefix = "numpy/core/include",
+    )
+```
+
+3. Use the cc_library target `@numpy_headers:numpy_headers` in a BUILD file as
+a dependency to a rule that needs the headers, e.g., the cc_library()-based
+pybind_library(). Note the target can be spelled as the default target of the
+repository's top-level package:
+```
+    pybind_library(
+        name = "your_extension_lib",
+        srcs = [...],
+        deps = ["@numpy_headers", ...],
+    )
+```
+"""

--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -1,4 +1,5 @@
 tensorflow-cpu
+numpy
 mako
 pillow
 yapf


### PR DESCRIPTION
Fix problems with the Python extension module build:

- Explicitly build against downloaded NumPy headers instead of relying on the build OS implicitly via the compiler's built-in paths, fixing #1283.
- Use tagged, verified downloads of pybind11_bazel and pybind to silence noise in the bazel output and improve tamper resistance, reproducibility, and caching.

The underlying issue was that the extension module depends on header files from numpy but that dependency was not captured in the BUILD rules.

Upstream Tensorflow's solution is too complicated to import. They manage dependencies on Python runtimes and libraries via much more extensive system of [custom rules](https://github.com/tensorflow/tensorflow/tree/master/third_party/py), designed to meet their many additional requirements.

Background:
- [pybind/pybind11](https://github.com/pybind/pybind11) is a C++ library that helps in creating our extension's interface to CPython.
- [pybind/pybind11_bazel](https://github.com/pybind/pybind11_bazel) provides Bazel rules for building pybind-based extensions, but doesn't cover the unusual case of using C headers provided in another Python module (in our case, NumPy).
- Bazel's own [bazelbuild/rules_python](https://github.com/bazelbuild/rules_python) provides rules for fetching Python dependencies from PyPI for use when *running* Python code via Bazel, but doesn't directly help with the unusual case of *building* code using headers provided by Python packages from PyPI (again, in our case, NumPy).
- The standard way, in Bazel, to build against third-party code is to create an [external repository](https://bazel.build/docs/external) by writing and calling [repository rules](https://bazel.build/extending/repo).

This PR supplies the C headers from NumPy to the build of our extension by adding a repository (via the new repository rule `tflm_py_cc_headers`) that reuses the PyPI package downloaded by rules_python and wraps it in a `cc_library` target on which the build of the extension can depend.

BUG=fixes #1283 