### PR TITLE
build: add network_tester to create_tflm_tree exports

### DIFF
--- a/tensorflow/lite/micro/examples/network_tester/Makefile.inc
+++ b/tensorflow/lite/micro/examples/network_tester/Makefile.inc
@@ -50,3 +50,9 @@ endif
 # Builds a standalone object recognition binary.
 $(eval $(call microlite_test,network_tester_test,\
 $(NETWORK_TESTER_TEST_SRCS),$(NETWORK_TESTER_TEST_HDRS),$(NETWORK_TESTER_GENERATOR_INPUTS)))
+
+list_network_tester_example_sources:
+	@echo $(NETWORK_TESTER_TEST_SRCS)
+
+list_network_tester_example_headers:
+	@echo $(NETWORK_TESTER_TEST_HDRS)

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -267,8 +267,8 @@ endif
 # Kernel integration tests must be excluded on certain targets.
 MICRO_LITE_INTEGRATION_TESTS += $(shell find $(TENSORFLOW_ROOT)tensorflow/lite/micro/integration_tests -name Makefile.inc)
 
-MICRO_LITE_GEN_MUTABLE_OP_RESOLVER_TEST += $(shell find \
-$(TENSORFLOW_ROOT)tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver_test/person_detect -name Makefile.inc)
+MICRO_LITE_GEN_MUTABLE_OP_RESOLVER_TEST += \
+  $(wildcard $(TENSORFLOW_ROOT)tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver_test/person_detect/Makefile.inc)
 
 MICRO_LITE_BENCHMARKS := $(wildcard $(TENSORFLOW_ROOT)tensorflow/lite/micro/benchmarks/Makefile.inc)
 


### PR DESCRIPTION
Take an initial stab at adding files for the network_tester
example to the create_tflm_tree.py export.

BUG=fixes #1644