### PR TITLE
fix all broken integration test in TFLM directory

### DIFF
--- a/tensorflow/lite/micro/integration_tests/seanet/add/integration_tests.cc
+++ b/tensorflow/lite/micro/integration_tests/seanet/add/integration_tests.cc
@@ -16,7 +16,7 @@ limitations under the License.
 #include <string.h>
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
+#include "tensorflow/lite/micro/all_ops_p.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/add/add0_golden_int16_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/add/add0_input0_int16_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/add/add0_input1_int16_test_data.h"
@@ -105,8 +105,9 @@ void RunModel(const uint8_t* model, const int16_t* input0,
               const uint32_t golden_size, const char* name) {
   InitializeTarget();
   MicroProfiler profiler;
+  AllOpsResolver op_resolver;
 
-  MicroInterpreter interpreter(GetModel(model), AllOpsResolver(), tensor_arena,
+  MicroInterpreter interpreter(GetModel(model), op_resolver, tensor_arena,
                                kTensorArenaSize, nullptr, &profiler);
   interpreter.AllocateTensors();
   TfLiteTensor* input0_tensor = interpreter.input(0);

--- a/tensorflow/lite/micro/integration_tests/seanet/add/integration_tests.cc
+++ b/tensorflow/lite/micro/integration_tests/seanet/add/integration_tests.cc
@@ -16,7 +16,7 @@ limitations under the License.
 #include <string.h>
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_p.h"
+#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/add/add0_golden_int16_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/add/add0_input0_int16_test_data.h"
 #include "tensorflow/lite/micro/integration_tests/seanet/add/add0_input1_int16_test_data.h"

--- a/tensorflow/lite/micro/integration_tests/seanet/leaky_relu/integration_tests.cc
+++ b/tensorflow/lite/micro/integration_tests/seanet/leaky_relu/integration_tests.cc
@@ -105,8 +105,9 @@ void RunModel(const uint8_t* model, const int16_t* input0,
               const uint32_t golden_size, const char* name) {
   InitializeTarget();
   MicroProfiler profiler;
+  AllOpsResolver resolver;
 
-  MicroInterpreter interpreter(GetModel(model), AllOpsResolver(), tensor_arena,
+  MicroInterpreter interpreter(GetModel(model), resolver, tensor_arena,
                                kTensorArenaSize, nullptr, &profiler);
   interpreter.AllocateTensors();
   TfLiteTensor* input0_tensor = interpreter.input(0);

--- a/tensorflow/lite/micro/integration_tests/seanet/strided_slice/integration_tests.cc
+++ b/tensorflow/lite/micro/integration_tests/seanet/strided_slice/integration_tests.cc
@@ -138,8 +138,9 @@ void RunModel(const uint8_t* model, const int16_t* input0,
               const uint32_t golden_size, const char* name) {
   InitializeTarget();
   MicroProfiler profiler;
+  AllOpsResolver op_resolver;
 
-  MicroInterpreter interpreter(GetModel(model), AllOpsResolver(), tensor_arena,
+  MicroInterpreter interpreter(GetModel(model), op_resolver, tensor_arena,
                                kTensorArenaSize, nullptr, &profiler);
   interpreter.AllocateTensors();
   TfLiteTensor* input0_tensor = interpreter.input(0);

--- a/tensorflow/lite/micro/integration_tests/seanet/sub/integration_tests.cc
+++ b/tensorflow/lite/micro/integration_tests/seanet/sub/integration_tests.cc
@@ -57,8 +57,9 @@ void RunModel(const uint8_t* model, const int16_t* input0,
               const uint32_t golden_size, const char* name) {
   InitializeTarget();
   MicroProfiler profiler;
+  AllOpsResolver op_resolver;
 
-  MicroInterpreter interpreter(GetModel(model), AllOpsResolver(), tensor_arena,
+  MicroInterpreter interpreter(GetModel(model), op_resolver, tensor_arena,
                                kTensorArenaSize, nullptr, &profiler);
   interpreter.AllocateTensors();
   TfLiteTensor* input0_tensor = interpreter.input(0);


### PR DESCRIPTION
see bug - https://b.corp.google.com/issues/245773171 for context, but essentially a few of the integration test need to be regenerated so that they match the mako template and run.  Since a simple system doesn't exist without remaking all the existing files in those directories I added the change that were needed manually and and not by running the micro/integration_tests/generate_per_layer_tests.py script. 

BUG= https://b.corp.google.com/issues/245773171 