### PR TITLE
Python interpreter automatically count number of resource variables

### DIFF
--- a/tensorflow/lite/micro/python/interpreter/src/BUILD
+++ b/tensorflow/lite/micro/python/interpreter/src/BUILD
@@ -52,5 +52,6 @@ py_library(
     srcs_version = "PY3",
     deps = [
         requirement("numpy"),
+        "//tensorflow/lite/tools:flatbuffer_utils",
     ],
 )

--- a/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
+++ b/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
@@ -43,11 +43,11 @@ class Interpreter(object):
       print(
           'WARNING: num_resource_variables is deprecated. Resource variable count is ',
           'calculated automatically.')
-    kNumResourceVariables = flatbuffer_utils.count_resource_variables(
+    number_resource_variables = flatbuffer_utils.count_resource_variables(
         model_data)
 
     self._interpreter = interpreter_wrapper_pybind.InterpreterWrapper(
-        model_data, custom_op_registerers, arena_size, kNumResourceVariables)
+        model_data, custom_op_registerers, arena_size, number_resource_variables)
 
   @classmethod
   def from_file(self,

--- a/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
+++ b/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
@@ -19,6 +19,7 @@ import os
 from tflite_micro.tensorflow.lite.micro.python.interpreter.src import interpreter_wrapper_pybind
 from tflite_micro.tensorflow.lite.tools import flatbuffer_utils
 
+
 class Interpreter(object):
 
   def __init__(self,
@@ -39,9 +40,11 @@ class Interpreter(object):
 
     # Some models make use of resource variables ops, get the count here
     if num_resource_variables != 0:
-      print('WARNING: num_resource_variables is deprecated. Resource variable count is ',
-        'calculated automatically.')
-    kNumResourceVariables = flatbuffer_utils.count_resource_variables(model_data)
+      print(
+          'WARNING: num_resource_variables is deprecated. Resource variable count is ',
+          'calculated automatically.')
+    kNumResourceVariables = flatbuffer_utils.count_resource_variables(
+        model_data)
 
     self._interpreter = interpreter_wrapper_pybind.InterpreterWrapper(
         model_data, custom_op_registerers, arena_size, kNumResourceVariables)

--- a/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
+++ b/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
@@ -17,7 +17,7 @@
 import os
 
 from tflite_micro.tensorflow.lite.micro.python.interpreter.src import interpreter_wrapper_pybind
-
+from tflite_micro.tensorflow.lite.tools import flatbuffer_utils
 
 class Interpreter(object):
 
@@ -37,8 +37,14 @@ class Interpreter(object):
     if arena_size is None:
       arena_size = len(model_data) * 10
 
+    # Some models make use of resource variables ops, get the count here
+    if num_resource_variables != 0:
+      print('WARNING: num_resource_variables is deprecated. Resource variable count is ',
+        'calculated automatically.')
+    kNumResourceVariables = flatbuffer_utils.count_resource_variables(model_data)
+
     self._interpreter = interpreter_wrapper_pybind.InterpreterWrapper(
-        model_data, custom_op_registerers, arena_size, num_resource_variables)
+        model_data, custom_op_registerers, arena_size, kNumResourceVariables)
 
   @classmethod
   def from_file(self,

--- a/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
+++ b/tensorflow/lite/micro/python/interpreter/src/tflm_runtime.py
@@ -47,7 +47,8 @@ class Interpreter(object):
         model_data)
 
     self._interpreter = interpreter_wrapper_pybind.InterpreterWrapper(
-        model_data, custom_op_registerers, arena_size, number_resource_variables)
+        model_data, custom_op_registerers, arena_size,
+        number_resource_variables)
 
   @classmethod
   def from_file(self,

--- a/tensorflow/lite/micro/python/interpreter/tests/interpreter_test.py
+++ b/tensorflow/lite/micro/python/interpreter/tests/interpreter_test.py
@@ -166,13 +166,11 @@ class ConvModelTests(test_util.TensorFlowTestCase):
       self.assertEqual(tflm_output.shape, self.output_shape)
       self.assertAllEqual(tflite_output, tflm_output)
 
-  def _helperModelFromFileAndBufferEqual(self, number_resource_variables=0):
+  def _helperModelFromFileAndBufferEqual(self):
     model_data = generate_test_models.generate_conv_model(True, self.filename)
 
-    file_interpreter = tflm_runtime.Interpreter.from_file(
-        self.filename, num_resource_variables=number_resource_variables)
-    bytes_interpreter = tflm_runtime.Interpreter.from_bytes(
-        model_data, num_resource_variables=number_resource_variables)
+    file_interpreter = tflm_runtime.Interpreter.from_file(self.filename)
+    bytes_interpreter = tflm_runtime.Interpreter.from_bytes(model_data)
 
     num_steps = 100
     for i in range(0, num_steps):
@@ -268,13 +266,6 @@ class ConvModelTests(test_util.TensorFlowTestCase):
         RuntimeError, "TFLM could not register custom op via SomeRandomOp"):
       interpreter = tflm_runtime.Interpreter.from_bytes(
           model_data, custom_op_registerers)
-
-  def testResourceVariableFunctionCall(self):
-    # Both interpreter function call cases should be valid for various
-    # number of resource variables.
-    self._helperModelFromFileAndBufferEqual(-2)
-    self._helperModelFromFileAndBufferEqual(1)
-    self._helperModelFromFileAndBufferEqual(12)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Deprecate old parameter for manually entering number of resource variables, and make use of new flatbuffer_utils.count_resource_variable().

BUG=[251851084](https://b.corp.google.com/issues/251851084)