### PR TITLE
move no-files check to step level from test_entry job level

### DIFF
--- a/.github/workflows/check_tflite_files.yml
+++ b/.github/workflows/check_tflite_files.yml
@@ -9,6 +9,9 @@ on:
       pr-number:
         required: true
         type: string
+      pr-body:
+        required: true
+        type: string
     secrets:
       tflm-bot-token:
         required: true
@@ -23,6 +26,7 @@ jobs:
           ref: ${{ inputs.trigger-sha }}
 
       - name: Check Files
+        if: ${{ !contains(inputs.pr-body, 'NO_CHECK_TFLITE_FILES=') }}
         run: |
           URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ inputs.pr-number }}/files"
           PR_FILES=$(curl -s -X GET -H "Authorization: Bearer ${{ secrets.tflm-bot-token }}" $URL | jq -r '.[] | .filename')

--- a/.github/workflows/tests_entry.yml
+++ b/.github/workflows/tests_entry.yml
@@ -108,9 +108,9 @@ jobs:
   call-check-tflite-files:
     needs: ci-run
     uses: ./.github/workflows/check_tflite_files.yml
-    if: ${{ !contains(github.event.pull_request.body, 'NO_CHECK_TFLITE_FILES=') }}
     with: 
       trigger-sha: ${{ github.event.pull_request.head.sha }}
       pr-number: ${{ github.event.pull_request.number }}
+      pr-body: ${{ github.event.pull_request.body }}
     secrets:
       tflm-bot-token: ${{ secrets.TFLM_BOT_PACKAGE_READ_TOKEN }}


### PR DESCRIPTION
The logic for the NO_CHECK_TFLITE_FILES check was in the wrong place, resulting in incorrectly failing tests if that flag was present. This PR moves the check to the relevant step in `check_tflite_files.yml` which will prevent job failure when the flag is present.

BUG=https://issuetracker.google.com/issues/256923954