### PR TITLE
Use RecordingMicroInterpreter. Add MicroProfiler to surface latency data.

### DIFF
--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
@@ -34,7 +34,6 @@ limitations under the License.
 #include "tensorflow/lite/micro/recording_micro_allocator.h"
 #include "tensorflow/lite/micro/recording_micro_interpreter.h"
 
-
 namespace tflite {
 namespace {
 // This function looks up the registerer symbol based on the string name

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
@@ -26,11 +26,14 @@ limitations under the License.
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
+#include "tensorflow/lite/micro/micro_profiler.h"
 #include "tensorflow/lite/micro/python/interpreter/src/numpy_utils.h"
 #include "tensorflow/lite/micro/python/interpreter/src/pybind11_lib.h"
 #include "tensorflow/lite/micro/python/interpreter/src/python_utils.h"
 #include "tensorflow/lite/micro/python/interpreter/src/shared_library.h"
 #include "tensorflow/lite/micro/recording_micro_allocator.h"
+#include "tensorflow/lite/micro/recording_micro_interpreter.h"
+
 
 namespace tflite {
 namespace {
@@ -238,8 +241,9 @@ InterpreterWrapper::InterpreterWrapper(
     }
   }
 
-  interpreter_ = new MicroInterpreter(model, all_ops_resolver_, allocator_,
-                                      resource_variables_);
+  interpreter_ = new tflite::RecordingMicroInterpreter(
+      model, all_ops_resolver_, allocator_,
+      resource_variables_, &profiler_);
 
   TfLiteStatus status = interpreter_->AllocateTensors();
   if (status != kTfLiteOk) {
@@ -252,6 +256,8 @@ InterpreterWrapper::InterpreterWrapper(
 }
 
 void InterpreterWrapper::PrintAllocations() { allocator_->PrintAllocations(); }
+
+void InterpreterWrapper::PrintLatencyStats() { profiler_.LogTicksPerTagCsv(); }
 
 int InterpreterWrapper::Invoke() { return interpreter_->Invoke(); }
 

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
@@ -255,7 +255,7 @@ InterpreterWrapper::InterpreterWrapper(
 
 void InterpreterWrapper::PrintAllocations() { allocator_->PrintAllocations(); }
 
-void InterpreterWrapper::PrintLatencyStats() { profiler_.LogTicksPerTagCsv(); }
+int InterpreterWrapper::GetTotalTicks() { return profiler_.GetTotalTicks(); }
 
 int InterpreterWrapper::Invoke() { return interpreter_->Invoke(); }
 

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
@@ -242,8 +242,7 @@ InterpreterWrapper::InterpreterWrapper(
   }
 
   interpreter_ = new tflite::RecordingMicroInterpreter(
-      model, all_ops_resolver_, allocator_,
-      resource_variables_, &profiler_);
+      model, all_ops_resolver_, allocator_, resource_variables_, &profiler_);
 
   TfLiteStatus status = interpreter_->AllocateTensors();
   if (status != kTfLiteOk) {

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
@@ -23,7 +23,6 @@ limitations under the License.
 #include "tensorflow/lite/micro/recording_micro_allocator.h"
 #include "tensorflow/lite/micro/recording_micro_interpreter.h"
 
-
 namespace tflite {
 
 class InterpreterWrapper {

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
@@ -33,7 +33,7 @@ class InterpreterWrapper {
   ~InterpreterWrapper();
 
   void PrintAllocations();
-  void PrintLatencyStats();
+  int GetTotalTicks();
   int Invoke();
   int Reset();
   void SetInputTensor(PyObject* data, size_t index);

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
@@ -19,7 +19,10 @@ limitations under the License.
 
 #include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
+#include "tensorflow/lite/micro/micro_profiler.h"
 #include "tensorflow/lite/micro/recording_micro_allocator.h"
+#include "tensorflow/lite/micro/recording_micro_interpreter.h"
+
 
 namespace tflite {
 
@@ -31,6 +34,7 @@ class InterpreterWrapper {
   ~InterpreterWrapper();
 
   void PrintAllocations();
+  void PrintLatencyStats();
   int Invoke();
   int Reset();
   void SetInputTensor(PyObject* data, size_t index);
@@ -43,7 +47,8 @@ class InterpreterWrapper {
   const PyObject* model_;
   std::unique_ptr<uint8_t[]> memory_arena_;
   tflite::AllOpsResolver all_ops_resolver_;
-  tflite::MicroInterpreter* interpreter_;
+  tflite::MicroProfiler profiler_;
+  tflite::RecordingMicroInterpreter* interpreter_;
 };
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper_pybind.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper_pybind.cc
@@ -34,6 +34,7 @@ PYBIND11_MODULE(interpreter_wrapper_pybind, m) {
                                    num_resource_variables));
       }))
       .def("PrintAllocations", &InterpreterWrapper::PrintAllocations)
+      .def("PrintLatencyStats", &InterpreterWrapper::PrintLatencyStats)
       .def("Invoke", &InterpreterWrapper::Invoke)
       .def("Reset", &InterpreterWrapper::Reset)
       .def(

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper_pybind.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper_pybind.cc
@@ -34,7 +34,7 @@ PYBIND11_MODULE(interpreter_wrapper_pybind, m) {
                                    num_resource_variables));
       }))
       .def("PrintAllocations", &InterpreterWrapper::PrintAllocations)
-      .def("PrintLatencyStats", &InterpreterWrapper::PrintLatencyStats)
+      .def("GetTotalTicks", &InterpreterWrapper::GetTotalTicks)
       .def("Invoke", &InterpreterWrapper::Invoke)
       .def("Reset", &InterpreterWrapper::Reset)
       .def(

--- a/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
+++ b/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
@@ -103,7 +103,7 @@ class Interpreter(object):
     Returns:
       This method returns nothing but prints the latency info.
     """
-    return self._interpreter.PrintLatencyStats()
+    self._interpreter.PrintLatencyStats()
 
   def print_allocations(self):
     """Invoke the RecordingMicroAllocator to print the arena usage.

--- a/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
+++ b/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
@@ -95,6 +95,16 @@ class Interpreter(object):
     return Interpreter(model_data, custom_op_registerers, arena_size,
                        num_resource_variables)
 
+  def print_latency_stats(self):
+    """Invoke the MicroProfiler to print the latency (ticks) numbers .
+
+    This should be called after `invoke()`.
+
+    Returns:
+      This method returns nothing but prints the latency info.
+    """
+    return self._interpreter.PrintLatencyStats()
+
   def print_allocations(self):
     """Invoke the RecordingMicroAllocator to print the arena usage.
 

--- a/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
+++ b/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
@@ -95,15 +95,15 @@ class Interpreter(object):
     return Interpreter(model_data, custom_op_registerers, arena_size,
                        num_resource_variables)
 
-  def print_latency_stats(self):
-    """Invoke the MicroProfiler to print the latency (ticks) numbers .
+  def get_latency(self):
+    """Invoke the MicroProfiler to returns the total number of ticks.
 
     This should be called after `invoke()`.
 
     Returns:
-      This method returns nothing but prints the latency info.
+      This method returns the total number of ticks.
     """
-    self._interpreter.PrintLatencyStats()
+    return self._interpreter.GetTotalTicks()
 
   def print_allocations(self):
     """Invoke the RecordingMicroAllocator to print the arena usage.


### PR DESCRIPTION
This is a new API exposed through the TFLM Python interpreter. This new API `GetTotalTicks();` will return the number of ticks (as an integer value) that the invoke() call to the interpreter took.
BUG=https://b.corp.google.com/issues/263221200

