### PR TITLE
Run renode from within docker container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,15 +51,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ inputs.trigger-sha }}
-      - name: Install dependencies
-        run: |
-          pip3 install Pillow
-          pip3 install Wave
       - name: Test
         run: |
-          cd ../
-          tflite-micro/tensorflow/lite/micro/tools/ci_build/test_bluepill.sh tflite-micro/
-          tflite-micro/tensorflow/lite/micro/tools/ci_build/test_stm32f4.sh tflite-micro/
+          docker run --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/tflm-ci:latest \
+          /bin/sh -c \
+          "cd /opt && tflite-micro/tensorflow/lite/micro/tools/ci_build/test_bluepill.sh tflite-micro/ && tflite-micro/tensorflow/lite/micro/tools/ci_build/test_stm32f4.sh tflite-micro/"
 
   check_code_style:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Workaround to keep renode working as part of CI without needing to upgrade(which is the subject of #1584).

BUG=http://b/260027053