### PR TITLE
Clean up python support for resource variables

### DIFF
--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
@@ -221,8 +221,10 @@ InterpreterWrapper::InterpreterWrapper(
 
   const Model* model = GetModel(buf);
   model_ = model_data;
-  allocator_ = MicroAllocator::Create(new uint8_t[arena_size], arena_size);
-  resource_variables_ = nullptr;
+  memory_arena_ = std::unique_ptr<uint8_t[]>(new uint8_t[arena_size]);
+  MicroAllocator* allocator_ =
+      MicroAllocator::Create(memory_arena_.get(), arena_size);
+  MicroResourceVariables* resource_variables_ = nullptr;
   if (num_resource_variables > 0)
     resource_variables_ =
         MicroResourceVariables::Create(allocator_, num_resource_variables);

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
@@ -38,8 +38,7 @@ class InterpreterWrapper {
 
  private:
   const PyObject* model_;
-  tflite::MicroAllocator* allocator_;
-  tflite::MicroResourceVariables* resource_variables_;
+  std::unique_ptr<uint8_t[]> memory_arena_;
   tflite::AllOpsResolver all_ops_resolver_;
   tflite::MicroInterpreter* interpreter_;
 };


### PR DESCRIPTION
* Correctly use unique pointer for the arena so it can be automatically deleted when correct time.
* Make allocator and MicroResourceVariables non members as they are not needed to be accessed after being passed to interpreter.

BUG= [251832638](https://b.corp.google.com/issues/251832638)