### PR TITLE
Optimized kernel reference fallbacks: SVDF

### DIFF
--- a/tensorflow/lite/micro/kernels/svdf.cc
+++ b/tensorflow/lite/micro/kernels/svdf.cc
@@ -48,7 +48,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       tflite::micro::GetEvalInput(context, node, kSvdfWeightsFeatureTensor);
   const TfLiteEvalTensor* weights_time =
       tflite::micro::GetEvalInput(context, node, kSvdfWeightsTimeTensor);
-  // TODO(tflite-micro#1751) account for optional bias tensor
+  // TODO(#1751): account for optional bias tensor
   const TfLiteEvalTensor* bias =
       (NumInputs(node) == 5)
           ? tflite::micro::GetEvalInput(context, node, kSvdfBiasTensor)

--- a/tensorflow/lite/micro/kernels/svdf.cc
+++ b/tensorflow/lite/micro/kernels/svdf.cc
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       tflite::micro::GetEvalInput(context, node, kSvdfWeightsFeatureTensor);
   const TfLiteEvalTensor* weights_time =
       tflite::micro::GetEvalInput(context, node, kSvdfWeightsTimeTensor);
+  // TODO(tflite-micro#1751) account for optional bias tensor
   const TfLiteEvalTensor* bias =
       (NumInputs(node) == 5)
           ? tflite::micro::GetEvalInput(context, node, kSvdfBiasTensor)
@@ -62,7 +63,6 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       EvalFloatSvdfReference(
           context, node, input, weights_feature, weights_time, bias, params,
           data.scratch_tensor_index, activation_state, output);
-      return kTfLiteOk;
       break;
     }
 
@@ -72,14 +72,12 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           EvalInt16SvdfReference(context, node, input, weights_feature,
                                  weights_time, bias, params, activation_state,
                                  output, data);
-          return kTfLiteOk;
           break;
         }
         case kTfLiteInt8: {
           EvalInt8SvdfReference(context, node, input, weights_feature,
                                 weights_time, bias, params, activation_state,
                                 output, data);
-          return kTfLiteOk;
           break;
         }
         default:
@@ -87,6 +85,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                       TfLiteTypeGetName(weights_time->type));
           return kTfLiteError;
       }
+      break;
     }
 
     default:

--- a/tensorflow/lite/micro/kernels/svdf.h
+++ b/tensorflow/lite/micro/kernels/svdf.h
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -82,7 +82,8 @@ TfLiteStatus PrepareSvdf(TfLiteContext* context, TfLiteNode* node);
 // implementation (reference or optimized) must define this function.
 TfLiteRegistration_V1 Register_SVDF();
 
-#if defined(HEXAGON) || defined(CMSIS_NN)
+#if defined(HEXAGON) || defined(CMSIS_NN) || defined(XTENSA)
+
 TfLiteRegistration_V1 Register_SVDF_INT8();
 
 #else

--- a/tensorflow/lite/micro/kernels/svdf_common.cc
+++ b/tensorflow/lite/micro/kernels/svdf_common.cc
@@ -303,7 +303,7 @@ void EvalFloatSvdfReference(
       tflite::micro::GetTensorData<float>(weights_feature);
   const float* weights_time_ptr =
       tflite::micro::GetTensorData<float>(weights_time);
-  // TODO(tflite-micro#1751) account for optional bias tensor
+  // TODO(#1751): account for optional bias tensor
   const float* bias_ptr = tflite::micro::GetTensorData<float>(bias);
   const float* input_ptr = tflite::micro::GetTensorData<float>(input);
 
@@ -460,7 +460,7 @@ TfLiteStatus PrepareSvdf(TfLiteContext* context, TfLiteNode* node) {
                             weights_time->params.scale / output->params.scale);
 
     // TODO(b/162018098): Use TF_LITE_ENSURE_NEAR when it is ready.
-    // TODO(tflite-micro#1751) account for optional bias tensor
+    // TODO(#1751): account for optional bias tensor
     TF_LITE_ENSURE(
         context,
         std::abs(static_cast<double>(bias->params.scale) -
@@ -509,7 +509,7 @@ TfLiteStatus PrepareSvdf(TfLiteContext* context, TfLiteNode* node) {
   micro_context->DeallocateTempTfLiteTensor(weights_time);
   micro_context->DeallocateTempTfLiteTensor(activation_state);
   micro_context->DeallocateTempTfLiteTensor(output);
-  // TODO(tflite-micro#1751) account for optional bias tensor
+  // TODO(#1751): account for optional bias tensor
   micro_context->DeallocateTempTfLiteTensor(bias);
   return kTfLiteOk;
 }

--- a/tensorflow/lite/micro/kernels/svdf_common.cc
+++ b/tensorflow/lite/micro/kernels/svdf_common.cc
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -303,6 +303,7 @@ void EvalFloatSvdfReference(
       tflite::micro::GetTensorData<float>(weights_feature);
   const float* weights_time_ptr =
       tflite::micro::GetTensorData<float>(weights_time);
+  // TODO(tflite-micro#1751) account for optional bias tensor
   const float* bias_ptr = tflite::micro::GetTensorData<float>(bias);
   const float* input_ptr = tflite::micro::GetTensorData<float>(input);
 
@@ -459,6 +460,7 @@ TfLiteStatus PrepareSvdf(TfLiteContext* context, TfLiteNode* node) {
                             weights_time->params.scale / output->params.scale);
 
     // TODO(b/162018098): Use TF_LITE_ENSURE_NEAR when it is ready.
+    // TODO(tflite-micro#1751) account for optional bias tensor
     TF_LITE_ENSURE(
         context,
         std::abs(static_cast<double>(bias->params.scale) -
@@ -507,6 +509,7 @@ TfLiteStatus PrepareSvdf(TfLiteContext* context, TfLiteNode* node) {
   micro_context->DeallocateTempTfLiteTensor(weights_time);
   micro_context->DeallocateTempTfLiteTensor(activation_state);
   micro_context->DeallocateTempTfLiteTensor(output);
+  // TODO(tflite-micro#1751) account for optional bias tensor
   micro_context->DeallocateTempTfLiteTensor(bias);
   return kTfLiteOk;
 }

--- a/tensorflow/lite/micro/kernels/svdf_test.cc
+++ b/tensorflow/lite/micro/kernels/svdf_test.cc
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -535,7 +535,6 @@ void ValidateSVDFGoldens(const int batch_size, const int num_units,
   TF_LITE_MICRO_EXPECT(runner.ValidateTempBufferDeallocated());
 }
 
-#if !defined(XTENSA)  // Needed to avoid build errors from unused functions.
 void TestSVDF(const int batch_size, const int num_units, const int input_size,
               const int memory_size, const int rank,
               TfLiteFusedActivation activation, float* input_data,
@@ -582,7 +581,6 @@ void TestSVDF(const int batch_size, const int num_units, const int input_size,
                       input_sequences_len, output_data, expected_output,
                       tolerance);
 }
-#endif
 
 // The pattern to this method's arguemnts is:
 // <kernel metadata>
@@ -832,9 +830,6 @@ void SvdfQuantized1x16Input64x1OutputReluShouldMatchGolden() {
 
 TF_LITE_MICRO_TESTS_BEGIN
 
-#if !defined(XTENSA)  // TODO(b/170332589): xtensa kernels are less general than
-                      // reference kernels and we ifdef out test cases that are
-                      // currently known to fail.
 TF_LITE_MICRO_TEST(SvdfFloat2x2Input2x4OutputShouldMatchGolden) {
   constexpr int batch_size = 2;
   constexpr int num_units = 4;
@@ -869,10 +864,9 @@ TF_LITE_MICRO_TEST(SvdfFloat2x2Input2x4OutputShouldMatchGolden) {
       sizeof(tflite::testing::input_data_2x2x10) / sizeof(float),
       tflite::testing::golden_output_2x2x10);
 }
-#endif
 
 // Only reference kernels suport full int8 svdf currently.
-#if !(defined(XTENSA) || defined(HEXAGON))
+#if !defined(HEXAGON)
 TF_LITE_MICRO_TEST(SvdfQuantized2x2Input2x4OutputShouldMatchGoldenInt8) {
   tflite::testing::SvdfQuantized2x2Input2x4OutputShouldMatchGolden<int8_t>();
 }
@@ -882,9 +876,6 @@ TF_LITE_MICRO_TEST(SvdfQuantized2x2Input2x4OutputShouldMatchGoldenInt16) {
   tflite::testing::SvdfQuantized2x2Input2x4OutputShouldMatchGolden<int16_t>();
 }
 
-#if !defined(XTENSA)  // TODO(b/170332589): xtensa kernels are less general than
-                      // reference kernels and we ifdef out test cases that are
-                      // currently known to fail.
 TF_LITE_MICRO_TEST(SvdfFloat1x16Input64x1OutputShouldMatchGolden) {
   constexpr int batch_size = 1;
   constexpr int num_units = 64;
@@ -946,10 +937,9 @@ TF_LITE_MICRO_TEST(SvdfFloat1x16Input64x1OutputReluShouldMatchGolden) {
       tflite::testing::input_data_16x1x1, input_size,
       tflite::testing::golden_output_relu_16x1x1);
 }
-#endif
 
 // Only reference kernels suport full int8 svdf currently.
-#if !(defined(XTENSA) || defined(HEXAGON))
+#if !defined(HEXAGON)
 TF_LITE_MICRO_TEST(SvdfQuantized1x16Input64x1OutputShouldMatchGoldenInt8) {
   tflite::testing::SvdfQuantized1x16Input64x1OutputShouldMatchGolden<int8_t>();
 }
@@ -960,7 +950,7 @@ TF_LITE_MICRO_TEST(SvdfQuantized1x16Input64x1OutputShouldMatchGoldenInt16) {
 }
 
 // Only reference kernels suport full int8 svdf currently.
-#if !(defined(XTENSA) || defined(HEXAGON))
+#if !defined(HEXAGON)
 TF_LITE_MICRO_TEST(SvdfQuantized1x16Input64x1OutputReluShouldMatchGoldenInt8) {
   tflite::testing::SvdfQuantized1x16Input64x1OutputReluShouldMatchGolden<
       int8_t>();


### PR DESCRIPTION
@tensorflow/micro

Remove conditional compilation for kernel tests for the following platforms: Xtensa
Add optimized kernel reference fallback code for the following platforms: Xtensa

The following table shows the size changes for each benchmark binary as a result of this PR:
| Platform | Benchmark | Build | Text | Data | BSS |
| --- | --- | --- | --- | --- | --- |
| hifi4 | keyword | default | -8 | +32 | 0 |
| hifi5 | keyword | default | 0 | +48 | 0 |
| p6 | keyword | default | -3072 | 0 | 0 |
| hifi4 | person detection | default | 0 | 0 | 0 |
| hifi5 | person detection | default | 0 | 0 | 0 |
| p6 | person detection | default | 0 | 0 | 0 |

bug=fixes #1758 
