### PR TITLE
build: add target to generate compiler_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bazel-*
+/compile_commands.json
 *.swp
 .vscode/
 *audio_frontend*
@@ -6,3 +7,9 @@
 *__pycache__*
 venv
 gen
+
+# Ignore the directory in which `clangd` stores its local index.
+/.cache/
+
+# Ignore the `external` symlink added by `bazel-compile-commands-extractor`
+/external

--- a/BUILD
+++ b/BUILD
@@ -2,7 +2,7 @@ load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile
 
 # `bazel run` this target to generate compile_commands.json, which can be used
 # by various tools like editors and LSPs to provide features like intelligent
-# navigation and autocompletion based on the source graph and compiler commands. 
+# navigation and autocompletion based on the source graph and compiler commands.
 refresh_compile_commands(
     name = "refresh_compile_commands",
     targets = [ "//...", ],

--- a/BUILD
+++ b/BUILD
@@ -5,5 +5,5 @@ load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile
 # navigation and autocompletion based on the source graph and compiler commands.
 refresh_compile_commands(
     name = "refresh_compile_commands",
-    targets = [ "//...", ],
+    targets = ["//..."],
 )

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,9 @@
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
+
+# `bazel run` this target to generate compile_commands.json, which can be used
+# by various tools like editors and LSPs to provide features like intelligent
+# navigation and autocompletion based on the source graph and compiler commands. 
+refresh_compile_commands(
+    name = "refresh_compile_commands",
+    targets = [ "//...", ],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,6 +17,16 @@ workspace(name = "tflite_micro")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# compile_commands.json generator
+http_archive(
+    name = "hedron_compile_commands",
+    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/1266d6a25314d165ca78d0061d3399e909b7920e.tar.gz",
+    strip_prefix = "bazel-compile-commands-extractor-1266d6a25314d165ca78d0061d3399e909b7920e",
+    sha256 = "bacabfe758676fdc19e4bea7c4a3ac99c7e7378d259a9f1054d341c6a6b44ff6",
+)
+load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
+hedron_compile_commands_setup()
+
 http_archive(
     name = "rules_python",
     url = "https://github.com/bazelbuild/rules_python/releases/download/0.4.0/rules_python-0.4.0.tar.gz",


### PR DESCRIPTION
Add a target `bazel run :refresh_compile_commands` to generate `./compile_commands.json`, which can be used by various tools like editors and language servers to provide features like intelligent navigation and autocompletion based on the source graph and compiler commands.

For more about this can be used:
* [clangd: Teach your editor C++](https://clangd.llvm.org)
* [Getting started with neovim's native LSP client: The easy way](https://dev.to/vonheikemen/getting-started-with-neovims-native-lsp-client-in-the-year-of-2022-the-easy-way-bp3#starting-from-scratch)
* [Language Server Protocol](https://en.wikipedia.org/wiki/Language_Server_Protocol)

BUG=cleanup, see description