### PR TITLE
remove unnecessary apt install of numpy that appear to be causing http://b/260016282

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     name: Bazel (presubmit)
     steps:
       - uses: actions/setup-python@v4
-        with: 
+        with:
           python-version: '3.10'
       - uses: actions/checkout@v2
         with:
@@ -36,8 +36,6 @@ jobs:
           sudo ci/install_bazel.sh
           pip3 install Pillow
           pip3 install Wave
-          export PYTHON_BIN_PATH=$(which python)
-          sudo apt install -y python-numpy
       - name: Test
         run: |
           tensorflow/lite/micro/tools/ci_build/test_bazel.sh
@@ -48,7 +46,7 @@ jobs:
     name: Cortex-M (presubmit)
     steps:
       - uses: actions/setup-python@v4
-        with: 
+        with:
           python-version: '3.10'
       - uses: actions/checkout@v2
         with:
@@ -69,7 +67,7 @@ jobs:
     name: Code Style (presubmit)
     steps:
       - uses: actions/setup-python@v4
-        with: 
+        with:
           python-version: '3.10'
       - uses: actions/checkout@v2
         with:
@@ -85,7 +83,7 @@ jobs:
     name: Project Generation (presubmit)
     steps:
       - uses: actions/setup-python@v4
-        with: 
+        with:
           python-version: '3.10'
       - uses: actions/checkout@v2
         with:
@@ -105,7 +103,7 @@ jobs:
     name: Makefile x86 (presubmit)
     steps:
       - uses: actions/setup-python@v4
-        with: 
+        with:
           python-version: '3.10'
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Manually tested by merging this change in my fork of tflite-micro and confirmed that the bazel job goes past the install stage with this change (and fails without it).

We will need to merge this change before it can have an effect on the tflite-micro repo and that will be done by ignoring the branch protection rules (administrator only).

Also, removed some extra trailing whitespaces.

BUG=http://b/260016282
