### PR TITLE
trigger-sha fixed to use correct variable call

### DIFF
--- a/.github/workflows/run_ci.yml
+++ b/.github/workflows/run_ci.yml
@@ -17,4 +17,4 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'schedule' && github.repository == 'tensorflow/tflite-micro')
     with:
-      trigger-sha: $GITHUB_SHA
+      trigger-sha: ${{ github.sha }}

--- a/.github/workflows/run_hexagon.yml
+++ b/.github/workflows/run_hexagon.yml
@@ -17,6 +17,6 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'schedule' && github.repository == 'tensorflow/tflite-micro')
     with:
-      trigger-sha: $GITHUB_SHA
+      trigger-sha: ${{ github.sha }}
     secrets:
       tflm-bot-token: ${{ secrets.TFLM_BOT_PACKAGE_READ_TOKEN }}

--- a/.github/workflows/run_xtensa.yml
+++ b/.github/workflows/run_xtensa.yml
@@ -17,7 +17,7 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' 
     with:
-      trigger-sha: $GITHUB_SHA
+      trigger-sha: ${{ github.sha }}
       is-dispatched: 'TRUE'
     secrets:
       tflm-bot-token: ${{ secrets.TFLM_BOT_PACKAGE_READ_TOKEN }}
@@ -27,7 +27,7 @@ jobs:
     if: |
       (github.event_name == 'schedule' && github.repository == 'tensorflow/tflite-micro')
     with:
-      trigger-sha: $GITHUB_SHA
+      trigger-sha: ${{ github.sha }}
       is-scheduled: 'TRUE'
     secrets:
       tflm-bot-token: ${{ secrets.TFLM_BOT_PACKAGE_READ_TOKEN }}


### PR DESCRIPTION
The env variable being used to populate `trigger-sha` in the Run-<x> jobs isn't available until the steps portion of a job. Changed the variable from `$GITHUB_SHA` to `${{ github.sha }}`. This was fixed once in my testing of  #1481 and somehow during the development process apparently managed to revert it before submitting that PR, doh.

BUG=https://issuetracker.google.com/issues/255704634