### PR TITLE
adding two hour timeout to merge queue

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,5 +1,6 @@
 queue_rules:
   - name: default
+    checks_timeout: 2 h
     conditions:
       - base=main
       - label=ci:ready_to_merge


### PR DESCRIPTION
Adding a two hour timeout to the merge queue to hopefully take care of a an intermittent race condition that makes Mergify kick PRs out of the queue before the branch protection tests have had a chance to run.

BUG=https://issuetracker.google.com/issues/260128211