### PR TITLE
Manual sync from tflite

### DIFF
--- a/tensorflow/lite/c/common.cc
+++ b/tensorflow/lite/c/common.cc
@@ -222,6 +222,9 @@ void TfLiteTensorResizeMaybeCopy(size_t num_bytes, TfLiteTensor* tensor,
     return;
   }
   // TODO(b/145340303): Tensor data should be aligned.
+#ifdef TFLITE_KERNEL_USE_XNNPACK
+  num_bytes += 16;  // XNNPACK_EXTRA_BYTES = 16
+#endif
   if (!tensor->data.data) {
     tensor->data.data = (char*)malloc(num_bytes);
 #ifdef TF_LITE_TENSORFLOW_PROFILER
@@ -243,6 +246,9 @@ void TfLiteTensorResizeMaybeCopy(size_t num_bytes, TfLiteTensor* tensor,
     tflite::OnTfLiteTensorAlloc(tensor, num_bytes);
 #endif
   }
+#ifdef TFLITE_KERNEL_USE_XNNPACK
+  num_bytes -= 16;  // XNNPACK_EXTRA_BYTES = 16
+#endif
   tensor->bytes = num_bytes;
 }
 

--- a/tensorflow/lite/c/common.h
+++ b/tensorflow/lite/c/common.h
@@ -675,6 +675,22 @@ typedef struct TfLiteDelegateParams {
   TfLiteIntArray* output_tensors;
 } TfLiteDelegateParams;
 
+// WARNING: This is an experimental interface that is subject to change.
+//
+// Currently, TfLiteOpaqueDelegateParams has to be allocated in a way that it's
+// trivially destructable. It will be stored as `builtin_data` field in
+// `TfLiteNode` of the delegate node.
+//
+// See also the `CreateOpaqueDelegateParams` function in `subgraph.cc`
+// details.
+typedef struct TfLiteOpaqueDelegateParams {
+  struct TfLiteOpaqueDelegateStruct* delegate;
+  void* delegate_data;
+  TfLiteIntArray* nodes_to_replace;
+  TfLiteIntArray* input_tensors;
+  TfLiteIntArray* output_tensors;
+} TfLiteOpaqueDelegateParams;
+
 typedef struct TfLiteContext {
   // Number of tensors in the context.
   size_t tensors_size;

--- a/tensorflow/lite/kernels/internal/common.h
+++ b/tensorflow/lite/kernels/internal/common.h
@@ -22,6 +22,7 @@ limitations under the License.
 #endif
 #endif
 
+#include <cmath>
 #include <functional>
 
 #include "fixedpoint/fixedpoint.h"
@@ -376,55 +377,80 @@ inline Integer FloorLog2(Integer n) {
   }
 }
 
-// The size of the LUT depends on the type of input. For int8 inputs a simple
-// 256 entries LUT is used. For int16 inputs the high 9 bits are used for
-// indexing and the 7 remaining bits are used for interpolation. We thus use a
-// 513-entries LUT for int16 cases, 512 for the 9-bit indexing and 1 extra entry
-// to interpolate the last value.
-template <typename LutInT>
-constexpr int lut_size() {
-  static_assert(std::is_same<LutInT, int8_t>::value ||
-                    std::is_same<LutInT, int16_t>::value,
-                "Only LUTs with int8 or int16 inputs are supported.");
-  return std::is_same<LutInT, int8_t>::value ? 256 : 513;
+// The size of the LUT depends on the type of input. For uint8 and int8 inputs
+// we use a 256 entries LUT to map all the values in the (u)int8 range. For
+// int16 inputs the high 9 bits are used for indexing and the 7 remaining bits
+// are used for interpolation. We thus use a 513-entries LUT for int16 cases,
+// 512 for the 9-bit indexing and 1 extra entry to interpolate the last value.
+template <typename T>
+constexpr int LUTSize() {
+  static_assert(std::is_same<T, uint8_t>::value ||
+                    std::is_same<T, int8_t>::value ||
+                    std::is_same<T, int16_t>::value,
+                "Only LUTs with uint8, int8 or int16 inputs are supported.");
+  if (std::is_same<T, uint8_t>::value || std::is_same<T, int8_t>::value) {
+    return 256;
+  } else {
+    return 513;
+  }
 }
 
-// Generate a LUT for 'func' which can be used to approximate functions like
-// exp, log, ...
-//
-// - func: the function to build the LUT for (e.g exp(x))
-// - input_min, input_max: range of the func inputs
-// - output_min, output_max: range of the func outputs
-// - lut: pointer to the LUT table to fill, the table must be of size
-// lut_size<LutInT>()
-template <typename FloatT, typename LutInT, typename LutOutT>
-inline void gen_lut(FloatT (*func)(FloatT), FloatT input_min, FloatT input_max,
-                    FloatT output_min, FloatT output_max, LutOutT* lut) {
-  static_assert(std::is_same<LutInT, int8_t>::value ||
-                    std::is_same<LutInT, int16_t>::value,
-                "Only LUTs with int8 or int16 inputs are supported.");
-  static_assert(std::is_same<LutOutT, int8_t>::value ||
-                    std::is_same<LutOutT, int16_t>::value,
-                "Only LUTs with int8 or int16 outputs are supported.");
+// Use the same LUT generation code for both uint8_t and int8_t. Int8_t indexes
+// will be directly casted to uint8_t, the int8 LUT will thus be ordered as [0,
+// 1, ..., 127, -128, ..., -2, -1] instead of [-128, -127, ..., -1, 0, 1, ...,
+// 126, 127].
+template <typename T>
+inline typename std::enable_if<std::is_same<T, uint8_t>::value ||
+                                   std::is_same<T, int8_t>::value,
+                               void>::type
+LUTPopulate(float input_scale, int32_t input_zero_point, float output_scale,
+            int32_t output_zero_point, float (*transform)(float), T* lut) {
+  uint8_t* lut_uint8 = reinterpret_cast<uint8_t*>(lut);
+  const float inverse_scale = 1 / output_scale;
+  int32_t maxval = std::numeric_limits<T>::max();
+  int32_t minval = std::numeric_limits<T>::min();
+  for (int32_t val = minval; val <= maxval; ++val) {
+    const float dequantized = input_scale * (val - input_zero_point);
+    const float transformed = transform(dequantized);
+    const float rescaled = std::round(transformed * inverse_scale);
+    const int32_t quantized =
+        static_cast<int32_t>(rescaled + output_zero_point);
+    lut_uint8[static_cast<uint8_t>(static_cast<T>(val))] = static_cast<uint8_t>(
+        static_cast<T>(std::max(std::min(maxval, quantized), minval)));
+  }
+}
+
+// Keep floating-point type configurable for backward compatibility. float
+// should be used for FloatT by default.
+template <typename T, typename FloatT>
+inline typename std::enable_if<std::is_same<T, int16_t>::value, void>::type
+LUTPopulate(FloatT input_scale, int32_t input_zero_point, FloatT output_scale,
+            int32_t output_zero_point, FloatT (*transform)(FloatT), T* lut) {
   static_assert(std::is_floating_point<FloatT>::value,
                 "FloatT must be a floating-point type.");
+  const FloatT input_min =
+      input_scale * (std::numeric_limits<int16_t>::min() - input_zero_point);
+  const FloatT input_max =
+      input_scale * (std::numeric_limits<int16_t>::max() - input_zero_point);
+  const FloatT output_min =
+      output_scale * (std::numeric_limits<int16_t>::min() - output_zero_point);
+  const FloatT output_max =
+      output_scale * (std::numeric_limits<int16_t>::max() - output_zero_point);
 
-  const int nb_steps = std::is_same<LutInT, int8_t>::value ? 256 : 512;
+  const int nb_steps = 512;
   const FloatT step = (input_max - input_min) / nb_steps;
   const FloatT half_step = step / 2;
   const FloatT output_scaling_inv =
-      static_cast<FloatT>(std::numeric_limits<LutOutT>::max() -
-                          std::numeric_limits<LutOutT>::min() + 1) /
+      static_cast<FloatT>(std::numeric_limits<T>::max() -
+                          std::numeric_limits<T>::min() + 1) /
       (output_max - output_min);
-  const FloatT table_min =
-      static_cast<FloatT>(std::numeric_limits<LutOutT>::min());
-  const FloatT table_max =
-      static_cast<FloatT>(std::numeric_limits<LutOutT>::max());
+  const FloatT table_min = static_cast<FloatT>(std::numeric_limits<T>::min());
+  const FloatT table_max = static_cast<FloatT>(std::numeric_limits<T>::max());
 
   for (int i = 0; i < nb_steps; i++) {
-    const FloatT val = func(input_min + i * step);
-    const FloatT val_midpoint = func(input_min + i * step + half_step);
-    const FloatT val_next = func(input_min + (i + 1) * step);
+    const FloatT val = transform(input_min + i * step);
+    const FloatT val_midpoint = transform(input_min + i * step + half_step);
+    const FloatT val_next = transform(input_min + (i + 1) * step);
 
     const FloatT sample_val = TfLiteRound(val * output_scaling_inv);
     const FloatT midpoint_interp_val =
@@ -435,66 +461,88 @@ inline void gen_lut(FloatT (*func)(FloatT), FloatT input_min, FloatT input_max,
     const FloatT midpoint_err = midpoint_interp_val - midpoint_val;
     const FloatT bias = TfLiteRound(midpoint_err / 2);
 
-    lut[i] = static_cast<LutOutT>(std::min<FloatT>(
+    lut[i] = static_cast<T>(std::min<FloatT>(
         std::max<FloatT>(sample_val - bias, table_min), table_max));
   }
 
-  const bool with_extra_interpolation_value =
-      std::is_same<LutInT, int16_t>::value;
-  if (with_extra_interpolation_value) {
-    lut[nb_steps] = static_cast<LutOutT>(std::min<FloatT>(
-        std::max<FloatT>(TfLiteRound(func(input_max) * output_scaling_inv),
-                         table_min),
-        table_max));
-  }
+  lut[nb_steps] = static_cast<T>(std::min<FloatT>(
+      std::max<FloatT>(TfLiteRound(transform(input_max) * output_scaling_inv),
+                       table_min),
+      table_max));
 }
 
+template <typename T>
+inline typename std::enable_if<std::is_same<T, int16_t>::value, void>::type
+LUTPopulate(float input_scale, int32_t input_zero_point, float output_scale,
+            int32_t output_zero_point, float (*transform)(float), T* lut) {
+  LUTPopulate<T, float>(input_scale, input_zero_point, output_scale,
+                        output_zero_point, transform, lut);
+}
+
+// Deprecated and will be removed in future, please use LUTPopulate instead
+template <typename FloatT, typename LutInT, typename LutOutT>
+inline void gen_lut(FloatT (*func)(FloatT), FloatT input_min, FloatT input_max,
+                    FloatT output_min, FloatT output_max, LutOutT* lut) {
+  static_assert(std::is_same<LutInT, LutOutT>::value,
+                "Input and output type of the LUT must be the same.");
+  static_assert(std::is_same<LutInT, int16_t>::value,
+                "Only int16_t type LUT are supported.");
+  static_assert(std::is_same<FloatT, float>::value,
+                "Only float type is supported for FloatT.");
+  using T = LutInT;
+
+  const auto zero_point = [](float min, float max, float scale) {
+    // Symmetric int16 LUT, we know the zero-point will not overflow an int32_t
+    // and zero-point from min will be the same as from max.
+    return static_cast<int32_t>(
+        static_cast<float>(std::numeric_limits<T>::min()) - min / scale);
+  };
+
+  const float scale = static_cast<float>(std::numeric_limits<T>::max() -
+                                         std::numeric_limits<T>::min());
+  const float input_scale = (input_max - input_min) / scale;
+  const FloatT output_scale = (output_max - output_min) / scale;
+  const int32_t input_zero_point =
+      zero_point(input_min, input_max, input_scale);
+  const int32_t output_zero_point =
+      zero_point(output_min, output_max, output_scale);
+
+  return LUTPopulate<T, float>(input_scale, input_zero_point, output_scale,
+                               output_zero_point, func, lut);
+}
+
+// int16_t -> int16_t table lookup with interpolation
 // LUT must have 513 values
-template <typename LutOutT>
-inline LutOutT lut_lookup_with_interpolation(int16_t value,
-                                             const LutOutT* lut) {
-  static_assert(std::is_same<LutOutT, int8_t>::value ||
-                    std::is_same<LutOutT, int16_t>::value,
-                "Only LUTs with int8 or int16 outputs are supported.");
+inline int16_t LUTLookup(int16_t value, const int16_t* lut) {
   // 512 base values, lut[513] is only used to calculate the slope
   const uint16_t index = static_cast<uint16_t>(256 + (value >> 7));
   assert(index < 512 && "LUT index out of range.");
   const int16_t offset = value & 0x7f;
 
   // Base and slope are Q0.x
-  const LutOutT base = lut[index];
-  const LutOutT slope = lut[index + 1] - lut[index];
+  const int16_t base = lut[index];
+  const int16_t slope = lut[index + 1] - lut[index];
 
   // Q0.x * Q0.7 = Q0.(x + 7)
   // Round and convert from Q0.(x + 7) to Q0.x
   const int delta = (slope * offset + 64) >> 7;
 
   // Q0.15 + Q0.15
-  return static_cast<LutOutT>(base + delta);
-}
-
-// int16_t -> int16_t table lookup with interpolation
-// LUT must have 513 values
-inline int16_t lut_lookup(int16_t value, const int16_t* lut) {
-  return lut_lookup_with_interpolation(value, lut);
-}
-
-// int16_t -> int8_t table lookup with interpolation
-// LUT must have 513 values
-inline int8_t lut_lookup(int16_t value, const int8_t* lut) {
-  return lut_lookup_with_interpolation(value, lut);
+  return static_cast<int16_t>(base + delta);
 }
 
 // int8_t -> int8_t table lookup without interpolation
 // LUT must have 256 values
-inline int8_t lut_lookup(int8_t value, const int8_t* lut) {
-  return lut[128 + value];
+// LUTPopulate<int8_t> has ordered the LUT so that indexing it with an
+// int8_t is just done by casting it to an uint8_t.
+inline int8_t LUTLookup(int8_t value, const int8_t* lut) {
+  return lut[static_cast<uint8_t>(value)];
 }
 
-// int8_t -> int16_t table lookup without interpolation
+// uint8_t -> uint8_t table lookup without interpolation
 // LUT must have 256 values
-inline int16_t lut_lookup(int8_t value, const int16_t* lut) {
-  return lut[128 + value];
+inline uint8_t LUTLookup(uint8_t value, const uint8_t* lut) {
+  return lut[value];
 }
 
 // Table of sigmoid(i/24) at 0.16 format - 256 elements.

--- a/tensorflow/lite/kernels/internal/common.h
+++ b/tensorflow/lite/kernels/internal/common.h
@@ -388,11 +388,9 @@ constexpr int LUTSize() {
                     std::is_same<T, int8_t>::value ||
                     std::is_same<T, int16_t>::value,
                 "Only LUTs with uint8, int8 or int16 inputs are supported.");
-  if (std::is_same<T, uint8_t>::value || std::is_same<T, int8_t>::value) {
-    return 256;
-  } else {
-    return 513;
-  }
+  return (std::is_same<T, uint8_t>::value || std::is_same<T, int8_t>::value)
+             ? 256
+             : 513;
 }
 
 // Use the same LUT generation code for both uint8_t and int8_t. Int8_t indexes

--- a/tensorflow/lite/kernels/internal/reference/softmax.h
+++ b/tensorflow/lite/kernels/internal/reference/softmax.h
@@ -160,7 +160,7 @@ inline int16_t SoftMaxCalculateExp(const SoftmaxParams& params,
       std::min(std::max(sym_scaled_diff, static_cast<int32_t>(-32768)),
                static_cast<int32_t>(32767));
   // apply the exp() LUT activation function
-  return lut_lookup(sat_sym_scaled_diff, params.exp_lut);
+  return LUTLookup(sat_sym_scaled_diff, params.exp_lut);
 }
 // Quantized softmax with int16_t input and int16_t output.
 inline void SoftmaxInt16(const SoftmaxParams& params,
@@ -209,7 +209,7 @@ inline void SoftmaxInt16(const SoftmaxParams& params,
                  static_cast<int32_t>(32767)));
     // apply 1/(1 + x) LUT activation function
     int16_t reciprocal_scale_Q015 =
-        lut_lookup(sat_sym_shifted_sum, params.one_over_one_plus_x_lut);
+        LUTLookup(sat_sym_shifted_sum, params.one_over_one_plus_x_lut);
 
     // Rescale the exp_result with reciprocal
     // range of output is [0, 32767] correspond to [0.0, 1.0]

--- a/tensorflow/lite/kernels/internal/reference/strided_slice.h
+++ b/tensorflow/lite/kernels/internal/reference/strided_slice.h
@@ -75,8 +75,8 @@ inline void StridedSlice(const tflite::StridedSliceParams& op_params,
       return index < end;
     }
   };
-  const int* shape = static_cast<const int*>(input_shape.DimsData());
-  const int* stride = static_cast<const int*>(params_copy.strides);
+  const int* shape = reinterpret_cast<const int*>(input_shape.DimsData());
+  const int* stride = reinterpret_cast<const int*>(params_copy.strides);
   const bool inner_stride_is_1 = params_copy.strides[4] == 1;
 
   for (int offset_0 = start_0; lc(stop_0, stride[0], offset_0);

--- a/tensorflow/lite/kernels/internal/reference/strided_slice.h
+++ b/tensorflow/lite/kernels/internal/reference/strided_slice.h
@@ -31,10 +31,6 @@ inline void StridedSlice(const tflite::StridedSliceParams& op_params,
                          const RuntimeShape& unextended_input_shape,
                          const RuntimeShape& unextended_output_shape,
                          SequentialTensorWriter<T>* writer) {
-  using strided_slice::LoopCondition;
-  using strided_slice::StartForAxis;
-  using strided_slice::StopForAxis;
-
   ruy::profiler::ScopeLabel label("StridedSlice");
 
   // Note that the output_shape is not used herein.
@@ -51,41 +47,67 @@ inline void StridedSlice(const tflite::StridedSliceParams& op_params,
   // requires (ie. all shapes must be 5D and are given backwards).
   strided_slice::StridedSlicePadIndices(&params_copy, 5);
 
-  const int start_0 = StartForAxis(params_copy, input_shape, 0);
-  const int stop_0 = StopForAxis(params_copy, input_shape, 0, start_0);
-  const int start_1 = StartForAxis(params_copy, input_shape, 1);
-  const int stop_1 = StopForAxis(params_copy, input_shape, 1, start_1);
-  const int start_2 = StartForAxis(params_copy, input_shape, 2);
-  const int stop_2 = StopForAxis(params_copy, input_shape, 2, start_2);
-  const int start_3 = StartForAxis(params_copy, input_shape, 3);
-  const int stop_3 = StopForAxis(params_copy, input_shape, 3, start_3);
-  const int start_4 = StartForAxis(params_copy, input_shape, 4);
-  const int stop_4 = StopForAxis(params_copy, input_shape, 4, start_4);
+  const int start_0 =
+      strided_slice::StridedSliceStartForAxis(params_copy, input_shape, 0);
+  const int stop_0 = strided_slice::StridedSliceEndForAxis(
+      params_copy, input_shape, 0, start_0);
+  const int start_1 =
+      strided_slice::StridedSliceStartForAxis(params_copy, input_shape, 1);
+  const int stop_1 = strided_slice::StridedSliceEndForAxis(
+      params_copy, input_shape, 1, start_1);
+  const int start_2 =
+      strided_slice::StridedSliceStartForAxis(params_copy, input_shape, 2);
+  const int stop_2 = strided_slice::StridedSliceEndForAxis(
+      params_copy, input_shape, 2, start_2);
+  const int start_3 =
+      strided_slice::StridedSliceStartForAxis(params_copy, input_shape, 3);
+  const int stop_3 = strided_slice::StridedSliceEndForAxis(
+      params_copy, input_shape, 3, start_3);
+  const int start_4 =
+      strided_slice::StridedSliceStartForAxis(params_copy, input_shape, 4);
+  const int stop_4 = strided_slice::StridedSliceEndForAxis(
+      params_copy, input_shape, 4, start_4);
 
-  for (int offset_0 = start_0 * input_shape.Dims(1),
-           end_0 = stop_0 * input_shape.Dims(1),
-           step_0 = params_copy.strides[0] * input_shape.Dims(1);
-       !LoopCondition(offset_0, end_0, params_copy.strides[0]);
-       offset_0 += step_0) {
-    for (int offset_1 = (offset_0 + start_1) * input_shape.Dims(2),
-             end_1 = (offset_0 + stop_1) * input_shape.Dims(2),
-             step_1 = params_copy.strides[1] * input_shape.Dims(2);
-         !LoopCondition(offset_1, end_1, params_copy.strides[1]);
-         offset_1 += step_1) {
-      for (int offset_2 = (offset_1 + start_2) * input_shape.Dims(3),
-               end_2 = (offset_1 + stop_2) * input_shape.Dims(3),
-               step_2 = params_copy.strides[2] * input_shape.Dims(3);
-           !LoopCondition(offset_2, end_2, params_copy.strides[2]);
-           offset_2 += step_2) {
-        for (int offset_3 = (offset_2 + start_3) * input_shape.Dims(4),
-                 end_3 = (offset_2 + stop_3) * input_shape.Dims(4),
-                 step_3 = params_copy.strides[3] * input_shape.Dims(4);
-             !LoopCondition(offset_3, end_3, params_copy.strides[3]);
-             offset_3 += step_3) {
-          for (int offset_4 = offset_3 + start_4, end_4 = offset_3 + stop_4;
-               !LoopCondition(offset_4, end_4, params_copy.strides[4]);
-               offset_4 += params_copy.strides[4]) {
-            writer->Write(offset_4);
+  auto lc = [&](int end, int stride, int index) {
+    if (stride < 0) {
+      return index > end;
+    } else {
+      return index < end;
+    }
+  };
+  const int* shape = static_cast<const int*>(input_shape.DimsData());
+  const int* stride = static_cast<const int*>(params_copy.strides);
+  const bool inner_stride_is_1 = params_copy.strides[4] == 1;
+
+  for (int offset_0 = start_0; lc(stop_0, stride[0], offset_0);
+       offset_0 += stride[0]) {
+    for (int offset_1 = start_1; lc(stop_1, stride[1], offset_1);
+         offset_1 += stride[1]) {
+      for (int offset_2 = start_2; lc(stop_2, stride[2], offset_2);
+           offset_2 += stride[2]) {
+        for (int offset_3 = start_3; lc(stop_3, stride[3], offset_3);
+             offset_3 += stride[3]) {
+          // When the stride is 1, the inner loop is equivalent to the
+          // optimized slice inner loop. Otherwise, it is identical to the
+          // strided_slice reference implementation inner loop.
+          if (inner_stride_is_1) {
+            const int len = stop_4 - start_4;
+            int index = start_4 + offset_3 * shape[4] +
+                        offset_2 * shape[3] * shape[4] +
+                        offset_1 * shape[2] * shape[3] * shape[4] +
+                        offset_0 * shape[1] * shape[2] * shape[3] * shape[4];
+            if (len > 0) {
+              writer->WriteN(index, len);
+            }
+          } else {
+            for (int offset_4 = start_4; lc(stop_4, stride[4], offset_4);
+                 offset_4 += stride[4]) {
+              int index = offset_4 + offset_3 * shape[4] +
+                          offset_2 * shape[3] * shape[4] +
+                          offset_1 * shape[2] * shape[3] * shape[4] +
+                          offset_0 * shape[1] * shape[2] * shape[3] * shape[4];
+              writer->Write(index);
+            }
           }
         }
       }

--- a/tensorflow/lite/kernels/internal/types.h
+++ b/tensorflow/lite/kernels/internal/types.h
@@ -988,9 +988,11 @@ struct TanhParams {
   int input_left_shift;
 };
 
+constexpr int kTransposeMaxDimensions = 6;
+
 struct TransposeParams {
   int8_t perm_count;
-  int32_t perm[5];
+  int32_t perm[kTransposeMaxDimensions];
 };
 
 struct UnpackParams {


### PR DESCRIPTION
The automatic sync job from tflite to tflm is failing due to some incompatibility in cpp version. TFLM uses c++11. The three commits can be described as 
1. The output of the sync_from_upstream_tf.sh. This script pull in the differences from the tflite repo to tflm repo.
2. http://b/255803710: In cpp11 constexpr methods should have one return statement.
3. http://b/254707165: Need reinterpret_cast to be able to compile with cpp11.

BUG=http://b/254707165 / http://b/255803710
NO_CHECK_TFLITE_FILES=automated sync file changes with some bug fixes