### PR TITLE
fixing integration_test generation for transpose_conv

### DIFF
--- a/tensorflow/lite/micro/tools/generate_cc_arrays.py
+++ b/tensorflow/lite/micro/tools/generate_cc_arrays.py
@@ -106,6 +106,8 @@ def get_array_name(input_fname):
     return [base_array_name + '_test_data', 'int16_t']
   elif input_fname.endswith('_int8.csv'):
     return [base_array_name + '_test_data', 'int8_t']
+  elif input_fname.endswith('_float.csv'):
+    return [base_array_name + '_test_data', 'float']
 
 
 def main():

--- a/tensorflow/lite/micro/tools/generate_test_for_model.py
+++ b/tensorflow/lite/micro/tools/generate_test_for_model.py
@@ -65,20 +65,27 @@ class TestDataGenerator:
     input_tensor0 = interpreter.tensor(0)
     filter_tensor = interpreter.tensor(1)
     input_tensor1 = interpreter.tensor(2)
-    output_shape = np.array([
-        1,
-        filter_tensor().shape[1] + input_tensor1().shape[1] - 1,
-        int(input_tensor1().shape[2] * 2 + filter_tensor().shape[2] / 2),
-        filter_tensor().shape[0]
-    ],
-                            dtype=np.int32)
-    return [
-        output_shape,
-        np.random.randint(low=np.iinfo(dtype).min,
-                          high=np.iinfo(dtype).max,
-                          dtype=dtype,
-                          size=input_tensor1().shape)
-    ]
+
+    output_shape = interpreter.get_output_details()[0]['shape_signature']
+    output_height = output_shape[1]
+    output_width = output_shape[2]
+
+    output_shape = np.array(
+        [1, output_height, output_width,
+         filter_tensor().shape[0]],
+        dtype=np.int32)
+    if dtype == np.float or dtype == np.float32 or dtype == np.float64:
+      random = np.random.uniform(low=1, high=100, size=input_tensor1().shape)
+      return [output_shape, random.astype(np.float32)]
+    else:
+      return [
+          output_shape,
+          np.random.randint(
+              low=np.iinfo(dtype).min,
+              high=np.iinfo(dtype).max,
+              dtype=dtype,
+              size=input_tensor1().shape)
+      ]
 
   def _GetTypeStringFromTensor(self, tensor):
     if tensor.dtype == np.int8:
@@ -87,7 +94,7 @@ class TestDataGenerator:
       return 'int16'
     if tensor.dtype == np.int32:
       return 'int32'
-    if tensor.dtype == np.float:
+    if tensor.dtype == np.float or tensor.dtype == np.float32:
       return 'float'
 
   def generate_golden_single_in_single_out(self):


### PR DESCRIPTION
Added floating point support for generate_per_layer test for transpose conv. Also fixed  transpose conv integration test generation issues. 

corresponding cl - [cl/485962623](https://critique.corp.google.com/cl/485962623)

BUG=[b/247163040](https://b.corp.google.com/issues/247163040)