### PR TITLE
Update Arm(R) Cortex(R)-M workflow to run per PR

### DIFF
--- a/.github/workflows/cortex_m.yml
+++ b/.github/workflows/cortex_m.yml
@@ -9,7 +9,10 @@ name: Cortex-M
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule
 on:
   schedule:
-  # - cron: '0 4 * * *'
+    # uncomment this to run daily
+    # - cron: '0 4 * * *'
+    # run on the 1st of every month
+    - cron: '0 4 1 * *'  
 
   # Allow manually triggering of the workflow.
   workflow_dispatch: {}

--- a/.github/workflows/cortex_m.yml
+++ b/.github/workflows/cortex_m.yml
@@ -9,7 +9,7 @@ name: Cortex-M
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule
 on:
   schedule:
-    - cron: '0 4 * * *'
+  # - cron: '0 4 * * *'
 
   # Allow manually triggering of the workflow.
   workflow_dispatch: {}
@@ -20,6 +20,7 @@ jobs:
 
     if: |
       github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:test')) ||
       (github.event_name == 'schedule' && github.repository == 'tensorflow/tflite-micro')
 
     name: Cortex-M Generic
@@ -38,6 +39,7 @@ jobs:
 
     if: |
       github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:test')) ||
       (github.event_name == 'schedule' && github.repository == 'tensorflow/tflite-micro')
 
     name: Cortex-M Corstone 300 (FVP)


### PR DESCRIPTION
BUG=#1529

I have updated the schedule to run the Cortex-M tests monthly as a baseline, and per PR whenever the "ci:run" label is added. Let us know what you think :) Thanks! 