### PR TITLE
removing interpreter.ResetVariableTensor() 

### DIFF
--- a/tensorflow/lite/micro/micro_interpreter.cc
+++ b/tensorflow/lite/micro/micro_interpreter.cc
@@ -312,11 +312,6 @@ TfLiteStatus MicroInterpreter::Reset() {
   return graph_.ResetVariableTensors();
 }
 
-// TODO: remove this API completely in favor of MicroInterpreter::Reset
-TfLiteStatus MicroInterpreter::ResetVariableTensors() {
-  return graph_.ResetVariableTensors();
-}
-
 TfLiteStatus MicroInterpreter::SetMicroExternalContext(
     void* external_context_payload) {
   return micro_context_.set_external_context(external_context_payload);

--- a/tensorflow/lite/micro/micro_interpreter.cc
+++ b/tensorflow/lite/micro/micro_interpreter.cc
@@ -265,7 +265,7 @@ TfLiteStatus MicroInterpreter::AllocateTensors() {
     }
   }
 
-  TF_LITE_ENSURE_STATUS(ResetVariableTensors());
+  TF_LITE_ENSURE_STATUS(Reset());
 
   tensors_allocated_ = true;
   return kTfLiteOk;

--- a/tensorflow/lite/micro/micro_interpreter.h
+++ b/tensorflow/lite/micro/micro_interpreter.h
@@ -140,10 +140,6 @@ class MicroInterpreter {
   // created. i.e. after Init and Prepare is called for the very first time.
   TfLiteStatus Reset();
 
-  // TODO(b/244457206): remove this in favor of Reset()
-  // Reset all variable tensors to the default value.
-  TfLiteStatus ResetVariableTensors();
-
   TfLiteStatus initialization_status() const { return initialization_status_; }
 
   // Populates node and registration pointers representing the inference graph


### PR DESCRIPTION
removing interpreter.ResetVariableTensor() since interpreter.Reset() already encapsulates everything it does already

BUG=[https://b.corp.google.com/issues/244457206](b/244457206)