### PR TITLE
Remove unused build target static_alloc

### DIFF
--- a/tensorflow/lite/micro/examples/micro_speech/micro_features/BUILD
+++ b/tensorflow/lite/micro/examples/micro_speech/micro_features/BUILD
@@ -29,11 +29,6 @@ cc_library(
 )
 
 cc_library(
-    name = "static_alloc",
-    hdrs = ["static_alloc.h"],
-)
-
-cc_library(
     name = "micro_features_generator",
     srcs = [
         "micro_features_generator.cc",


### PR DESCRIPTION
`static_alloc.h` was removed in
https://github.com/tensorflow/tflite-micro/commit/b02d611cbd349b539225ed48d6d56e9f468b51e7 but its build target is still present. This causes google3 build to fail.

BUG=b/256673042