### PR TITLE
adding doc string and testing new ci setup part 1

### DIFF
--- a/.github/workflows/run_ci.yml
+++ b/.github/workflows/run_ci.yml
@@ -1,7 +1,6 @@
 name: Run-CI
 
-# This is the entry point for ci.yml for scheduled and workflow_dispactch events. For normal
-# testing automation the entry point is tests_entry.yml
+# This is the entry point for ci.yml for scheduled and workflow_dispatch events.
 
 on:
   schedule:

--- a/.github/workflows/run_ci.yml
+++ b/.github/workflows/run_ci.yml
@@ -1,5 +1,8 @@
 name: Run-CI
 
+# This is the entry point for ci.yml for scheduled and workflow_dispactch events. For normal
+# testing automation the entry point is tests_entry.yml
+
 on:
   schedule:
     # 10am UTC is 3am or 4am PT depending on daylight savings.


### PR DESCRIPTION
Trivial documentation string add to test functionality of new ci dispatch system discussed in the bug below.

BUG=https://issuetracker.google.com/issues/246664234