### PR TITLE
Pull in the latest version of pybind11_bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,9 +37,9 @@ workspace()
 
 http_archive(
   name = "pybind11_bazel",
-  strip_prefix = "pybind11_bazel-72cbbf1fbc830e487e3012862b7b720001b70672",
-  urls = ["https://github.com/pybind/pybind11_bazel/archive/72cbbf1fbc830e487e3012862b7b720001b70672.zip"],
-  sha256 = "fec6281e4109115c5157ca720b8fe20c8f655f773172290b03f57353c11869c2",
+  strip_prefix = "pybind11_bazel-faf56fb3df11287f26dbc66fdedf60a2fc2c6631",
+  urls = ["https://github.com/pybind/pybind11_bazel/archive/faf56fb3df11287f26dbc66fdedf60a2fc2c6631.zip"],
+  sha256 = "a185aa68c93b9f62c80fcb3aadc3c83c763854750dc3f38be1dadcb7be223837",
 )
 
 http_archive(

--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -3,3 +3,4 @@ numpy
 mako
 pillow
 yapf
+protobuf


### PR DESCRIPTION
Python3.10 incompatibility issue is resolved on the head of pybind11_bazel. This means that the workaround to use python3.9 venv is no longer necessary to build the Python interpreter.

BUG=http://b/243847898