### PR TITLE
Revert error_reporter_macro.h

### DIFF
--- a/ci/tflite_files.txt
+++ b/ci/tflite_files.txt
@@ -13,7 +13,6 @@ tensorflow/lite/c/builtin_op_data.h
 tensorflow/lite/c/c_api_types.h
 tensorflow/lite/c/common.h
 tensorflow/lite/core/api/error_reporter.h
-tensorflow/lite/core/api/error_reporter_macro.h
 tensorflow/lite/core/api/flatbuffer_conversions.h
 tensorflow/lite/core/api/op_resolver.h
 tensorflow/lite/core/api/tensor_utils.h


### PR DESCRIPTION
This PR will revert the error_reporter_macro.h. TFLite decided to continue to use the TF_LITE_REPORT_ERROR macro, so hiding this macro is no longer needed.

BUG=b/256646805