### PR TITLE
add error_reporter_macro.h to shared files list

### DIFF
--- a/ci/tflite_files.txt
+++ b/ci/tflite_files.txt
@@ -13,6 +13,7 @@ tensorflow/lite/c/builtin_op_data.h
 tensorflow/lite/c/c_api_types.h
 tensorflow/lite/c/common.h
 tensorflow/lite/core/api/error_reporter.h
+tensorflow/lite/core/api/error_reporter_macro.h
 tensorflow/lite/core/api/flatbuffer_conversions.h
 tensorflow/lite/core/api/op_resolver.h
 tensorflow/lite/core/api/tensor_utils.h

--- a/tensorflow/lite/core/api/BUILD
+++ b/tensorflow/lite/core/api/BUILD
@@ -59,7 +59,6 @@ cc_library(
 cc_library(
     name = "error_reporter_macro",
     hdrs = ["error_reporter_macro.h"],
-    compatible_with = get_compatible_with_portable(),
     copts = tflite_copts() + micro_copts(),
     visibility = [
         "//tensorflow/lite/core/api:__pkg__",

--- a/tensorflow/lite/core/api/BUILD
+++ b/tensorflow/lite/core/api/BUILD
@@ -60,9 +60,9 @@ cc_library(
     name = "error_reporter_macro",
     hdrs = ["error_reporter_macro.h"],
     compatible_with = get_compatible_with_portable(),
-    copts = tflite_copts(),
+    copts = tflite_copts() + micro_copts(),
     visibility = [
-        "//third_party/tensorflow/lite/core/api:__pkg__",
+        "//tensorflow/lite/core/api:__pkg__",
     ],
     deps = [
         ":error_reporter",

--- a/tensorflow/lite/core/api/BUILD
+++ b/tensorflow/lite/core/api/BUILD
@@ -22,6 +22,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":error_reporter",
+        ":error_reporter_macro",
         ":op_resolver",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/kernels/internal:compatibility",
@@ -47,10 +48,24 @@ cc_library(
     ],
     deps = [
         ":error_reporter",
+        ":error_reporter_macro",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/schema:schema_fbs",
         "//tensorflow/lite/schema:schema_utils",
         "@flatbuffers//:runtime_cc",
+    ],
+)
+
+cc_library(
+    name = "error_reporter_macro",
+    hdrs = ["error_reporter_macro.h"],
+    compatible_with = get_compatible_with_portable(),
+    copts = tflite_copts(),
+    visibility = [
+        "//third_party/tensorflow/lite/core/api:__pkg__",
+    ],
+    deps = [
+        ":error_reporter",
     ],
 )
 

--- a/tensorflow/lite/core/api/error_reporter.h
+++ b/tensorflow/lite/core/api/error_reporter.h
@@ -34,26 +34,25 @@ namespace tflite {
 /// that drives a GUI error log box.
 class ErrorReporter {
  public:
-  virtual ~ErrorReporter() {}
+  virtual ~ErrorReporter() = default;
+  /// Converts `args` to character equivalents according to `format` string,
+  /// constructs the error string and report it.
+  /// Returns number of characters written or zero on success, and negative
+  /// number on error.
   virtual int Report(const char* format, va_list args) = 0;
+
+  /// Converts arguments to character equivalents according to `format` string,
+  /// constructs the error string and report it.
+  /// Returns number of characters written or zero on success, and negative
+  /// number on error.
   int Report(const char* format, ...);
+
+  /// Equivalent to `Report` above. The additional `void*` parameter is unused.
+  /// This method is for compatibility with macros that takes `TfLiteContext`,
+  /// like TF_LITE_ENSURE and related macros.
   int ReportError(void*, const char* format, ...);
 };
 
 }  // namespace tflite
-
-// You should not make bare calls to the error reporter, instead use the
-// TF_LITE_REPORT_ERROR macro, since this allows message strings to be
-// stripped when the binary size has to be optimized. If you are looking to
-// reduce binary size, define TF_LITE_STRIP_ERROR_STRINGS when compiling and
-// every call will be stubbed out, taking no memory.
-#ifndef TF_LITE_STRIP_ERROR_STRINGS
-#define TF_LITE_REPORT_ERROR(reporter, ...)                             \
-  do {                                                                  \
-    static_cast<tflite::ErrorReporter*>(reporter)->Report(__VA_ARGS__); \
-  } while (false)
-#else  // TF_LITE_STRIP_ERROR_STRINGS
-#define TF_LITE_REPORT_ERROR(reporter, ...)
-#endif  // TF_LITE_STRIP_ERROR_STRINGS
 
 #endif  // TENSORFLOW_LITE_CORE_API_ERROR_REPORTER_H_

--- a/tensorflow/lite/core/api/error_reporter_macro.h
+++ b/tensorflow/lite/core/api/error_reporter_macro.h
@@ -1,0 +1,36 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_LITE_CORE_API_ERROR_REPORTER_MACRO_H_
+#define TENSORFLOW_LITE_CORE_API_ERROR_REPORTER_MACRO_H_
+
+#include "tensorflow/lite/core/api/error_reporter.h"
+
+// This Macro is intended to be used only by the code that TFLite Micro
+// shares with TFLite. In the code that is shared with TFLM you should
+// not make bare calls to the error reporter, instead use the
+// TF_LITE_REPORT_ERROR macro, since this allows message strings to be
+// stripped when the binary size has to be optimized. If you are looking to
+// reduce binary size, define TF_LITE_STRIP_ERROR_STRINGS when compiling and
+// every call will be stubbed out, taking no memory.
+#ifndef TF_LITE_STRIP_ERROR_STRINGS
+#define TF_LITE_REPORT_ERROR(reporter, ...)                             \
+  do {                                                                  \
+    static_cast<tflite::ErrorReporter*>(reporter)->Report(__VA_ARGS__); \
+  } while (false)
+#else  // TF_LITE_STRIP_ERROR_STRINGS
+#define TF_LITE_REPORT_ERROR(reporter, ...)
+#endif  // TF_LITE_STRIP_ERROR_STRINGS
+
+#endif  // TENSORFLOW_LITE_CORE_API_ERROR_REPORTER_MACRO_H_

--- a/tensorflow/lite/core/api/flatbuffer_conversions.cc
+++ b/tensorflow/lite/core/api/flatbuffer_conversions.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/core/api/error_reporter.h"
+#include "tensorflow/lite/core/api/error_reporter_macro.h"
 #include "tensorflow/lite/kernels/internal/compatibility.h"
 #include "tensorflow/lite/schema/schema_generated.h"
 

--- a/tensorflow/lite/core/api/op_resolver.cc
+++ b/tensorflow/lite/core/api/op_resolver.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "flatbuffers/flatbuffers.h"  // from @flatbuffers
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/core/api/error_reporter.h"
+#include "tensorflow/lite/core/api/error_reporter_macro.h"
 #include "tensorflow/lite/schema/schema_utils.h"
 
 namespace tflite {

--- a/tensorflow/lite/kernels/internal/common.h
+++ b/tensorflow/lite/kernels/internal/common.h
@@ -388,6 +388,7 @@ constexpr int LUTSize() {
                     std::is_same<T, int8_t>::value ||
                     std::is_same<T, int16_t>::value,
                 "Only LUTs with uint8, int8 or int16 inputs are supported.");
+  // As per c++11: constexpr methods cannot have more than one return statement.
   return (std::is_same<T, uint8_t>::value || std::is_same<T, int8_t>::value)
              ? 256
              : 513;

--- a/tensorflow/lite/kernels/internal/reference/strided_slice.h
+++ b/tensorflow/lite/kernels/internal/reference/strided_slice.h
@@ -75,6 +75,10 @@ inline void StridedSlice(const tflite::StridedSliceParams& op_params,
       return index < end;
     }
   };
+  // With a static_cast it is not possible to initialize
+  // a variable of type 'const int *'
+  // with an rvalue of type 'const int32_t *' (aka 'const long *').
+  // reinterpret_cast is required to handle this casting.
   const int* shape = reinterpret_cast<const int*>(input_shape.DimsData());
   const int* stride = reinterpret_cast<const int*>(params_copy.strides);
   const bool inner_stride_is_1 = params_copy.strides[4] == 1;


### PR DESCRIPTION
With https://github.com/tensorflow/tflite-micro/pull/1532, we have a new header file that is shared between TF Lite and TFLM. The current PR is updating the corresponding BUILD targets.

BUG=http://b/245802069
NO_CHECK_TFLITE_FILES=manually ran the sync script