### PR TITLE
LUT based tanh for cell state in LSTM - update

### DIFF
--- a/tensorflow/lite/micro/kernels/lstm_eval.cc
+++ b/tensorflow/lite/micro/kernels/lstm_eval.cc
@@ -363,17 +363,14 @@ void CalculateLstmOutputInteger8x8_16(
   {
     int32_t tanh_input_left_shift = (15 + cell_state_scale) - 3;
     int32_t dims_data = n_batch * n_cell;
+	int32_t input_multiplier = 0;
     if (tanh_input_left_shift < 0) /* handling negative shift value */
     {
-      int32_t i;
       tanh_input_left_shift = -tanh_input_left_shift;
-      for (i = 0; i < dims_data; i++) {
-        cell_state[i] = cell_state[i] >> tanh_input_left_shift;
-      }
-      tanh_input_left_shift = 0;
+	  input_multiplier = 3;
     }
     RuntimeShape tanh_inp_shape = RuntimeShape(1, &dims_data);
-    reference_integer_ops::Tanh(0, tanh_input_left_shift, tanh_inp_shape,
+    reference_integer_ops::Tanh(input_multiplier, tanh_input_left_shift, tanh_inp_shape,
                                 cell_state, tanh_inp_shape, scratch0);
   }
   tflite::tensor_utils::CwiseMul(output_gate, scratch0, hidden_scale_a,

--- a/tensorflow/lite/micro/kernels/unidirectional_sequence_lstm_test_config.cc
+++ b/tensorflow/lite/micro/kernels/unidirectional_sequence_lstm_test_config.cc
@@ -237,7 +237,7 @@ LstmIntegerTestConfig lstm_integer_no_peephole_config = {
                 kLstmSeqLengthIntegerNoPeephole *
                 kLstmNumOutputIntegerNoPeephole]){
             127, 127, -108, -67, 127, 127, -128, 127, 127, -128, 127, 127, 127,
-            127, 13, -128, 127, 127},
+            127, 127, -128, 127, 127},
 
     .asymmetric_quantize_inputs = false,
     .ranges = {{-1.0, 127.0 / 128},
@@ -484,8 +484,8 @@ LstmIntegerTestConfig lstm_integer_peephole_config = {
     .expected_output =
         (int8_t[kLstmNumBatchIntegerPeephole * kLstmSeqLengthIntegerPeephole *
                 kLstmNumOutputIntegerPeephole]){127, 127, -16, -21, 127, 127,
-                                                -128, 127, 127, -128, 127, 127,
-                                                127, 127, 105, -128, 127, 127},
+                                                23, 127, 127, -128, 127, 127,
+                                                127, 127, 127, -128, 127, 127},
 
     .asymmetric_quantize_inputs = false,
     .ranges = {{-1.0, 127.0 / 128},


### PR DESCRIPTION
No explicit down shift to Q12 for tanh of cell state. 
Input multiplier of  3 and appropriate shift value is passed to LUT tanh function.