### PR TITLE
Update to Renode 1.13.2

### DIFF
--- a/tensorflow/lite/micro/docs/renode.md
+++ b/tensorflow/lite/micro/docs/renode.md
@@ -83,7 +83,7 @@ and issue following commands:
 # Create platform
 include @tensorflow/lite/micro/testing/bluepill_nontest.resc
 # Load ELF file
-sysbus LoadELF @gen/bluepill_cortex-m3_default/bin/keyword_benchmark
+sysbus LoadELF @gen/bluepill_x86_64_default/bin/kernel_add_test
 # Start simulation
 start
 
@@ -98,7 +98,7 @@ start
 To make repeat runs a bit easier, you can put all the commands into a
 single line (up arrow will show the last command in the Renode terminal):
 ```
-Clear; include @tensorflow/lite/micro/testing/bluepill_nontest.resc; sysbus LoadELF @gen/bluepill_cortex-m3_default/bin/keyword_benchmark; start
+Clear; include @tensorflow/lite/micro/testing/bluepill_nontest.resc; sysbus LoadELF @gen/bluepill_x86_64_default/bin/kernel_add_test; start
 ```
 
 You can also connect GDB to the simulation.

--- a/tensorflow/lite/micro/testing/robot.resource.txt
+++ b/tensorflow/lite/micro/testing/robot.resource.txt
@@ -9,7 +9,7 @@ Teardown With Custom Message
 Create Platform
     Execute Command           $logfile=@${UART_LOG}
     Execute Script            ${RESC}
-    Provides                  ready-platform
+    Provides                  ready-platform Reexecution
 
 Test Binary
     [Arguments]               ${BIN}

--- a/tensorflow/lite/micro/testing/robot.resource.txt
+++ b/tensorflow/lite/micro/testing/robot.resource.txt
@@ -9,7 +9,7 @@ Teardown With Custom Message
 Create Platform
     Execute Command           $logfile=@${UART_LOG}
     Execute Script            ${RESC}
-    Provides                  ready-platform Reexecution
+    Provides                  ready-platform    Reexecution
 
 Test Binary
     [Arguments]               ${BIN}

--- a/tensorflow/lite/micro/testing/test_with_renode.sh
+++ b/tensorflow/lite/micro/testing/test_with_renode.sh
@@ -39,7 +39,7 @@ ROBOT_RESOURCE=${TFLM_ROOT_DIR}/testing/robot.resource.txt
 TARGET_RESOURCE=${TFLM_ROOT_DIR}/testing/${TARGET}.resource.txt
 
 # Renode's entrypoint for using the Robot Framework.
-RENODE_TEST_SCRIPT=${TFLM_ROOT_DIR}/tools/make/downloads/renode/test.sh
+RENODE_TEST_SCRIPT=${TFLM_ROOT_DIR}/tools/make/downloads/renode/renode-test
 
 if [ ! -f "${RENODE_TEST_SCRIPT}" ]; then
   echo "The renode test script: ${RENODE_TEST_SCRIPT} does not exist. Please " \

--- a/tensorflow/lite/micro/tools/make/renode_download.sh
+++ b/tensorflow/lite/micro/tools/make/renode_download.sh
@@ -46,13 +46,13 @@ DOWNLOADED_RENODE_PATH=${DOWNLOADS_DIR}/renode
 if [ -d ${DOWNLOADED_RENODE_PATH} ]; then
   echo >&2 "${DOWNLOADED_RENODE_PATH} already exists, skipping the download."
 else
-  LINUX_PORTABLE_URL="https://dl.antmicro.com/projects/renode/builds/renode-1.12.0+20210816git8ea21ebd.linux-portable.tar.gz"
+  LINUX_PORTABLE_URL="https://github.com/renode/renode/releases/download/v1.13.2/renode-1.13.2.linux-portable.tar.gz"
   TEMP_ARCHIVE="/tmp/renode.tar.gz"
 
   echo >&2 "Downloading from url: ${LINUX_PORTABLE_URL}"
   wget ${LINUX_PORTABLE_URL} -O ${TEMP_ARCHIVE} >&2
 
-  EXPECTED_MD5="aff9e160f3c99edda33e15e9f87e4b1b"
+  EXPECTED_MD5="cf940256fd32597975f10f9146925d9b"
   check_md5 ${TEMP_ARCHIVE} ${EXPECTED_MD5}
 
   mkdir ${DOWNLOADED_RENODE_PATH}


### PR DESCRIPTION
With help from @PiotrZierhoffer, this PR updates TFLM to use the Renode release from Oct 3 (renode-1.13.2.linux-portable).

Manually confirmed that I can run the following command locally (http://b/257332395):
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=bluepill test -j8
```

BUG=http://b/260027053 and http://b/257332395