### PR TITLE
Remove noasan, nomsan, noubsan tags for tflm_runtime

### DIFF
--- a/tensorflow/lite/micro/examples/mnist_lstm/BUILD
+++ b/tensorflow/lite/micro/examples/mnist_lstm/BUILD
@@ -34,11 +34,6 @@ py_test(
     ],
     main = "evaluate_test.py",
     python_version = "PY3",
-    tags = [
-        "noasan",
-        "nomsan",  # Python doesn't like these symbols from interpreter_wrapper_pybind.so
-        "noubsan",
-    ],
     deps = [
         ":evaluate",
         ":train",

--- a/tensorflow/lite/micro/python/interpreter/tests/BUILD
+++ b/tensorflow/lite/micro/python/interpreter/tests/BUILD
@@ -8,10 +8,7 @@ py_test(
     main = "interpreter_test.py",
     python_version = "PY3",
     tags = [
-        "noasan",
-        "nomsan",  # Python doesn't like these symbols from interpreter_wrapper_pybind.so
         "notap",  # TODO(b/247808903)
-        "noubsan",
     ],
     deps = [
         requirement("numpy"),


### PR DESCRIPTION
BUG=b/236154360

These tags are no longer required now that b/236154360 is fixed.