### PR TITLE
Fix hedron_compile_commands fetch with updated sha256

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,7 +22,7 @@ http_archive(
     name = "hedron_compile_commands",
     url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/1266d6a25314d165ca78d0061d3399e909b7920e.tar.gz",
     strip_prefix = "bazel-compile-commands-extractor-1266d6a25314d165ca78d0061d3399e909b7920e",
-    sha256 = "bacabfe758676fdc19e4bea7c4a3ac99c7e7378d259a9f1054d341c6a6b44ff6",
+    sha256 = "6f2affa15ad72afec99be300c053ad305ec6adb394b6a701d2bcd8737f900472",
 )
 load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
 hedron_compile_commands_setup()


### PR DESCRIPTION
hedron_compile_commands is causing build to fail due to fetch error with wrong sha256. Using expected sha256 fixes error.

More info to follow in bug for root cause.
BUG=[267220031](https://b.corp.google.com/issues/267220031)