### PR TITLE
Add API doc comments for core inferencing classes and functions

### DIFF
--- a/tensorflow/lite/micro/kernels/kernel_util.h
+++ b/tensorflow/lite/micro/kernels/kernel_util.h
@@ -59,7 +59,9 @@ const TfLiteEvalTensor* GetEvalInput(const TfLiteContext* context,
 TfLiteEvalTensor* GetEvalOutput(const TfLiteContext* context,
                                 const TfLiteNode* node, int index);
 
-// Returns data for a TfLiteEvalTensor struct that are expected to exist.
+// Gets the mutable data for a specified tensor.
+// @param tensor The tensor to read/write.
+// @return A pointer to the tensor data.
 template <typename T>
 T* GetTensorData(TfLiteEvalTensor* tensor) {
   TFLITE_DCHECK(tensor != nullptr);
@@ -67,6 +69,9 @@ T* GetTensorData(TfLiteEvalTensor* tensor) {
 }
 
 // Returns const data for a TfLiteEvalTensor struct that are expected to exist.
+//
+// For example, use this to access the allocated input tensor data by passing
+// it the result from `MicroInterpreter::input_tensor`.
 template <typename T>
 const T* GetTensorData(const TfLiteEvalTensor* tensor) {
   TFLITE_DCHECK(tensor != nullptr);

--- a/tensorflow/lite/micro/kernels/kernel_util.h
+++ b/tensorflow/lite/micro/kernels/kernel_util.h
@@ -59,19 +59,21 @@ const TfLiteEvalTensor* GetEvalInput(const TfLiteContext* context,
 TfLiteEvalTensor* GetEvalOutput(const TfLiteContext* context,
                                 const TfLiteNode* node, int index);
 
-// Gets the mutable data for a specified tensor.
+// Gets the mutable data for a tensor that is expected to exist.
 // @param tensor The tensor to read/write.
-// @return A pointer to the tensor data.
+// @return A pointer to the mutable tensor data.
 template <typename T>
 T* GetTensorData(TfLiteEvalTensor* tensor) {
   TFLITE_DCHECK(tensor != nullptr);
   return reinterpret_cast<T*>(tensor->data.raw);
 }
 
-// Returns const data for a TfLiteEvalTensor struct that are expected to exist.
+// Gets the immutable data for a tensor that is expected to exist.
 //
 // For example, use this to access the allocated input tensor data by passing
 // it the result from `MicroInterpreter::input_tensor`.
+// @param tensor The tensor to read.
+// @return A pointer to the read-only tensor data.
 template <typename T>
 const T* GetTensorData(const TfLiteEvalTensor* tensor) {
   TFLITE_DCHECK(tensor != nullptr);

--- a/tensorflow/lite/micro/micro_interpreter.h
+++ b/tensorflow/lite/micro/micro_interpreter.h
@@ -39,7 +39,6 @@ namespace tflite {
 
 // Encapsulates a pre-trained model and drives the model inference.
 //
-//
 // @note This class is not thread-safe.
 // The client is responsible for ensuring serialized interaction to avoid data
 // races and undefined behavior.
@@ -100,7 +99,7 @@ class MicroInterpreter {
   // tensor buffers), and must be called again if (and only if) an input tensor
   // is resized.
   //
-  // @return Atatus of success or failure. Will fail if any of the
+  // @return Status of success or failure. Will fail if any of the
   // ops in the model (other than those which were rewritten by delegates, if
   // any) are not supported by the Interpreter's OpResolver.
   TfLiteStatus AllocateTensors();
@@ -109,6 +108,7 @@ class MicroInterpreter {
   //
   // In order to support partial graph runs for strided models, this can return
   // values other than kTfLiteOk and kTfLiteError.
+  // TODO(b/149795762): Add this to the TfLiteStatus enum.
   TfLiteStatus Invoke();
 
   // This is the recommended API for an application to pass an external payload

--- a/tensorflow/lite/micro/micro_interpreter.h
+++ b/tensorflow/lite/micro/micro_interpreter.h
@@ -37,8 +37,16 @@ limitations under the License.
 
 namespace tflite {
 
+// Encapsulates a pre-trained model and drives the model inference.
+//
+//
+// @note This class is not thread-safe.
+// The client is responsible for ensuring serialized interaction to avoid data
+// races and undefined behavior.
 class MicroInterpreter {
  public:
+  // Constructor. Creates an instance with an allocated tensor arena.
+  //
   // The lifetime of the model, op resolver, tensor arena, error reporter,
   // resource variables, and profiler must be at least as long as that of the
   // interpreter object, since the interpreter may need to access them at any
@@ -47,16 +55,36 @@ class MicroInterpreter {
   // variables through a top-level function. The interpreter doesn't do any
   // deallocation of any of the pointed-to objects, ownership remains with the
   // caller.
+  //
+  // @param model A trained TensorFlow Lite model.
+  // @param op_resolver The op resolver that contains all ops used by the model.
+  //   This is usually an instance of `tflite::MicroMutableOpResolver`.
+  // @param tensor_arena The allocated memory for all intermediate tensor data.
+  // @param tensor_arena_size The size of `tensor_arena`.
+  // @param resource_variables Handles assign/read ops for resource variables.
+  //   See [Resource variable docs](https://github.com/tensorflow/tflite-micro/blob/main/tensorflow/lite/micro/docs/resource_variables.md).
+  // @param profiler Handles profiling for op kernels and TFLM routines.
+  //   See [Profiling docs](https://github.com/tensorflow/tflite-micro/blob/main/tensorflow/lite/micro/docs/profiling.md).
   MicroInterpreter(const Model* model, const MicroOpResolver& op_resolver,
                    uint8_t* tensor_arena, size_t tensor_arena_size,
                    MicroResourceVariables* resource_variables = nullptr,
                    MicroProfilerInterface* profiler = nullptr);
 
-  // Create an interpreter instance using an existing MicroAllocator instance.
+  // Constructor. Creates an instance using an existing MicroAllocator instance.
+  //
   // This constructor should be used when creating an allocator that needs to
   // have allocation handled in more than one interpreter or for recording
   // allocations inside the interpreter. The lifetime of the allocator must be
   // as long as that of the interpreter object.
+  //
+  // @param model A trained TensorFlow Lite model.
+  // @param op_resolver The op resolver that contains all ops used by the model.
+  //   This is usually an instance of `tflite::MicroMutableOpResolver`.
+  // @param allocator The object that allocates all intermediate tensor data.
+  // @param resource_variables Handles assign/read ops for resource variables.
+  //   See [Resource variable docs](https://github.com/tensorflow/tflite-micro/blob/main/tensorflow/lite/micro/docs/resource_variables.md).
+  // @param profiler Handles profiling for op kernels and TFLM routines.
+  //   See [Profiling docs](https://github.com/tensorflow/tflite-micro/blob/main/tensorflow/lite/micro/docs/profiling.md).
   MicroInterpreter(const Model* model, const MicroOpResolver& op_resolver,
                    MicroAllocator* allocator,
                    MicroResourceVariables* resource_variables = nullptr,
@@ -64,13 +92,23 @@ class MicroInterpreter {
 
   ~MicroInterpreter();
 
-  // Runs through the model and allocates all necessary input, output and
-  // intermediate tensors.
+  // Allocates all the model's necessary input, output and intermediate tensors.
+  //
+  // This will redim dependent tensors using the input tensor dimensionality as
+  // given. This is relatively expensive. This must be called after the
+  // interpreter has been created and before running inference (and accessing
+  // tensor buffers), and must be called again if (and only if) an input tensor
+  // is resized.
+  //
+  // @return Atatus of success or failure. Will fail if any of the
+  // ops in the model (other than those which were rewritten by delegates, if
+  // any) are not supported by the Interpreter's OpResolver.
   TfLiteStatus AllocateTensors();
 
+  // Invokes the model to run inference using allocated input tensors.
+  //
   // In order to support partial graph runs for strided models, this can return
   // values other than kTfLiteOk and kTfLiteError.
-  // TODO(b/149795762): Add this to the TfLiteStatus enum.
   TfLiteStatus Invoke();
 
   // This is the recommended API for an application to pass an external payload
@@ -79,14 +117,28 @@ class MicroInterpreter {
   // one external context.
   TfLiteStatus SetMicroExternalContext(void* external_context_payload);
 
+  // Gets a mutable pointer to an input tensor.
+  // @param index The index position of the input tensor.
+  //   Must be between 0 and `inputs_size()`.
+  // @return The input tensor.
   TfLiteTensor* input(size_t index);
+
+  // Gets the size of the input tensors.
   size_t inputs_size() const {
     return model_->subgraphs()->Get(0)->inputs()->size();
   }
+
+  // Gets a read-only list of all inputs.
   const flatbuffers::Vector<int32_t>& inputs() const {
     return *model_->subgraphs()->Get(0)->inputs();
   }
+
+  // Same as `input()`.
   TfLiteTensor* input_tensor(size_t index) { return input(index); }
+
+  // Gets a mutable pointer into the data of a given input tensor.
+  //
+  // The given index must be between 0 and `inputs_size()`.
   template <class T>
   T* typed_input_tensor(int tensor_index) {
     if (TfLiteTensor* tensor_ptr = input_tensor(tensor_index)) {
@@ -97,14 +149,28 @@ class MicroInterpreter {
     return nullptr;
   }
 
+  // Gets a mutable pointer to an output tensor.
+  // @param index The index position of the output tensor.
+  //   Must be between 0 and `outputs_size()`.
+  // @return The output tensor.
   TfLiteTensor* output(size_t index);
+
+  // Gets the size of the output tensors.
   size_t outputs_size() const {
     return model_->subgraphs()->Get(0)->outputs()->size();
   }
+
+  // Gets a read-only list of all outputs.
   const flatbuffers::Vector<int32_t>& outputs() const {
     return *model_->subgraphs()->Get(0)->outputs();
   }
+
+  // Same as `output()`.
   TfLiteTensor* output_tensor(size_t index) { return output(index); }
+
+  // Gets a mutable pointer into the data of a given output tensor.
+  //
+  // The given index must be between 0 and `outputs_size()`.
   template <class T>
   T* typed_output_tensor(int tensor_index) {
     if (TfLiteTensor* tensor_ptr = output_tensor(tensor_index)) {

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -40,6 +40,12 @@ namespace tflite {
 TfLiteRegistration* Register_DETECTION_POSTPROCESS();
 
 template <unsigned int tOpCount>
+
+// Maps ops in the loaded model to executable functions on the device.
+//
+// You must use this object to specify each of the ops required by your model
+// (using the various `Add...` functions), and then pass this to the
+// `tflite::MicroInterpreter` constructor.
 class MicroMutableOpResolver : public MicroOpResolver {
  public:
   TF_LITE_REMOVE_VIRTUAL_DELETE
@@ -80,10 +86,14 @@ class MicroMutableOpResolver : public MicroOpResolver {
 
   // Registers a Custom Operator with the MicroOpResolver.
   //
-  // Only the first call for a given name will be successful. i.e. if this
+  // Only the first call for a given name will be successful. That is, if this
   // function is called again for a previously added Custom Operator, the
   // MicroOpResolver will be unchanged and this function will return
   // kTfLiteError.
+  //
+  // @param name Name of the custom op.
+  // @param registration Handler for the custom op.
+  // @returns `kTfLiteOk` if successful; `kTfLiteError` otherwise.
   TfLiteStatus AddCustom(const char* name, TfLiteRegistration* registration) {
     if (registrations_len_ >= tOpCount) {
       MicroPrintf(

--- a/tensorflow/lite/schema/schema_generated.h
+++ b/tensorflow/lite/schema/schema_generated.h
@@ -20088,6 +20088,12 @@ inline void BuiltinOptionsUnion::Reset() {
   type = BuiltinOptions_NONE;
 }
 
+// Creates a `Model` object with the given model data, which you need for the
+// `tflite::MicroInterpreter` constructor.
+// @param buf The model data, either loaded from a C array or from a
+//   `.tflite` file.
+// @return The model object to use with the `tflite::MicroInterpreter`
+//   constructor.
 inline const tflite::Model *GetModel(const void *buf) {
   return flatbuffers::GetRoot<tflite::Model>(buf);
 }


### PR DESCRIPTION
These code comments cover the essential APIs needed to setup a `MicroInterpreter` and run inference with TFLM. The comments are written in a style that's intended for parsing into HTML with Doxygen. (RE: issue #1640)

I originally created these code comments for the [coralmicro API reference](https://coral.ai/docs/reference/micro/tensorflow/). (See info about [building the API docs](https://github.com/google-coral/coralmicro/tree/main/docs#coralmicro-api-docs).)

Basically all of the code comments are still the same as created for coralmicro, except I removed the `ErrorReporter` parameter from the `MicroInterpreter` constructor (no longer used in tflite-micro) and made a few new small copyedits.