### PR TITLE
Fix the out of bound issue in LSTM eval test 

### DIFF
--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -919,10 +919,6 @@ cc_test(
     srcs = [
         "lstm_eval_internal_test.cc",
     ],
-    tags = [
-        "noasan",  # TODO(b/266028903): fix test with ubsan
-        "noubsan",  # TODO(b/266028903): fix test with asan
-    ],
     deps = [
         ":lstm_eval_test_lib",
         "//tensorflow/lite/micro:debug_log",

--- a/tensorflow/lite/micro/kernels/testdata/lstm_test_data.h
+++ b/tensorflow/lite/micro/kernels/testdata/lstm_test_data.h
@@ -240,7 +240,7 @@ class LstmNodeContents {
 
   // Internal tensors, fixed (const). see lstm_shared.h for tensor names
   const TfLiteEvalTensor* GetEvalTensor(const int tensor_index) const {
-    auto valid_index = input_tensor_indeces_[tensor_index + 1];
+    auto valid_index = input_tensor_indices_[tensor_index + 1];
     if (valid_index < 0) {
       return nullptr;
     }
@@ -282,9 +282,9 @@ class LstmNodeContents {
  private:
   void InitializeTensors() {
     // Invalid all the input tensors untill we set it
-    input_tensor_indeces_[0] = 24;  // tot elements
+    input_tensor_indices_[0] = 24;  // tot elements
     for (size_t i = 1; i < 25; i++) {
-      input_tensor_indeces_[i] = kTfLiteOptionalTensor;
+      input_tensor_indices_[i] = kTfLiteOptionalTensor;
     }
     // Input Tensor
     SetTensor(kLstmInputTensor, input_, input_size_);
@@ -373,9 +373,9 @@ class LstmNodeContents {
   // Use for internel kernel testing
   TfLiteEvalTensor eval_tensors_[24 + 1];
   // indices for the tensors inside the node (required by kernel runner)
-  int input_tensor_indeces_[1 + 24] = {};
+  int input_tensor_indices_[1 + 24] = {};
   // single output (last in the tensors array)
-  int output_tensor_indeces_[2] = {1, 24};
+  int output_tensor_indices_[2] = {1, 24};
 
   // tennsor data
   // states are initialized to zero

--- a/tensorflow/lite/micro/kernels/testdata/lstm_test_data.h
+++ b/tensorflow/lite/micro/kernels/testdata/lstm_test_data.h
@@ -333,7 +333,9 @@ class LstmNodeContents {
     eval_tensors_[index].dims = IntArrayFromInts(dims);
     eval_tensors_[index].type = typeToTfLiteType<T>();
     // update the index
-    input_tensor_indeces_[index + 1] = index;
+    if (index < 24) {
+      input_tensor_indices_[index + 1] = index;
+    }
   }
 
   void SetTensorQuantizationParam(


### PR DESCRIPTION
BUG=http://b/266028903

Fix the out of bound memory access issue in the LSTM eval test to pass TAP test with asan on. 