### PR TITLE
Set a default last_used value for micro_allocation_info

### DIFF
--- a/tensorflow/lite/micro/micro_allocation_info.cc
+++ b/tensorflow/lite/micro/micro_allocation_info.cc
@@ -39,6 +39,10 @@ void AllocationInfoBuilder::UpdateFirstCreated(AllocationInfo* current,
   TFLITE_DCHECK(current->first_created <= allocation_scope_count);
   if (current->first_created == kUninitializedLifetime) {
     current->first_created = allocation_scope_count;
+    // TODO(b/257084942): This will ensure that tensors that are outputs from an
+    // OP but not inputs to any other OP also have a reasonable lifetime.
+    // This bug will be used to add automated tests for this issue.
+    current->last_used = allocation_scope_count;
   }
 }
 


### PR DESCRIPTION
In the TFLM memory planning there is an implicit assumption currently that all tensors (other than the model inputs and outputs) must be both inputs and outputs of an OP.

In the case of the model from the bug, the else subgraph of the IF doesn't have any OPs which is breaking that assumption and hence the buffer for that tensor was not getting planned.

This fix will ensure that tensors that are outputs from an OP but not inputs to any other OP also have a reasonable lifetime.

BUG=b/257084942