### PR TITLE
Match name change in upstream (http://cl/510336249)

### DIFF
--- a/tensorflow/lite/kernels/internal/BUILD
+++ b/tensorflow/lite/kernels/internal/BUILD
@@ -139,7 +139,7 @@ cc_library(
 )
 
 cc_library(
-    name = "tensor_utils",
+    name = "tensor_utils_no_eigen",
     srcs = [
         "portable_tensor_utils.cc",
         "reference/portable_tensor_utils.cc",

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -114,7 +114,7 @@ cc_library(
     deps = [
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/kernels/internal:compatibility",
-        "//tensorflow/lite/kernels/internal:tensor_utils",
+        "//tensorflow/lite/kernels/internal:tensor_utils_no_eigen",
         "//tensorflow/lite/kernels/internal:types",
         "//tensorflow/lite/micro:debug_log",
         "//tensorflow/lite/micro:micro_context",
@@ -155,7 +155,7 @@ cc_library(
         "//tensorflow/lite/kernels/internal:common",
         "//tensorflow/lite/kernels/internal:compatibility",
         "//tensorflow/lite/kernels/internal:cppmath",
-        "//tensorflow/lite/kernels/internal:tensor_utils",
+        "//tensorflow/lite/kernels/internal:tensor_utils_no_eigen",
     ],
 )
 
@@ -326,7 +326,7 @@ tflm_kernel_cc_library(
     ],
     deps = [
         ":micro_tensor_utils",
-        "//tensorflow/lite/kernels/internal:tensor_utils",
+        "//tensorflow/lite/kernels/internal:tensor_utils_no_eigen",
         ":activation_utils",
         ":kernel_util",
         "//tensorflow/lite/c:common",


### PR DESCRIPTION
The reason for this name change is to allow for a BUILD target in upstream TF Lite as well that explicitly avoids pulling in Eigen headers.

Also, update the existing dependencies on `tensor_utils` to the updated `tensor_utils_no_eigen`.

BUG=http://b/269699951
