### PR TITLE
Add missing dependencies for some Python targets

### DIFF
--- a/tensorflow/lite/micro/examples/mnist_lstm/BUILD
+++ b/tensorflow/lite/micro/examples/mnist_lstm/BUILD
@@ -16,6 +16,7 @@ py_binary(
     srcs_version = "PY3",
     deps = [
         "//tensorflow/lite/micro/python/interpreter/src:tflm_runtime",
+        "@absl_py//absl:app",
     ],
 )
 

--- a/tensorflow/lite/micro/python/interpreter/src/BUILD
+++ b/tensorflow/lite/micro/python/interpreter/src/BUILD
@@ -1,4 +1,5 @@
 load("@pybind11_bazel//:build_defs.bzl", "pybind_extension", "pybind_library")
+load("@tflm_pip_deps//:requirements.bzl", "requirement")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -49,4 +50,7 @@ py_library(
         ":interpreter_wrapper_pybind.so",
     ],
     srcs_version = "PY3",
+    deps = [
+        requirement("numpy"),
+    ],
 )


### PR DESCRIPTION
BUG=b/257314384

Tested with copybara changes in cl/485911587 and a forced copybara import. Passed all presubmits.