### PR TITLE
Hexagon workflow changes to run the hexagon tests from '/opt' directory instead of '/' directory.

### DIFF
--- a/.github/workflows/hexagon.yml
+++ b/.github/workflows/hexagon.yml
@@ -38,6 +38,8 @@ jobs:
       - run: |
           rm -rf .git
           echo ${{ secrets.TFLM_BOT_PACKAGE_READ_TOKEN }} | docker login ghcr.io -u tflm-bot --password-stdin
-          docker run --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/hexagon:0.2 /opt/tflite-micro/tensorflow/lite/micro/tools/ci_build/test_hexagon.sh
+          docker run --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/hexagon:0.2 \
+          /bin/bash -c \
+          "cd /opt && tflite-micro/tensorflow/lite/micro/tools/ci_build/test_hexagon.sh tflite-micro/"
 
 


### PR DESCRIPTION
At present, when we run the hexagon tests from the docker container, we run the test from root (/) directory. In the scripts, we then find out the current directory for the script and then jump to tflite-micro/ directory and run the rest of the commands from that directory( like we run a bunch of make commands from tflite-micro).

This PR is aiming to simplify that process and make it more aligned with the google3 build system. In this modified hexagon.yml, we are jumping inside the /opt directory and running the test scripts. Now through the docker command, we can pass in additional parameters to the test scripts so that the script can use those parameters to run the make commands relative to the /opt directory.

A follow up PR will have the hexagon test scripts to contain all the changes that are required to use these parameters.

BUG=http://b/244204467