### PR TITLE
Update deprecated keyword for cfg = "host"

### DIFF
--- a/ci/flatbuffers_for_tf_sync/build_defs.bzl
+++ b/ci/flatbuffers_for_tf_sync/build_defs.bzl
@@ -356,7 +356,7 @@ _gen_flatbuffer_srcs = rule(
         "_flatc": attr.label(
             default = Label("@flatbuffers//:flatc"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     output_to_genfiles = True,

--- a/third_party/flatbuffers/build_defs.bzl
+++ b/third_party/flatbuffers/build_defs.bzl
@@ -354,7 +354,7 @@ _gen_flatbuffer_srcs = rule(
         "_flatc": attr.label(
             default = Label("@flatbuffers//:flatc"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     output_to_genfiles = True,


### PR DESCRIPTION
Migrate from cfg = "host" to cfg = "exec", as "host" is being deprecated.

Internal change: http://cl/488632222

BUG=[258839383](https://b.corp.google.com/issues/258839383)