### PR TITLE
Downgrade numpy in test virtual environment

### DIFF
--- a/tensorflow/lite/micro/tools/make/ext_libs/person_detection_int8_vela_convert.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/person_detection_int8_vela_convert.sh
@@ -55,6 +55,8 @@ if [ ! -f ${CONVERTED_PERSON_MODEL_INT8} ]; then
   source $TEMPFILE/bin/activate
   python3 -m pip install --upgrade pip >&2
   pip install --upgrade cython >&2
+  pip install numpy==1.21.3 >&2  # Some types are removed in the latest numpy.
+                                 # Use an older version until the ethos-u-vela package is updated.
   pip install --prefer-binary ethos-u-vela >&2
   vela --accelerator-config=ethos-u55-256 ${DOWNLOADS_DIR}/../../../models/person_detect.tflite \
        --output-dir ${MODEL_DIR} >&2


### PR DESCRIPTION
Since some types have been removed from latest numpy it breaks the current pip ethos-u-vela pip package. This has been resolved but not yet updated on PyPI. So until then just downgrade numpy in this isolated test.

BUG=AVH failing: https://github.com/tensorflow/tflite-micro/actions/runs/3945612209/jobs/6752658001