### PR TITLE
pinning python version 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
 
     name: Bazel (presubmit)
     steps:
+      - uses: actions/setup-python@v4
+        with: 
+          python-version: '3.10'
       - uses: actions/checkout@v2
         with:
           ref: ${{ inputs.trigger-sha }}
@@ -44,6 +47,9 @@ jobs:
 
     name: Cortex-M (presubmit)
     steps:
+      - uses: actions/setup-python@v4
+        with: 
+          python-version: '3.10'
       - uses: actions/checkout@v2
         with:
           ref: ${{ inputs.trigger-sha }}
@@ -62,6 +68,9 @@ jobs:
 
     name: Code Style (presubmit)
     steps:
+      - uses: actions/setup-python@v4
+        with: 
+          python-version: '3.10'
       - uses: actions/checkout@v2
         with:
           ref: ${{ inputs.trigger-sha }}
@@ -75,6 +84,9 @@ jobs:
 
     name: Project Generation (presubmit)
     steps:
+      - uses: actions/setup-python@v4
+        with: 
+          python-version: '3.10'
       - uses: actions/checkout@v2
         with:
           ref: ${{ inputs.trigger-sha }}
@@ -92,6 +104,9 @@ jobs:
 
     name: Makefile x86 (presubmit)
     steps:
+      - uses: actions/setup-python@v4
+        with: 
+          python-version: '3.10'
       - uses: actions/checkout@v2
         with:
           ref: ${{ inputs.trigger-sha }}

--- a/.github/workflows/cortex_m.yml
+++ b/.github/workflows/cortex_m.yml
@@ -24,6 +24,9 @@ jobs:
 
     name: Cortex-M Generic
     steps:
+      - uses: actions/setup-python@v4
+        with: 
+          python-version: '3.10'
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: |
@@ -42,6 +45,9 @@ jobs:
 
     name: Cortex-M Corstone 300 (FVP)
     steps:
+      - uses: actions/setup-python@v4
+        with: 
+          python-version: '3.10'
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: |

--- a/.github/workflows/generate_integration_tests.yml
+++ b/.github/workflows/generate_integration_tests.yml
@@ -23,6 +23,9 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'tensorflow/tflite-micro')
     name: Generate Integration Tests
     steps:
+      - uses: actions/setup-python@v4
+        with: 
+          python-version: '3.10'
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: |

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -20,6 +20,9 @@ jobs:
 
     name: RISC-V Continuous Builds
     steps:
+      - uses: actions/setup-python@v4
+        with: 
+          python-version: '3.10'
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: |

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -24,7 +24,9 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'tensorflow/tflite-micro')
 
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
+        with: 
+          python-version: '3.10'
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.TFLM_BOT_REPO_TOKEN }}


### PR DESCRIPTION
Nightly sync.yml was failing due to python being upgraded to 3.11 in the default linux runner environment. This PR pins all jobs that use python in the runner environment to python 3.10

BUG=https://issuetracker.google.com/issues/257470387