### PR TITLE
Xtensa linker issue

### DIFF
--- a/tensorflow/lite/micro/kernels/fully_connected.h
+++ b/tensorflow/lite/micro/kernels/fully_connected.h
@@ -73,7 +73,7 @@ TfLiteStatus CalculateOpDataFullyConnected(
 // (reference or optimized) must define this function.
 TfLiteRegistration Register_FULLY_CONNECTED();
 
-#if defined(CMSIS_NN) || defined(HEXAGON)
+#if defined(CMSIS_NN) || defined(HEXAGON) || defined(XTENSA)
 // Returns a TfLiteRegistration struct for kernel variant that only supports
 // int8.
 TfLiteRegistration Register_FULLY_CONNECTED_INT8();

--- a/tensorflow/lite/micro/kernels/fully_connected_test.cc
+++ b/tensorflow/lite/micro/kernels/fully_connected_test.cc
@@ -43,8 +43,7 @@ const float simple_weights_data[] = {
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10,  // u = 2
 };
 // TODO(b/258710417): INT4 isn't currently supported on Hexagon.
-// TODO(b/265349042): INT4 isn't currently supported on Hifimini.
-#if !defined(HEXAGON) && !defined(HIFIMINI)
+#if !defined(HEXAGON)
 const float simple_int4_weights_data[] = {
     -2, -1, 0, 1, 2, 3, 4, 5, 6, 7,  // u = 0
     -2, -1, 0, 1, 2, 3, 4, 5, 6, 7,  // u = 1
@@ -293,7 +292,6 @@ TfLiteStatus ValidateFullyConnectedGoldens(
   return kTfLiteOk;
 }
 
-#if !defined(XTENSA)  // Needed to avoid build error from unused functions.
 TfLiteStatus TestFullyConnectedFloat(
     int* input_dims_data, const float* input_data, int* weights_dims_data,
     const float* weights_data, int* bias_dims_data, const float* bias_data,
@@ -326,7 +324,6 @@ TfLiteStatus TestFullyConnectedFloat(
                                        activation, 1e-4f, output_dims_count,
                                        golden, output_data);
 }
-#endif
 
 template <typename dataT, typename weightT, typename biasT>
 TfLiteStatus TestFullyConnectedQuantized(
@@ -381,16 +378,6 @@ TfLiteStatus TestFullyConnectedQuantized(
 
 TF_LITE_MICRO_TESTS_BEGIN
 
-#if !defined(XTENSA) && !defined(CEVA_BX1) && !defined(CEVA_SP500)
-// TODO(b/170503075): xtensa kernels are less general
-// than reference kernels and we ifdef out test cases that are currently known
-// to fail.
-
-// CEVA's fully connected implementation assumes weights_zero_point=0 as
-// described in TFLite's quantization specification. tests which use a different
-// zero point will so ifdefed out.
-// See tflite quantization spec:
-// https://www.tensorflow.org/lite/performance/quantization_spec
 TF_LITE_MICRO_TEST(SimpleTest) {
   float output_data[tflite::testing::simple_output_size];
   TF_LITE_MICRO_EXPECT_EQ(
@@ -417,8 +404,6 @@ TF_LITE_MICRO_TEST(SimpleTestNullBias) {
           tflite::testing::simple_output_dims, kTfLiteActNone, output_data),
       kTfLiteOk);
 }
-
-#endif
 
 TF_LITE_MICRO_TEST(SimpleTestQuantizedInt8) {
   const float input_scale = 1.0f;
@@ -448,7 +433,7 @@ TF_LITE_MICRO_TEST(SimpleTestQuantizedInt8) {
       kTfLiteOk);
 }
 
-#if !(defined(XTENSA) || defined(HEXAGON))
+#if !defined(HEXAGON)
 TF_LITE_MICRO_TEST(SimpleTestQuantizedInt16) {
   const float input_scale = 128.0 / 65536;
   const int input_zero_point = 0;
@@ -537,9 +522,6 @@ TF_LITE_MICRO_TEST(SimpleTestQuantizedInt8Relu) {
       kTfLiteOk);
 }
 
-#if !defined(XTENSA)  // TODO(b/170503075): xtensa kernels are less general than
-                      // reference kernels and we ifdef out test cases that are
-                      // currently known to fail.
 TF_LITE_MICRO_TEST(SimpleTest4DInput) {
   int input_dims_4d[] = {4, 1, 1, 2, 10};
 
@@ -572,8 +554,6 @@ TF_LITE_MICRO_TEST(Representative1x64Input1x16Output) {
           output_data),
       kTfLiteOk);
 }
-
-#endif
 
 TF_LITE_MICRO_TEST(Representative1x64Input1x16OutputQuantizedInt8) {
   const float input_scale = 0.051445;
@@ -634,8 +614,7 @@ TF_LITE_MICRO_TEST(SimpleTestQuantizedInt8NullBias) {
 }
 
 // TODO(b/258710417): INT4 isn't currently supported on Hexagon.
-// TODO(b/265349042): INT4 isn't currently supported on Hifimini.
-#if !defined(HEXAGON) && !defined(HIFIMINI)
+#if !defined(HEXAGON)
 // This test was created by handcrafting simple_int4_weights_data, and
 // simple_golden_null_bias_int4_weights was obtained by running
 // TestFullyConnectedQuantized() with int8 quantization, and ensuring that int4

--- a/tensorflow/lite/micro/kernels/xtensa/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/fully_connected.cc
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,187 +24,112 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
-#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa_fully_connected.h"
 #include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
+
 namespace {
 
-TfLiteStatus CalculateOpData(TfLiteContext* context,
-                             TfLiteFusedActivation activation,
-                             TfLiteType data_type, const TfLiteTensor* input,
-                             const TfLiteTensor* filter,
-                             const TfLiteTensor* bias, TfLiteTensor* output,
-                             OpDataFullyConnected* data) {
-  double real_multiplier = 0.0;
-  TF_LITE_ENSURE_STATUS(GetQuantizedConvolutionMultipler(
-      context, input, filter, bias, output, &real_multiplier));
-#if defined(HIFIMINI)
-  QuantizeMultiplierForInt24(real_multiplier, &data->output_multiplier,
-                             &data->output_shift);
-#else
-  QuantizeMultiplier(real_multiplier, &data->output_multiplier,
-                     &data->output_shift);
-#endif
-  data->input_zero_point = input->params.zero_point;
-  data->filter_zero_point = filter->params.zero_point;
-  data->output_zero_point = output->params.zero_point;
-
-  return CalculateActivationRangeQuantized(context, activation, output,
-                                           &data->output_activation_min,
-                                           &data->output_activation_max);
-}
-
-void* Init(TfLiteContext* context, const char* buffer, size_t length) {
-  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
-#if !defined(VISION_P6)
-  return context->AllocatePersistentBuffer(context,
-                                           sizeof(OpDataFullyConnected));
-#else
-  void* data = context->AllocatePersistentBuffer(
-      context, sizeof(XtensaFullyConnectedOpData));
-#if !defined(HIFIMINI)
-  if (InitXtensaContext()) {
-    return nullptr;
-  }
-#endif
-  return data;
-#endif  // defined(VISION_P6)
-}
-
-TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
-  TFLITE_DCHECK(node->user_data != nullptr);
-  TFLITE_DCHECK(node->builtin_data != nullptr);
-
-  auto* data = static_cast<OpDataFullyConnected*>(node->user_data);
-  const auto* params =
-      reinterpret_cast<TfLiteFullyConnectedParams*>(node->builtin_data);
-
-  MicroContext* micro_context = GetMicroContext(context);
-
-  TfLiteTensor* input =
-      micro_context->AllocateTempInputTensor(node, kFullyConnectedInputTensor);
-  TF_LITE_ENSURE(context, input != nullptr);
-  TfLiteTensor* filter = micro_context->AllocateTempInputTensor(
-      node, kFullyConnectedWeightsTensor);
-  TF_LITE_ENSURE(context, filter != nullptr);
-  TfLiteTensor* bias =
-      micro_context->AllocateTempInputTensor(node, kFullyConnectedBiasTensor);
-  TfLiteTensor* output = micro_context->AllocateTempOutputTensor(
-      node, kFullyConnectedOutputTensor);
-  TF_LITE_ENSURE(context, output != nullptr);
-
-  if (input->type != kTfLiteInt8) {
-    MicroPrintf("Type %s (%d) not supported.", TfLiteTypeGetName(input->type),
-                input->type);
-    return kTfLiteError;
-  }
-
-  if (filter->type == kTfLiteInt4) {
-    int filter_size =
-        RuntimeShape(filter->dims->size,
-                     reinterpret_cast<const int32_t*>(filter->dims->data))
-            .FlatSize();
-    context->RequestScratchBufferInArena(context, filter_size,
-                                         &data->filter_buffer_index);
-  }
-
-  // Filter weights will always be symmetric quantized since we only support
-  // int8 quantization.
-  TFLITE_DCHECK(filter->params.zero_point == 0);
-
-  TFLITE_DCHECK_GE(GetTensorShape(output).DimensionsCount(), 1);
-
-  TF_LITE_ENSURE_OK(
-      context, CalculateOpData(context, params->activation, input->type, input,
-                               filter, bias, output, data));
-
-  micro_context->DeallocateTempTfLiteTensor(input);
-  micro_context->DeallocateTempTfLiteTensor(filter);
-  if (bias != nullptr) {
-    micro_context->DeallocateTempTfLiteTensor(bias);
-  }
-  micro_context->DeallocateTempTfLiteTensor(output);
-#if defined(VISION_P6)
-  TF_LITE_ENSURE_OK(context, FullyConnectedPrepareVision(context, node));
-#endif  // VISION_P6
-
-  return kTfLiteOk;
-}
-
-TfLiteStatus EvalQuantizedInt8(TfLiteContext* context, TfLiteNode* node,
-                               const OpDataFullyConnected& data,
-                               const TfLiteEvalTensor* input,
-                               const TfLiteEvalTensor* filter,
-                               const TfLiteEvalTensor* bias,
-                               TfLiteEvalTensor* output) {
-  const int32_t* bias_data =
-      nullptr != bias ? tflite::micro::GetTensorData<int32_t>(bias) : nullptr;
-
-#if defined(HIFIMINI)
-  FullyConnectedEvalHifimini(FullyConnectedParamsQuantized(data),
-                             tflite::micro::GetTensorShape(input),
-                             tflite::micro::GetTensorData<int8_t>(input),
-                             tflite::micro::GetTensorShape(filter),
-                             tflite::micro::GetTensorData<int8_t>(filter),
-                             tflite::micro::GetTensorShape(bias), bias_data,
-                             tflite::micro::GetTensorShape(output),
-                             tflite::micro::GetTensorData<int8_t>(output));
-#elif defined(HIFI4) || defined(HIFI5)
-  const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
-  const int num_batches =
-      FlatSizeSkipDim(output_shape, output_shape.DimensionsCount() - 1);
-  const int output_depth =
-      output_shape.Dims(output_shape.DimensionsCount() - 1);
-
-  const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
-  const int filter_dim_count = filter_shape.DimensionsCount();
-  const int accum_depth = filter_shape.Dims(filter_dim_count - 1);
-
-  FullyConnectedParams op_params = FullyConnectedParamsQuantized(data);
-  for (int b = 0; b < num_batches; ++b) {
-    TF_LITE_ENSURE_EQ(
-        context,
-        xa_nn_fully_connected_sym8sxasym8s_asym8s(
-            (tflite::micro::GetTensorData<int8_t>(output) + b * output_depth),
-            tflite::micro::GetTensorData<int8_t>(filter),
-            (tflite::micro::GetTensorData<int8_t>(input) + b * accum_depth),
-            bias_data, accum_depth, output_depth, op_params.input_offset,
-            op_params.output_multiplier, op_params.output_shift,
-            op_params.output_offset),
-        0);
-  }
-
-  int8_t* output_arr = tflite::micro::GetTensorData<int8_t>(output);
-  TF_LITE_ENSURE_EQ(context,
-                    xa_nn_vec_activation_min_max_8_8(
-                        output_arr, output_arr, data.output_activation_min,
-                        data.output_activation_max, num_batches * output_depth),
-                    0);
-#elif defined(VISION_P6)
-  (void)bias_data;
-  const auto& params =
-      *(reinterpret_cast<TfLiteConvParams*>(node->builtin_data));
-  const auto& op_data =
-      *(reinterpret_cast<XtensaFullyConnectedOpData*>(node->user_data));
-  FullyConnectedEvalVision(context, node, params, op_data, input, filter, bias,
-                           output);
-#else
-  reference_integer_ops::FullyConnected(
-      FullyConnectedParamsQuantized(data), tflite::micro::GetTensorShape(input),
-      tflite::micro::GetTensorData<int8_t>(input),
-      tflite::micro::GetTensorShape(filter),
-      tflite::micro::GetTensorData<int8_t>(filter),
-      tflite::micro::GetTensorShape(bias), bias_data,
-      tflite::micro::GetTensorShape(output),
-      tflite::micro::GetTensorData<int8_t>(output));
-#endif  // defined(HIFI4) || defined(HIFI5)
-
-  return kTfLiteOk;
-}
-
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->builtin_data != nullptr);
+  const auto* params =
+      static_cast<const TfLiteFullyConnectedParams*>(node->builtin_data);
+
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kFullyConnectedInputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kFullyConnectedWeightsTensor);
+  const TfLiteEvalTensor* bias =
+      tflite::micro::GetEvalInput(context, node, kFullyConnectedBiasTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kFullyConnectedOutputTensor);
+
+  TFLITE_DCHECK(node->user_data != nullptr);
+
+  const auto& data =
+      *(static_cast<const OpDataFullyConnected*>(node->user_data));
+
+  // Checks in Prepare ensure input, output and filter types are all the same.
+  switch (input->type) {
+    case kTfLiteFloat32: {
+      tflite::reference_ops::FullyConnected(
+          FullyConnectedParamsFloat(params->activation),
+          tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<float>(input),
+          tflite::micro::GetTensorShape(filter),
+          tflite::micro::GetTensorData<float>(filter),
+          tflite::micro::GetTensorShape(bias),
+          tflite::micro::GetOptionalTensorData<float>(bias),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<float>(output));
+      break;
+    }
+
+    case kTfLiteInt8: {
+      switch (filter->type) {
+        case kTfLiteInt8: {
+          return XtensaEvalFullyConnectedQuantizedInt8(
+              context, node, data, input, filter, bias, output);
+        }
+        case kTfLiteInt4: {
+          int8_t* unpacked_filter_data = static_cast<int8_t*>(
+              context->GetScratchBuffer(context, data.filter_buffer_index));
+          tflite::reference_integer_ops::FullyConnectedWithPackedInt4Weights(
+              FullyConnectedParamsQuantized(data),
+              tflite::micro::GetTensorShape(input),
+              tflite::micro::GetTensorData<int8_t>(input),
+              tflite::micro::GetTensorShape(filter),
+              tflite::micro::GetTensorData<int8_t>(filter),
+              unpacked_filter_data, tflite::micro::GetTensorShape(bias),
+              tflite::micro::GetOptionalTensorData<int32_t>(bias),
+              tflite::micro::GetTensorShape(output),
+              tflite::micro::GetTensorData<int8_t>(output));
+          break;
+        }
+        default: {
+          MicroPrintf("Filter type %s (%d) not supported.",
+                      TfLiteTypeGetName(filter->type), input->type);
+          return kTfLiteError;
+        }
+      }
+      break;
+    }
+
+    case kTfLiteInt16: {
+      switch (filter->type) {
+        case kTfLiteInt8: {
+          tflite::reference_integer_ops::FullyConnected(
+              FullyConnectedParamsQuantized(data),
+              tflite::micro::GetTensorShape(input),
+              tflite::micro::GetTensorData<int16_t>(input),
+              tflite::micro::GetTensorShape(filter),
+              tflite::micro::GetTensorData<int8_t>(filter),
+              tflite::micro::GetTensorShape(bias),
+              tflite::micro::GetOptionalTensorData<int64_t>(bias),
+              tflite::micro::GetTensorShape(output),
+              tflite::micro::GetTensorData<int16_t>(output));
+          break;
+        }
+        default: {
+          MicroPrintf("Filter type %s (%d) not supported.",
+                      TfLiteTypeGetName(filter->type), input->type);
+          return kTfLiteError;
+        }
+      }
+      break;
+    }
+
+    default: {
+      MicroPrintf("Input type %s (%d) not supported.",
+                  TfLiteTypeGetName(input->type), input->type);
+      return kTfLiteError;
+    }
+  }
+  return kTfLiteOk;
+}
+
+TfLiteStatus EvalInt8(TfLiteContext* context, TfLiteNode* node) {
   TFLITE_DCHECK(node->user_data != nullptr);
   const auto& data =
       *(static_cast<const OpDataFullyConnected*>(node->user_data));
@@ -214,9 +139,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   const TfLiteEvalTensor* filter =
       tflite::micro::GetEvalInput(context, node, kFullyConnectedWeightsTensor);
   const TfLiteEvalTensor* bias =
-      (NumInputs(node) == 3) ? tflite::micro::GetEvalInput(
-                                   context, node, kFullyConnectedBiasTensor)
-                             : nullptr;
+      tflite::micro::GetEvalInput(context, node, kFullyConnectedBiasTensor);
 
   TfLiteEvalTensor* output =
       tflite::micro::GetEvalOutput(context, node, kFullyConnectedOutputTensor);
@@ -236,14 +159,22 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
         tflite::micro::GetTensorData<int8_t>(output));
     return kTfLiteOk;
   } else {
-    return EvalQuantizedInt8(context, node, data, input, filter, bias, output);
+    return XtensaEvalFullyConnectedQuantizedInt8(context, node, data, input,
+                                                 filter, bias, output);
   }
 }
 
 }  // namespace
 
 TfLiteRegistration Register_FULLY_CONNECTED() {
-  return tflite::micro::RegisterOp(Init, Prepare, Eval);
+  return tflite::micro::RegisterOp(XtensaInitFullyConnected,
+                                   XtensaPrepareFullyConnected, Eval);
+}
+
+TfLiteRegistration Register_FULLY_CONNECTED_INT8() {
+  return tflite::micro::RegisterOp(XtensaInitFullyConnected,
+                                   XtensaPrepareFullyConnected<kTfLiteInt8>,
+                                   EvalInt8);
 }
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/fully_connected_common_xtensa.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/fully_connected_common_xtensa.cc
@@ -1,0 +1,84 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa_fully_connected.h"
+
+namespace tflite {
+
+void* XtensaInitFullyConnected(TfLiteContext* context, const char* buffer,
+                               size_t length) {
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+#if !defined(VISION_P6)
+  return context->AllocatePersistentBuffer(context,
+                                           sizeof(OpDataFullyConnected));
+#else
+  void* data = context->AllocatePersistentBuffer(
+      context, sizeof(XtensaFullyConnectedOpData));
+#if !defined(HIFIMINI)
+  if (InitXtensaContext()) {
+    return nullptr;
+  }
+#endif
+  return data;
+#endif  // defined(VISION_P6)
+}
+
+TfLiteStatus XtensaCalculateOpDataFullyConnected(
+    TfLiteContext* context, TfLiteFusedActivation activation,
+    TfLiteType data_type, const TfLiteTensor* input, const TfLiteTensor* filter,
+    const TfLiteTensor* bias, TfLiteTensor* output,
+    OpDataFullyConnected* data) {
+  if (data_type != kTfLiteFloat32) {
+    double real_multiplier = 0.0;
+    TF_LITE_ENSURE_STATUS(GetQuantizedConvolutionMultipler(
+        context, input, filter, bias, output, &real_multiplier));
+#if defined(HIFIMINI)
+    if (input->type == kTfLiteInt8 && filter->type == kTfLiteInt8) {
+      QuantizeMultiplierForInt24(real_multiplier, &data->output_multiplier,
+                                 &data->output_shift);
+    } else {
+      QuantizeMultiplier(real_multiplier, &data->output_multiplier,
+                         &data->output_shift);
+    }
+#else
+    QuantizeMultiplier(real_multiplier, &data->output_multiplier,
+                       &data->output_shift);
+#endif
+
+    // Filter weights will always be symmetric quantized since we only support
+    // int8 quantization. See
+    // https://github.com/tensorflow/tensorflow/issues/44912 for additional
+    // context.
+    TFLITE_DCHECK(filter->params.zero_point == 0);
+
+    data->input_zero_point = input->params.zero_point;
+    data->filter_zero_point = filter->params.zero_point;
+    data->output_zero_point = output->params.zero_point;
+
+    return CalculateActivationRangeQuantized(context, activation, output,
+                                             &data->output_activation_min,
+                                             &data->output_activation_max);
+  }
+  return kTfLiteOk;
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/fully_connected_int8.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/fully_connected_int8.cc
@@ -1,0 +1,99 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/integer_ops/fully_connected.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa_fully_connected.h"
+
+namespace tflite {
+
+TfLiteStatus XtensaEvalFullyConnectedQuantizedInt8(
+    TfLiteContext* context, TfLiteNode* node, const OpDataFullyConnected& data,
+    const TfLiteEvalTensor* input, const TfLiteEvalTensor* filter,
+    const TfLiteEvalTensor* bias, TfLiteEvalTensor* output) {
+#if !defined(VISION_P6)
+  const int32_t* bias_data =
+      tflite::micro::GetOptionalTensorData<int32_t>(bias);
+#endif  // !defined(VISION_P6)
+
+#if defined(HIFIMINI)
+  FullyConnectedEvalHifimini(FullyConnectedParamsQuantized(data),
+                             tflite::micro::GetTensorShape(input),
+                             tflite::micro::GetTensorData<int8_t>(input),
+                             tflite::micro::GetTensorShape(filter),
+                             tflite::micro::GetTensorData<int8_t>(filter),
+                             tflite::micro::GetTensorShape(bias), bias_data,
+                             tflite::micro::GetTensorShape(output),
+                             tflite::micro::GetTensorData<int8_t>(output));
+#elif defined(HIFI4) || defined(HIFI5)
+  const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+  const int num_batches =
+      FlatSizeSkipDim(output_shape, output_shape.DimensionsCount() - 1);
+  const int output_depth =
+      output_shape.Dims(output_shape.DimensionsCount() - 1);
+
+  const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
+  const int filter_dim_count = filter_shape.DimensionsCount();
+  const int accum_depth = filter_shape.Dims(filter_dim_count - 1);
+
+  FullyConnectedParams op_params = FullyConnectedParamsQuantized(data);
+  for (int b = 0; b < num_batches; ++b) {
+    TF_LITE_ENSURE_EQ(
+        context,
+        xa_nn_fully_connected_sym8sxasym8s_asym8s(
+            (tflite::micro::GetTensorData<int8_t>(output) + b * output_depth),
+            tflite::micro::GetTensorData<int8_t>(filter),
+            (tflite::micro::GetTensorData<int8_t>(input) + b * accum_depth),
+            bias_data, accum_depth, output_depth, op_params.input_offset,
+            op_params.output_multiplier, op_params.output_shift,
+            op_params.output_offset),
+        0);
+  }
+
+  int8_t* output_arr = tflite::micro::GetTensorData<int8_t>(output);
+  TF_LITE_ENSURE_EQ(context,
+                    xa_nn_vec_activation_min_max_8_8(
+                        output_arr, output_arr, data.output_activation_min,
+                        data.output_activation_max, num_batches * output_depth),
+                    0);
+#elif defined(VISION_P6)
+  const auto& params =
+      *(reinterpret_cast<TfLiteConvParams*>(node->builtin_data));
+  const auto& op_data =
+      *(reinterpret_cast<XtensaFullyConnectedOpData*>(node->user_data));
+  FullyConnectedEvalVision(context, node, params, op_data, input, filter, bias,
+                           output);
+#else
+  reference_integer_ops::FullyConnected(
+      FullyConnectedParamsQuantized(data), tflite::micro::GetTensorShape(input),
+      tflite::micro::GetTensorData<int8_t>(input),
+      tflite::micro::GetTensorShape(filter),
+      tflite::micro::GetTensorData<int8_t>(filter),
+      tflite::micro::GetTensorShape(bias), bias_data,
+      tflite::micro::GetTensorShape(output),
+      tflite::micro::GetTensorData<int8_t>(output));
+#endif  // defined(HIFI4) || defined(HIFI5)
+
+  return kTfLiteOk;
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_fully_connected.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_fully_connected.h
@@ -1,4 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/micro/kernels/fully_connected.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 struct XtensaFullyConnectedOpData {
@@ -55,6 +56,82 @@ TfLiteStatus FullyConnectedEvalVision(TfLiteContext* context, TfLiteNode* node,
                                       const TfLiteEvalTensor* bias,
                                       TfLiteEvalTensor* output);
 #endif  // VISION_P6
+
+void* XtensaInitFullyConnected(TfLiteContext* context, const char* buffer,
+                               size_t length);
+
+TfLiteStatus XtensaEvalFullyConnectedQuantizedInt8(
+    TfLiteContext* context, TfLiteNode* node, const OpDataFullyConnected& data,
+    const TfLiteEvalTensor* input, const TfLiteEvalTensor* filter,
+    const TfLiteEvalTensor* bias, TfLiteEvalTensor* output);
+
+TfLiteStatus XtensaCalculateOpDataFullyConnected(
+    TfLiteContext* context, TfLiteFusedActivation activation,
+    TfLiteType data_type, const TfLiteTensor* input, const TfLiteTensor* filter,
+    const TfLiteTensor* bias, TfLiteTensor* output, OpDataFullyConnected* data);
+
+template <TfLiteType T = kTfLiteVariant>
+TfLiteStatus XtensaPrepareFullyConnected(TfLiteContext* context,
+                                         TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  TFLITE_DCHECK(node->builtin_data != nullptr);
+
+  auto* data = static_cast<OpDataFullyConnected*>(node->user_data);
+  const auto params =
+      static_cast<const TfLiteFullyConnectedParams*>(node->builtin_data);
+
+  MicroContext* micro_context = GetMicroContext(context);
+
+  TfLiteTensor* input =
+      micro_context->AllocateTempInputTensor(node, kFullyConnectedInputTensor);
+  TF_LITE_ENSURE(context, input != nullptr);
+  TfLiteTensor* filter = micro_context->AllocateTempInputTensor(
+      node, kFullyConnectedWeightsTensor);
+  TF_LITE_ENSURE(context, filter != nullptr);
+  TfLiteTensor* bias =
+      micro_context->AllocateTempInputTensor(node, kFullyConnectedBiasTensor);
+  TfLiteTensor* output = micro_context->AllocateTempOutputTensor(
+      node, kFullyConnectedOutputTensor);
+  TF_LITE_ENSURE(context, output != nullptr);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
+
+  if (kTfLiteInt8 == T) {
+    if (input->type != kTfLiteInt8) {
+      MicroPrintf("Type %s (%d) not supported.", TfLiteTypeGetName(input->type),
+                  input->type);
+      return kTfLiteError;
+    }
+  }
+
+  if (filter->type == kTfLiteInt4) {
+    int filter_size =
+        RuntimeShape(filter->dims->size,
+                     reinterpret_cast<const int32_t*>(filter->dims->data))
+            .FlatSize();
+    context->RequestScratchBufferInArena(context, filter_size,
+                                         &data->filter_buffer_index);
+  }
+
+  TFLITE_DCHECK_GE(GetTensorShape(output).DimensionsCount(), 1);
+
+  TF_LITE_ENSURE_OK(context, XtensaCalculateOpDataFullyConnected(
+                                 context, params->activation, input->type,
+                                 input, filter, bias, output, data));
+
+  micro_context->DeallocateTempTfLiteTensor(input);
+  micro_context->DeallocateTempTfLiteTensor(filter);
+  if (bias != nullptr) {
+    micro_context->DeallocateTempTfLiteTensor(bias);
+  }
+  micro_context->DeallocateTempTfLiteTensor(output);
+#if defined(VISION_P6)
+  if (input->type == kTfLiteInt8 && filter->type == kTfLiteInt8) {
+    TF_LITE_ENSURE_OK(context, FullyConnectedPrepareVision(context, node));
+  }
+#endif  // VISION_P6
+
+  return kTfLiteOk;
+}
 
 }  // namespace tflite
 

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -8,6 +8,8 @@ MICROLITE_CC_KERNEL_SRCS += \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_vision.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_common_xtensa.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_int8.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_vision.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/pad_vision.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/pooling_vision.cc \


### PR DESCRIPTION
This commit demonstrates an issue with the Xtensa toolchain, where the linker allows dead code in the fully linked application.

This PR does not represent production code, and may differ significantly from  the tflite-micro main branch.

This PR has modified the Xtensa optimized code for the `FULLY_CONNECTED` kernel operator, such that reference implementations are available for all non-INT8 input tensors.  The `keyword_benchmark` application uses the `FULLY_CONNECTED` kernel operator and registers usage for only the INT8 version. Checking the size of the code segment of the application, we see an increase of approx. 2Kbytes for HIFI4 and 3Kbytes for P6 compiles.  This is due to dead code being included in the fully linked application.

The failure to remove dead code occurs when using inlines and/or templates, and varies according to the compiler optimization level used:

- Code with an inline attribute and which the compiler decides not to inline, and the inline code is used within an unused method the linker does discard
- Template code instantiated within an unused method, the unused method being discarded by the linker

Dead code as a result of the inline attribute is created at optimization levels 2 and 3 (-O2, -O3).  For templates, this occurs at optimization levels 0 and 1.

The `keyword_benchamrk` application was created for P6 with this command: `make -f ${TENSORFLOW_ROOT}tensorflow/lite/micro/tools/make/Makefile   TARGET=xtensa   TARGET_ARCH=vision_p6   OPTIMIZED_KERNEL_DIR=xtensa   XTENSA_CORE=P6_200528   TENSORFLOW_ROOT=${TENSORFLOW_ROOT}   BUILD_TYPE= keyword_benchmark -j$(nproc)`

For HIFI4 this command was used: `make -f ${TENSORFLOW_ROOT}tensorflow/lite/micro/tools/make/Makefile   TARGET=xtensa   TARGET_ARCH=hifi4   OPTIMIZED_KERNEL_DIR=xtensa   XTENSA_CORE=F1_190305_swupgrade   TENSORFLOW_ROOT=${TENSORFLOW_ROOT}   BUILD_TYPE= keyword_benchmark -j$(nproc)`

The `xt-clang++` version: `XtensaTools-14.04 clang version 6.0.1  (based on LLVM 6.0.1)`

The attached zip file contains a simplified application and shell script to build the application.  This will also demonstrate the dead code issue.  In the simplified application `__attribute__((weak))` is used to simulate inline code the compiler has chosen not to inline.  The following command is an example of how to build the simplified application: `COMP=xt-clang++ OPTIM=-O2 ./test_weak.sh`

Examining the symbol table of the simplified application will show either `weak_foo_func` or `template_foo_func` as dead code depending on the optimization level given to the compiler.  The x86 g++ and clang++ compilers were also tested, and did not demonstrate the issue.  The x86 compiler versions:

- g++: ` (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0`
- clang++: `6.0.0-1ubuntu2 (tags/RELEASE_600/final)`

[xtensa-linker-issue.zip](https://github.com/tensorflow/tflite-micro/files/10727645/xtensa-linker-issue.zip)

The zip file also contains the symbol table output of `xt-objdump` for the `keyword_benchmark` application.  The following methods appear in the symbol table (and in disassembler output):

1. `tflite::reference_integer_ops::FullyConnected<long long>(tflite::FullyConnectedParams const&, tflite::RuntimeShape const&, short const*, tflite::RuntimeShape const&, signed char const*, tflite::RuntimeShape const&, long long const*, tflite::RuntimeShape const&, short*)`
2. `tflite::reference_ops::FullyConnected(tflite::FullyConnectedParams const&, tflite::RuntimeShape const&, float const*, tflite::RuntimeShape const&, float const*, tflite::RuntimeShape const&, float const*, tflite::RuntimeShape const&, float*)`
3. `tflite::reference_integer_ops::FullyConnected(tflite::FullyConnectedParams const&, tflite::RuntimeShape const&, signed char const*, tflite::RuntimeShape const&, signed char const*, tflite::RuntimeShape const&, int const*, tflite::RuntimeShape const&, signed char*))`

The first and second methods are dead code and when examined using the `xt-objdump` disassembler, are not called.  The third method correctly appears in the `keyword_benchmark` application, as the application only uses the INT8 kernel operator code.

Compiler options `-ffunction-sections -fdata-sections` and linker option `--gc-sections` were used for all testing.
