### PR TITLE
Surfacing arena allocation through python interpreter.

### DIFF
--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
@@ -362,8 +362,8 @@ PyObject* InterpreterWrapper::GetOutputTensorDetails(size_t index) const {
   return GetTensorDetails(interpreter_->output(index));
 }
 
-PyObject* InterpreterWrapper::GetAllocations() {
-  AllocationData allocation_data = allocator_->GetAllocations();
+PyObject* InterpreterWrapper::GetMemoryStats() {
+  MemoryStats allocation_data = allocator_->GetMemoryStats();
   PyObject* result = PyDict_New();
 
   PyObject* value = PyLong_FromLong(allocation_data.used_bytes);
@@ -374,41 +374,6 @@ PyObject* InterpreterWrapper::GetAllocations() {
 
   value = PyLong_FromLong(allocation_data.persistent_used_bytes);
   PyDict_SetItemString(result, "persistent_used_bytes", value);
-
-  RecordedAllocationWithMetadata* allocation_with_metadata =
-      allocation_data.head.next_allocation_with_metadata;
-  PyObject* allocation_metadata = PyList_New(allocation_data.allocation_count);
-  int pos = 0;
-  while (allocation_with_metadata != nullptr) {
-    PyObject* allocation_entry = PyDict_New();
-    value = PyBytes_FromStringAndSize(
-        allocation_with_metadata->allocation_description,
-        strlen(allocation_with_metadata->allocation_description));
-    PyDict_SetItemString(allocation_entry, "allocation_description", value);
-
-    value = PyBytes_FromStringAndSize(
-        allocation_with_metadata->allocation_name,
-        strlen(allocation_with_metadata->allocation_name));
-    PyDict_SetItemString(allocation_entry, "allocation_name", value);
-
-    value = PyLong_FromLong(
-        allocation_with_metadata->recorded_allocation_.used_bytes);
-    PyDict_SetItemString(allocation_entry, "used_bytes", value);
-
-    value =
-        PyLong_FromLong(allocation_with_metadata->recorded_allocation_.count);
-    PyDict_SetItemString(allocation_entry, "count", value);
-
-    value = PyLong_FromLong(
-        allocation_with_metadata->recorded_allocation_.requested_bytes);
-    PyDict_SetItemString(allocation_entry, "requested_bytes", value);
-
-    PyList_SetItem(allocation_metadata, pos, allocation_entry);
-    allocation_with_metadata =
-        allocation_with_metadata->next_allocation_with_metadata;
-    pos++;
-  }
-  PyDict_SetItemString(result, "allocation_metadata", allocation_metadata);
   return result;
 }
 

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
@@ -367,13 +367,13 @@ PyObject* InterpreterWrapper::GetMemoryStats() {
   PyObject* result = PyDict_New();
 
   PyObject* value = PyLong_FromLong(allocation_data.used_bytes);
-  PyDict_SetItemString(result, "used_bytes", value);
+  PyDict_SetItemString(result, "total_bytes", value);
 
   value = PyLong_FromLong(allocation_data.non_persistent_used_bytes);
-  PyDict_SetItemString(result, "non_persistent_used_bytes", value);
+  PyDict_SetItemString(result, "non_persistent_bytes", value);
 
   value = PyLong_FromLong(allocation_data.persistent_used_bytes);
-  PyDict_SetItemString(result, "persistent_used_bytes", value);
+  PyDict_SetItemString(result, "persistent_bytes", value);
   return result;
 }
 

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
@@ -362,4 +362,54 @@ PyObject* InterpreterWrapper::GetOutputTensorDetails(size_t index) const {
   return GetTensorDetails(interpreter_->output(index));
 }
 
+PyObject* InterpreterWrapper::GetAllocations() {
+  AllocationData allocation_data = allocator_->GetAllocations();
+  PyObject* result = PyDict_New();
+
+  PyObject* value = PyLong_FromLong(allocation_data.used_bytes);
+  PyDict_SetItemString(result, "used_bytes", value);
+
+  value = PyLong_FromLong(allocation_data.non_persistent_used_bytes);
+  PyDict_SetItemString(result, "non_persistent_used_bytes", value);
+
+  value = PyLong_FromLong(allocation_data.persistent_used_bytes);
+  PyDict_SetItemString(result, "persistent_used_bytes", value);
+
+  RecordedAllocationWithMetadata* allocation_with_metadata =
+      allocation_data.head.next_allocation_with_metadata;
+  PyObject* allocation_metadata = PyList_New(allocation_data.allocation_count);
+  int pos = 0;
+  while (allocation_with_metadata != nullptr) {
+    PyObject* allocation_entry = PyDict_New();
+    value = PyBytes_FromStringAndSize(
+        allocation_with_metadata->allocation_description,
+        strlen(allocation_with_metadata->allocation_description));
+    PyDict_SetItemString(allocation_entry, "allocation_description", value);
+
+    value = PyBytes_FromStringAndSize(
+        allocation_with_metadata->allocation_name,
+        strlen(allocation_with_metadata->allocation_name));
+    PyDict_SetItemString(allocation_entry, "allocation_name", value);
+
+    value = PyLong_FromLong(
+        allocation_with_metadata->recorded_allocation_.used_bytes);
+    PyDict_SetItemString(allocation_entry, "used_bytes", value);
+
+    value =
+        PyLong_FromLong(allocation_with_metadata->recorded_allocation_.count);
+    PyDict_SetItemString(allocation_entry, "count", value);
+
+    value = PyLong_FromLong(
+        allocation_with_metadata->recorded_allocation_.requested_bytes);
+    PyDict_SetItemString(allocation_entry, "requested_bytes", value);
+
+    PyList_SetItem(allocation_metadata, pos, allocation_entry);
+    allocation_with_metadata =
+        allocation_with_metadata->next_allocation_with_metadata;
+    pos++;
+  }
+  PyDict_SetItemString(result, "allocation_metadata", allocation_metadata);
+  return result;
+}
+
 }  // namespace tflite

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
@@ -31,6 +31,7 @@ class InterpreterWrapper {
   ~InterpreterWrapper();
 
   void PrintAllocations();
+  PyObject* GetAllocations();
   int Invoke();
   int Reset();
   void SetInputTensor(PyObject* data, size_t index);

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
@@ -31,7 +31,7 @@ class InterpreterWrapper {
   ~InterpreterWrapper();
 
   void PrintAllocations();
-  PyObject* GetAllocations();
+  PyObject* GetMemoryStats();
   int Invoke();
   int Reset();
   void SetInputTensor(PyObject* data, size_t index);

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper_pybind.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper_pybind.cc
@@ -34,9 +34,9 @@ PYBIND11_MODULE(interpreter_wrapper_pybind, m) {
                                    num_resource_variables));
       }))
       .def("PrintAllocations", &InterpreterWrapper::PrintAllocations)
-      .def("GetAllocations",
+      .def("GetMemoryStats",
            [](InterpreterWrapper& self) {
-             return tflite::PyoOrThrow(self.GetAllocations());
+             return tflite::PyoOrThrow(self.GetMemoryStats());
            })
       .def("Invoke", &InterpreterWrapper::Invoke)
       .def("Reset", &InterpreterWrapper::Reset)

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper_pybind.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper_pybind.cc
@@ -34,11 +34,10 @@ PYBIND11_MODULE(interpreter_wrapper_pybind, m) {
                                    num_resource_variables));
       }))
       .def("PrintAllocations", &InterpreterWrapper::PrintAllocations)
-      .def(
-          "GetAllocations",
-          [](InterpreterWrapper& self) {
-            return tflite::PyoOrThrow(self.GetAllocations());
-          })
+      .def("GetAllocations",
+           [](InterpreterWrapper& self) {
+             return tflite::PyoOrThrow(self.GetAllocations());
+           })
       .def("Invoke", &InterpreterWrapper::Invoke)
       .def("Reset", &InterpreterWrapper::Reset)
       .def(

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper_pybind.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper_pybind.cc
@@ -34,6 +34,11 @@ PYBIND11_MODULE(interpreter_wrapper_pybind, m) {
                                    num_resource_variables));
       }))
       .def("PrintAllocations", &InterpreterWrapper::PrintAllocations)
+      .def(
+          "GetAllocations",
+          [](InterpreterWrapper& self) {
+            return tflite::PyoOrThrow(self.GetAllocations());
+          })
       .def("Invoke", &InterpreterWrapper::Invoke)
       .def("Reset", &InterpreterWrapper::Reset)
       .def(

--- a/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
+++ b/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
@@ -106,7 +106,7 @@ class Interpreter(object):
     """
     self._interpreter.PrintAllocations()
 
-  def get_allocations(self):
+  def memory_stats(self):
     """Invoke the RecordingMicroAllocator to get the arena usage.
 
     This should be called after `invoke()`.
@@ -114,7 +114,7 @@ class Interpreter(object):
     Returns:
       This method returns the arena usage as an PyObject.
     """
-    return self._interpreter.GetAllocations()
+    return self._interpreter.GetMemoryStats()
 
   def invoke(self):
     """Invoke the TFLM interpreter to run an inference.

--- a/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
+++ b/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
@@ -106,6 +106,16 @@ class Interpreter(object):
     """
     self._interpreter.PrintAllocations()
 
+  def get_allocations(self):
+    """Invoke the RecordingMicroAllocator to get the arena usage.
+
+    This should be called after `invoke()`.
+
+    Returns:
+      This method returns the arena usage as an PyObject.
+    """
+    return self._interpreter.GetAllocations()
+
   def invoke(self):
     """Invoke the TFLM interpreter to run an inference.
 

--- a/tensorflow/lite/micro/recording_micro_allocator.cc
+++ b/tensorflow/lite/micro/recording_micro_allocator.cc
@@ -114,6 +114,54 @@ void RecordingMicroAllocator::PrintAllocations() const {
                           "Operator runtime data", "OpData structs");
 }
 
+AllocationData RecordingMicroAllocator::GetAllocations() const {
+  AllocationData allocation_data = AllocationData();
+  allocation_data.used_bytes = recording_memory_allocator_->GetUsedBytes();
+  allocation_data.non_persistent_used_bytes =
+      recording_memory_allocator_->GetNonPersistentUsedBytes();
+  allocation_data.persistent_used_bytes =
+      recording_memory_allocator_->GetPersistentUsedBytes();
+  int allocation_count = 0;
+
+  allocation_data.head = RecordedAllocationWithMetadata();
+  RecordedAllocationWithMetadata* allocation_with_metadata =
+      GetRecordedAllocationWithMetadata(
+          RecordedAllocationType::kTfLiteEvalTensorData,
+          "TfLiteEvalTensor data", "allocations", &allocation_data.head,
+          &allocation_count);
+
+  allocation_with_metadata = GetRecordedAllocationWithMetadata(
+      RecordedAllocationType::kPersistentTfLiteTensorData,
+      "Persistent TfLiteTensor data", "tensors", allocation_with_metadata,
+      &allocation_count);
+
+  allocation_with_metadata = GetRecordedAllocationWithMetadata(
+      RecordedAllocationType::kPersistentTfLiteTensorQuantizationData,
+      "Persistent TfLiteTensor quantization data", "allocations",
+      allocation_with_metadata, &allocation_count);
+
+  allocation_with_metadata = GetRecordedAllocationWithMetadata(
+      RecordedAllocationType::kPersistentBufferData, "Persistent buffer data",
+      "allocations", allocation_with_metadata, &allocation_count);
+
+  allocation_with_metadata = GetRecordedAllocationWithMetadata(
+      RecordedAllocationType::kTfLiteTensorVariableBufferData,
+      "TfLiteTensor variable buffer data", "allocations",
+      allocation_with_metadata, &allocation_count);
+
+  allocation_with_metadata = GetRecordedAllocationWithMetadata(
+      RecordedAllocationType::kNodeAndRegistrationArray,
+      "NodeAndRegistration struct", "NodeAndRegistration structs",
+      allocation_with_metadata, &allocation_count);
+
+  GetRecordedAllocationWithMetadata(
+      RecordedAllocationType::kOpData, "Operator runtime data",
+      "OpData structs", allocation_with_metadata, &allocation_count);
+
+  allocation_data.allocation_count = allocation_count;
+  return allocation_data;
+}
+
 void* RecordingMicroAllocator::AllocatePersistentBuffer(size_t bytes) {
   RecordedAllocation allocations = SnapshotAllocationUsage();
   void* buffer = MicroAllocator::AllocatePersistentBuffer(bytes);
@@ -135,6 +183,30 @@ void RecordingMicroAllocator::PrintRecordedAllocation(
         allocation.count, allocation_description);
   }
 #endif
+}
+
+RecordedAllocationWithMetadata*
+RecordingMicroAllocator::GetRecordedAllocationWithMetadata(
+    RecordedAllocationType allocation_type, const char* allocation_name,
+    const char* allocation_description,
+    RecordedAllocationWithMetadata* last_allocation_with_metadata,
+    int* allocation_count) const {
+#ifndef TF_LITE_STRIP_ERROR_STRINGS
+  RecordedAllocation allocation = GetRecordedAllocation(allocation_type);
+  if (allocation.used_bytes > 0 || allocation.requested_bytes > 0) {
+    RecordedAllocationWithMetadata* allocation_with_metadata =
+        new RecordedAllocationWithMetadata();
+    allocation_with_metadata->allocation_name = allocation_name;
+    allocation_with_metadata->allocation_description = allocation_description;
+    allocation_with_metadata->recorded_allocation_ = allocation;
+    allocation_with_metadata->next_allocation_with_metadata = nullptr;
+    last_allocation_with_metadata->next_allocation_with_metadata =
+        allocation_with_metadata;
+    ++(*allocation_count);
+    return allocation_with_metadata;
+  }
+#endif
+  return last_allocation_with_metadata;
 }
 
 TfLiteStatus RecordingMicroAllocator::AllocateNodeAndRegistrations(

--- a/tensorflow/lite/micro/recording_micro_allocator.h
+++ b/tensorflow/lite/micro/recording_micro_allocator.h
@@ -45,28 +45,12 @@ struct RecordedAllocation {
   size_t count;
 };
 
-// Container for holding information about allocation recordings by a given
-// type with the metadata of the allocation like name, description along with a
-// pointer to the next allocation_with_metadata.
-struct RecordedAllocationWithMetadata {
-  const char* allocation_name;
-  const char* allocation_description;
-  RecordedAllocation recorded_allocation_;
-  RecordedAllocationWithMetadata* next_allocation_with_metadata = nullptr;
-};
-
-// Container for holding about allocation recording along with some data from
-// Recording memory allocator like used bytes etc. This is mainly used to
-// transport these numbers to python interpreter.
-struct AllocationData {
+// Container for holding about arena allocation. This is mainly used to
+// transport arena allocation numbers to python interpreter.
+struct MemoryStats {
   int used_bytes;
   int non_persistent_used_bytes;
   int persistent_used_bytes;
-  int allocation_count;
-  // The following data field named head does not contain any data but just the
-  // data for next_allocation_with_metadata. So whenever iterating, start from
-  // head.next_allocation_with_metadata to get the first valid data.
-  RecordedAllocationWithMetadata head;
 };
 
 // Utility subclass of MicroAllocator that records all allocations
@@ -94,9 +78,9 @@ class RecordingMicroAllocator : public MicroAllocator {
   // defined in RecordedAllocationType.
   void PrintAllocations() const;
 
-  // Gathers all allocation recordings by type defined in RecordedAllocationType
-  // And returns that consolidated informations as a struct.
-  AllocationData GetAllocations() const;
+  // Gathers all arena allocation returns that consolidated information as a
+  // struct.
+  MemoryStats GetMemoryStats() const;
 
   void* AllocatePersistentBuffer(size_t bytes) override;
 
@@ -127,12 +111,6 @@ class RecordingMicroAllocator : public MicroAllocator {
   void PrintRecordedAllocation(RecordedAllocationType allocation_type,
                                const char* allocation_name,
                                const char* allocation_description) const;
-
-  RecordedAllocationWithMetadata* GetRecordedAllocationWithMetadata(
-      RecordedAllocationType allocation_type, const char* allocation_name,
-      const char* allocation_description,
-      RecordedAllocationWithMetadata* last_allocation_with_metadata,
-      int* allocation_count) const;
 
   RecordedAllocation SnapshotAllocationUsage() const;
   void RecordAllocationUsage(const RecordedAllocation& snapshotted_allocation,

--- a/tensorflow/lite/micro/recording_micro_allocator.h
+++ b/tensorflow/lite/micro/recording_micro_allocator.h
@@ -45,6 +45,30 @@ struct RecordedAllocation {
   size_t count;
 };
 
+// Container for holding information about allocation recordings by a given
+// type with the metadata of the allocation like name, description along with a
+// pointer to the next allocation_with_metadata.
+struct RecordedAllocationWithMetadata {
+  const char* allocation_name;
+  const char* allocation_description;
+  RecordedAllocation recorded_allocation_;
+  RecordedAllocationWithMetadata* next_allocation_with_metadata = nullptr;
+};
+
+// Container for holding about allocation recording along with some data from
+// Recording memory allocator like used bytes etc. This is mainly used to
+// transport these numbers to python interpreter.
+struct AllocationData {
+  int used_bytes;
+  int non_persistent_used_bytes;
+  int persistent_used_bytes;
+  int allocation_count;
+  // The following data field named head does not contain any data but just the
+  // data for next_allocation_with_metadata. So whenever iterating, start from
+  // head.next_allocation_with_metadata to get the first valid data.
+  RecordedAllocationWithMetadata head;
+};
+
 // Utility subclass of MicroAllocator that records all allocations
 // inside the arena. A summary of allocations can be logged through the
 // ErrorReporter by invoking LogAllocations(). This special allocator requires
@@ -69,6 +93,10 @@ class RecordingMicroAllocator : public MicroAllocator {
   // Logs out through the ErrorReporter all allocation recordings by type
   // defined in RecordedAllocationType.
   void PrintAllocations() const;
+
+  // Gathers all allocation recordings by type defined in RecordedAllocationType
+  // And returns that consolidated informations as a struct.
+  AllocationData GetAllocations() const;
 
   void* AllocatePersistentBuffer(size_t bytes) override;
 
@@ -99,6 +127,12 @@ class RecordingMicroAllocator : public MicroAllocator {
   void PrintRecordedAllocation(RecordedAllocationType allocation_type,
                                const char* allocation_name,
                                const char* allocation_description) const;
+
+  RecordedAllocationWithMetadata* GetRecordedAllocationWithMetadata(
+      RecordedAllocationType allocation_type, const char* allocation_name,
+      const char* allocation_description,
+      RecordedAllocationWithMetadata* last_allocation_with_metadata,
+      int* allocation_count) const;
 
   RecordedAllocation SnapshotAllocationUsage() const;
   void RecordAllocationUsage(const RecordedAllocation& snapshotted_allocation,


### PR DESCRIPTION
This is a new API that enables the TFLM python interpreter users to get hold of the arena usage for a particular model. 

In the following way, we can get the arena allocation for a particular model using TFLM python interpreter 
To create a python TFLM interpreter from python 
```
  tflm_interpreter = tflm_runtime.Interpreter.from_file(model_path)
```
Then we can invoke the interpreter like below
```
  tflm_interpreter.set_input(data, 0)
  tflm_interpreter.invoke()
  tflm_output = interpreter.get_output(0)
```
And then finally, invoke the following API to get the arena allocation data
```
allocations = interpreter.get_allocations()
```

This API returns the arena usage in the following format 

`{'total_bytes': 289280, 'non_persistent_bytes': 119184, 'persistent_bytes': 170096}`

BUG=https://b.corp.google.com/issues/261439737