### PR TITLE
trap error if ci:run label not present

### DIFF
--- a/.github/workflows/tests_entry.yml
+++ b/.github/workflows/tests_entry.yml
@@ -70,6 +70,7 @@ jobs:
               repo: context.repo.repo,
               name: 'ci:run'
             })
+        continue-on-error: true
 
   pr-has-bug:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Current workflows don't require ci:run to be present to start the ci test script sequence as ci:ready_to_merge can start those tests without ci:run being involved. The remove-cirun step in tests_entry.yml is causing a failure in those cases. 

This PR adds a continue-on-error trap to the removal step.

BUG=https://issuetracker.google.com/issues/258403976 