### PR TITLE
Fix asan/msan issues for LSTM kernel

### DIFF
--- a/tensorflow/lite/micro/kernels/lstm_eval.cc
+++ b/tensorflow/lite/micro/kernels/lstm_eval.cc
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -196,7 +196,7 @@ void LstmStepManager::UpdateBatch() {
 
 // Input shape for each single time LSTM invocation.
 // Multi-batch for time_major input
-const RuntimeShape LstmStepManager::InputShape() const {
+RuntimeShape LstmStepManager::InputShape() const {
   int batch_size = 1;
   if (size_info_.time_major) {
     batch_size = size_info_.batch_size;
@@ -208,7 +208,7 @@ const RuntimeShape LstmStepManager::InputShape() const {
 
 // State shape (both hidden and cell) for each single time LSTM invocation.
 // Multi-batch for time_major input
-const RuntimeShape LstmStepManager::StateShape() const {
+RuntimeShape LstmStepManager::StateShape() const {
   int batch_size = 1;
   if (size_info_.time_major) {
     batch_size = size_info_.batch_size;

--- a/tensorflow/lite/micro/kernels/lstm_eval.h
+++ b/tensorflow/lite/micro/kernels/lstm_eval.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -102,8 +102,8 @@ class LstmStepManager {
   void UpdateBatch();
 
   void ResetTime() { current_time_ = 0; }
-  const RuntimeShape InputShape() const;
-  const RuntimeShape StateShape() const;
+  RuntimeShape InputShape() const;
+  RuntimeShape StateShape() const;
 
   int InputOffset() const { return input_offset_; }
   int OutputOffset() const { return output_offset_; }

--- a/tensorflow/lite/micro/kernels/lstm_eval_test.h
+++ b/tensorflow/lite/micro/kernels/lstm_eval_test.h
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -300,6 +300,8 @@ OpDataLSTM CreateLstmOpDataFloat(
                          node_contents.GetEvalTensor(kLstmInputTensor)->dims,
                          node_contents.HiddenStateEvalTensor()->dims);
   op_data.cell_state_info.cell_clip = builtin_data.cell_clip;
+  op_data.cell_state_info.quantized_cell_clip = 0;     // No quantization
+  op_data.cell_state_info.cell_state_scale_power = 0;  // No quantization
 
   // Gate Parameters
   op_data.forget_gate_parameters = CreateGateParamsFloat();

--- a/tensorflow/lite/micro/kernels/unidirectional_sequence_lstm_test.cc
+++ b/tensorflow/lite/micro/kernels/unidirectional_sequence_lstm_test.cc
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
BUG=http://b/267678775

Internal tests reveal that the floating point computation for the LSTM kernels used uninitialized variables. Although these variables are not actually used in inference pass, they triggered the memory sanitizer errors.

This PR explicitly set the variables to avoid the asan/msan errors.