### PR TITLE
Optimized kernel reference fallbacks: MAX_POOL_2D et al

### DIFF
--- a/tensorflow/lite/micro/benchmarks/person_detection_benchmark.cc
+++ b/tensorflow/lite/micro/benchmarks/person_detection_benchmark.cc
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ PersonDetectionBenchmarkRunner* CreateBenchmarkRunner(MicroProfiler* profiler) {
   op_resolver->AddConv2D(tflite::Register_CONV_2D_INT8REF());
   op_resolver->AddDepthwiseConv2D();
   op_resolver->AddSoftmax();
-  op_resolver->AddAveragePool2D();
+  op_resolver->AddAveragePool2D(tflite::Register_AVERAGE_POOL_2D_INT8());
   op_resolver->AddReshape();
   return new (benchmark_runner_buffer)
       PersonDetectionBenchmarkRunner(g_person_detect_model_data, op_resolver,

--- a/tensorflow/lite/micro/kernels/pooling.h
+++ b/tensorflow/lite/micro/kernels/pooling.h
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ void MaxPoolingEvalQuantized(TfLiteContext* context, TfLiteNode* node,
                                  tflite::micro::GetTensorData<T>(output));
 }
 
-#if defined(CMSIS_NN)
+#if defined(CMSIS_NN) || defined(XTENSA)
 TfLiteRegistration Register_AVERAGE_POOL_2D_INT8();
 
 TfLiteRegistration Register_MAX_POOL_2D_INT8();

--- a/tensorflow/lite/micro/kernels/pooling_test.cc
+++ b/tensorflow/lite/micro/kernels/pooling_test.cc
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -305,7 +305,6 @@ TF_LITE_MICRO_TEST(SimpleAveragePoolTestInt8PaddingSameStride1ActNone) {
       output_data);
 }
 
-#if !defined(XTENSA)
 TF_LITE_MICRO_TEST(SimpleAveragePoolTestInt16PaddingValidStride2ActNone) {
   int input_shape[] = {4, 1, 2, 4, 1};
   const int16_t input_values[] = {0, -24, 8, 16, 12, 8, -40, 28};
@@ -416,7 +415,6 @@ TF_LITE_MICRO_TEST(SimpleAveragePoolTestInt16PaddingSameStride1ActNone) {
       output_scale, output_zero_point, kTfLitePaddingValid, kTfLiteActNone,
       output_data);
 }
-#endif
 
 TF_LITE_MICRO_TEST(SimpleMaxPoolTestFloat) {
   int input_shape[] = {4, 1, 2, 4, 1};
@@ -616,7 +614,6 @@ TF_LITE_MICRO_TEST(MaxPoolTestInt8ActRelu6) {
       output_data);
 }
 
-#if !defined(XTENSA)
 TF_LITE_MICRO_TEST(SimpleMaxPoolTestInt16ActNone) {
   int input_shape[] = {4, 1, 2, 4, 1};
   const int16_t input_values1[] = {0, 6, 2, 4, 3, 2, 10, 7};
@@ -704,6 +701,5 @@ TF_LITE_MICRO_TEST(MaxPoolTestInt16ActRelu6) {
       output_scale, output_zero_point, kTfLitePaddingValid, kTfLiteActRelu6,
       output_data);
 }
-#endif
 
 TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/kernels/xtensa/pooling_int8.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/pooling_int8.cc
@@ -1,0 +1,338 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/pooling.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa_pooling.h"
+#include "tensorflow/lite/micro/micro_log.h"
+
+namespace tflite {
+
+#if defined(HIFI5)
+
+TfLiteStatus AveragePrepareHifi(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_STATUS(PoolingPrepare(context, node));
+  MicroContext* micro_context = GetMicroContext(context);
+  TfLiteTensor* input =
+      micro_context->AllocateTempInputTensor(node, kPoolingInputTensor);
+
+  if (input->type == kTfLiteInt8) {
+    const RuntimeShape& input_shape = GetTensorShape(input);
+    TfLiteTensor* output =
+        micro_context->AllocateTempInputTensor(node, kPoolingOutputTensor);
+    const RuntimeShape& output_shape = GetTensorShape(output);
+    micro_context->DeallocateTempTfLiteTensor(output);
+
+    const int depth = MatchingDim(input_shape, 3, output_shape, 3);
+    const int input_height = input_shape.Dims(1);
+    const int input_width = input_shape.Dims(2);
+    const int output_height = output_shape.Dims(1);
+    const int output_width = output_shape.Dims(2);
+
+    auto* params = reinterpret_cast<TfLitePoolParams*>(node->builtin_data);
+    auto* data = static_cast<XtensaOpDataPooling*>(node->user_data);
+
+    int required_scratch = xa_nn_avgpool_getsize(
+        depth, PREC_8, PREC_8, input_height, input_width, params->filter_height,
+        params->filter_width,
+        params->stride_width,                    // x_stride,
+        params->stride_height,                   // y_stride,
+        data->reference_op_data.padding.width,   // x_padding,
+        data->reference_op_data.padding.height,  // y_padding,
+        output_height, output_width, 0 /*NHWC input */, 0 /* NHWC output */);
+
+    if (required_scratch <= 0) {
+      MicroPrintf("Averagepool: xa_nn_avgpool_getsize failed");
+      return kTfLiteError;
+    }
+
+    TF_LITE_ENSURE_STATUS(context->RequestScratchBufferInArena(
+        context, required_scratch, &(data->scratch_tensor_index)));
+  }
+
+  micro_context->DeallocateTempTfLiteTensor(input);
+  return kTfLiteOk;
+}
+
+TfLiteStatus AverageEvalQuantizedHifi(TfLiteContext* context,
+                                      const TfLiteNode* node,
+                                      const TfLitePoolParams* params,
+                                      const XtensaOpDataPooling* data,
+                                      const TfLiteEvalTensor* input,
+                                      TfLiteEvalTensor* output) {
+  TFLITE_DCHECK(input->type == kTfLiteInt8);
+
+  const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+  const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+  const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+  const int depth = MatchingDim(input_shape, 3, output_shape, 3);
+  const int input_height = input_shape.Dims(1);
+  const int input_width = input_shape.Dims(2);
+  const int output_height = output_shape.Dims(1);
+  const int output_width = output_shape.Dims(2);
+
+  void* p_scratch = static_cast<void*>(
+      context->GetScratchBuffer(context, data->scratch_tensor_index));
+
+  const int8_t* inp_data_ptr = tflite::micro::GetTensorData<int8_t>(input);
+  int8_t* out_data_ptr = tflite::micro::GetTensorData<int8_t>(output);
+
+  for (int batch = 0; batch < batches; ++batch) {
+    TF_LITE_ENSURE_EQ(
+        context,
+        xa_nn_avgpool_8(
+            &out_data_ptr[output_height * output_width * depth * batch],
+            const_cast<int8_t*>(
+                &inp_data_ptr[output_height * output_width * depth * batch]),
+            input_height, input_width, depth, params->filter_height,
+            params->filter_width, params->stride_width, params->stride_height,
+            data->reference_op_data.padding.width,
+            data->reference_op_data.padding.height, output_height, output_width,
+            0, 0, p_scratch),
+        0);
+  }
+
+  const int out_length = batches * output_height * output_width * depth;
+  TF_LITE_ENSURE_EQ(
+      context,
+      xa_nn_vec_activation_min_max_8_8(
+          out_data_ptr, out_data_ptr, data->reference_op_data.activation_min,
+          data->reference_op_data.activation_max, out_length),
+      0);
+
+  return kTfLiteOk;
+}
+
+TfLiteStatus MaxPrepareHifi(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_STATUS(PoolingPrepare(context, node));
+
+  MicroContext* micro_context = GetMicroContext(context);
+
+  TfLiteTensor* input =
+      micro_context->AllocateTempInputTensor(node, kPoolingInputTensor);
+
+  if (input->type == kTfLiteInt8) {
+    auto* params = reinterpret_cast<TfLitePoolParams*>(node->builtin_data);
+    auto* data = static_cast<XtensaOpDataPooling*>(node->user_data);
+
+    const RuntimeShape& input_shape = GetTensorShape(input);
+    TfLiteTensor* output =
+        micro_context->AllocateTempOutputTensor(node, kPoolingOutputTensor);
+    const RuntimeShape& output_shape = GetTensorShape(output);
+    micro_context->DeallocateTempTfLiteTensor(output);
+
+    const int depth = MatchingDim(input_shape, 3, output_shape, 3);
+    const int input_height = input_shape.Dims(1);
+    const int input_width = input_shape.Dims(2);
+    const int output_height = output_shape.Dims(1);
+    const int output_width = output_shape.Dims(2);
+
+    int required_scratch = xa_nn_maxpool_getsize(
+        depth, PREC_8, PREC_8, input_height, input_width, params->filter_height,
+        params->filter_width,
+        params->stride_width,                    // x_stride,
+        params->stride_height,                   // y_stride,
+        data->reference_op_data.padding.width,   // x_padding,
+        data->reference_op_data.padding.height,  // y_padding,
+        output_height, output_width, 0 /* NHWC inpput */, 0 /* NHWC output */);
+
+    if (required_scratch <= 0) {
+      MicroPrintf("Maxpool: xa_nn_maxpool_getsize failed");
+      return kTfLiteError;
+    }
+
+    TF_LITE_ENSURE_STATUS(context->RequestScratchBufferInArena(
+        context, required_scratch, &(data->scratch_tensor_index)));
+  }
+
+  micro_context->DeallocateTempTfLiteTensor(input);
+  return kTfLiteOk;
+}
+
+TfLiteStatus MaxEvalQuantizedHifi(TfLiteContext* context, TfLiteNode* node,
+                                  TfLitePoolParams* params,
+                                  const XtensaOpDataPooling* data,
+                                  const TfLiteEvalTensor* input,
+                                  TfLiteEvalTensor* output) {
+  const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+  const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+  const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+  const int depth = MatchingDim(input_shape, 3, output_shape, 3);
+  const int input_height = input_shape.Dims(1);
+  const int input_width = input_shape.Dims(2);
+  const int output_height = output_shape.Dims(1);
+  const int output_width = output_shape.Dims(2);
+
+  void* p_scratch = static_cast<void*>(
+      context->GetScratchBuffer(context, data->scratch_tensor_index));
+
+  const int8_t* inp_data_ptr = tflite::micro::GetTensorData<int8_t>(input);
+  int8_t* out_data_ptr = tflite::micro::GetTensorData<int8_t>(output);
+
+  for (int batch = 0; batch < batches; ++batch) {
+    TF_LITE_ENSURE_EQ(
+        context,
+        xa_nn_maxpool_8(
+            &out_data_ptr[output_height * output_width * depth * batch],
+            const_cast<int8_t*>(
+                &inp_data_ptr[output_height * output_width * depth * batch]),
+            input_height, input_width, depth, params->filter_height,
+            params->filter_width, params->stride_width, params->stride_height,
+            data->reference_op_data.padding.width,
+            data->reference_op_data.padding.height, output_height, output_width,
+            0, 0, p_scratch),
+        0);
+  }
+
+  const int out_length = batches * output_height * output_width * depth;
+  TF_LITE_ENSURE_EQ(
+      context,
+      xa_nn_vec_activation_min_max_8_8(
+          out_data_ptr, out_data_ptr, data->reference_op_data.activation_min,
+          data->reference_op_data.activation_max, out_length),
+      0);
+
+  return kTfLiteOk;
+}
+
+#endif  // defined(HIFI5)
+
+namespace {
+
+TfLiteStatus AverageEvalInt8(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->builtin_data != nullptr);
+  auto* params = reinterpret_cast<TfLitePoolParams*>(node->builtin_data);
+
+  TFLITE_DCHECK(node->user_data != nullptr);
+
+  const TfLiteEvalTensor* input =
+      micro::GetEvalInput(context, node, kPoolingInputTensor);
+  TfLiteEvalTensor* output =
+      micro::GetEvalOutput(context, node, kPoolingOutputTensor);
+
+  // Inputs and outputs share the same type, guaranteed by the converter.
+  switch (input->type) {
+    case kTfLiteInt8: {
+#if defined(HIFI5)
+      auto* op_data = static_cast<const XtensaOpDataPooling*>(node->user_data);
+      AverageEvalQuantizedHifi(context, node, params, op_data, input, output);
+#elif defined(VISION_P6)
+      const auto& op_data =
+          *(reinterpret_cast<XtensaOpDataPooling*>(node->user_data));
+      PoolEvalVision(context, node, *params, op_data, input, output);
+#else
+      const OpDataPooling* reference_op_data =
+          static_cast<const OpDataPooling*>(node->user_data);
+      AveragePoolingEvalQuantized<int8_t>(context, node, params,
+                                          reference_op_data, input, output);
+#endif
+      break;
+    }
+    default: {
+      MicroPrintf("Input type %s is not currently supported",
+                  TfLiteTypeGetName(input->type));
+      return kTfLiteError;
+    }
+  }
+  return kTfLiteOk;
+}
+
+TfLiteStatus MaxEvalInt8(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->builtin_data != nullptr);
+  auto* params = reinterpret_cast<TfLitePoolParams*>(node->builtin_data);
+
+  TFLITE_DCHECK(node->user_data != nullptr);
+
+  const TfLiteEvalTensor* input =
+      micro::GetEvalInput(context, node, kPoolingInputTensor);
+  TfLiteEvalTensor* output =
+      micro::GetEvalOutput(context, node, kPoolingOutputTensor);
+
+  switch (input->type) {
+    case kTfLiteInt8: {
+#if defined(HIFI5)
+      auto* op_data = static_cast<const XtensaOpDataPooling*>(node->user_data);
+      MaxEvalQuantizedHifi(context, node, params, op_data, input, output);
+#elif defined(VISION_P6)
+      const auto& op_data =
+          *(reinterpret_cast<XtensaOpDataPooling*>(node->user_data));
+      PoolEvalVision(context, node, *params, op_data, input, output);
+#else
+      const OpDataPooling* reference_op_data =
+          static_cast<const OpDataPooling*>(node->user_data);
+      MaxPoolingEvalQuantized<int8_t>(context, node, params, reference_op_data,
+                                      input, output);
+#endif
+      break;
+    }
+    default: {
+      MicroPrintf("Type %s not currently supported.",
+                  TfLiteTypeGetName(input->type));
+      return kTfLiteError;
+    }
+  }
+  return kTfLiteOk;
+}
+
+}  // namespace
+
+void* XtensaPoolingInit(TfLiteContext* context, const char* buffer,
+                        size_t length) {
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+#if defined(HIFI5)
+  return context->AllocatePersistentBuffer(context,
+                                           sizeof(XtensaOpDataPooling));
+#elif defined(VISION_P6)
+  if (InitXtensaContext()) {
+    return nullptr;
+  }
+  return context->AllocatePersistentBuffer(context,
+                                           sizeof(XtensaOpDataPooling));
+#else
+  return context->AllocatePersistentBuffer(context, sizeof(OpDataPooling));
+#endif
+}
+
+TfLiteRegistration Register_AVERAGE_POOL_2D_INT8() {
+#if defined(HIFI5)
+  return tflite::micro::RegisterOp(XtensaPoolingInit, AveragePrepareHifi,
+                                   AverageEvalInt8);
+#elif defined(VISION_P6)
+  return tflite::micro::RegisterOp(XtensaPoolingInit, AvgPoolingPrepareVision,
+                                   AverageEvalInt8);
+#else
+  return tflite::micro::RegisterOp(XtensaPoolingInit, PoolingPrepare,
+                                   AverageEvalInt8);
+#endif
+}
+
+TfLiteRegistration Register_MAX_POOL_2D_INT8() {
+#if defined(HIFI5)
+  return tflite::micro::RegisterOp(XtensaPoolingInit, MaxPrepareHifi,
+                                   MaxEvalInt8);
+#elif defined(VISION_P6)
+  return tflite::micro::RegisterOp(XtensaPoolingInit, MaxPoolingPrepareVision,
+                                   MaxEvalInt8);
+#else
+  return tflite::micro::RegisterOp(XtensaPoolingInit, PoolingPrepare,
+                                   MaxEvalInt8);
+#endif
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/pooling_vision.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/pooling_vision.cc
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -46,41 +46,43 @@ TfLiteStatus PoolingPrepareVision(TfLiteContext* context, TfLiteNode* node,
       micro_context->AllocateTempInputTensor(node, kPoolingInputTensor);
   TF_LITE_ENSURE(context, input != nullptr);
 
-  uint32_t context_size = 0;
-  uint32_t status = xiPoolGetMemReqd_Context(&context_size);
-  TFLITE_DCHECK(status == 0);
-  if (context_size) {
-    void* context_data =
-        context->AllocatePersistentBuffer(context, context_size);
-    if (context_data == nullptr) {
+  if (input->type == kTfLiteInt8) {
+    uint32_t context_size = 0;
+    uint32_t status = xiPoolGetMemReqd_Context(&context_size);
+    TFLITE_DCHECK(status == 0);
+    if (context_size) {
+      void* context_data =
+          context->AllocatePersistentBuffer(context, context_size);
+      if (context_data == nullptr) {
+        return kTfLiteError;
+      }
+      data->p_context = reinterpret_cast<uint8_t*>(context_data);
+      data->context_size = context_size;
+    }
+
+    uint32_t input_dims[4] = {1, 1, 1, 1};
+    uint32_t output_dims[4] = {1, 1, 1, 1};
+    for (int i = 0; i < NumDimensions(input); i++) {
+      input_dims[i] =
+          std::max(1, SizeOfDimension(input, NumDimensions(input) - 1 - i));
+    }
+    for (int i = 0; i < NumDimensions(output); i++) {
+      output_dims[i] =
+          std::max(1, SizeOfDimension(output, NumDimensions(output) - 1 - i));
+    }
+
+    status = xiPoolSetContext(
+        data->p_context, data->context_size, input_dims[0], input_dims[1],
+        input_dims[2], input_dims[3], output_dims[0], output_dims[1],
+        output_dims[2], params.filter_width, params.filter_height,
+        params.stride_width, params.stride_height,
+        data->reference_op_data.padding.width,
+        data->reference_op_data.padding.height, input->params.zero_point,
+        output->params.zero_point, data->reference_op_data.activation_min,
+        data->reference_op_data.activation_max, pool_type);
+    if (status) {
       return kTfLiteError;
     }
-    data->p_context = reinterpret_cast<uint8_t*>(context_data);
-    data->context_size = context_size;
-  }
-
-  uint32_t input_dims[4] = {1, 1, 1, 1};
-  uint32_t output_dims[4] = {1, 1, 1, 1};
-  for (int i = 0; i < NumDimensions(input); i++) {
-    input_dims[i] =
-        std::max(1, SizeOfDimension(input, NumDimensions(input) - 1 - i));
-  }
-  for (int i = 0; i < NumDimensions(output); i++) {
-    output_dims[i] =
-        std::max(1, SizeOfDimension(output, NumDimensions(output) - 1 - i));
-  }
-
-  status = xiPoolSetContext(
-      data->p_context, data->context_size, input_dims[0], input_dims[1],
-      input_dims[2], input_dims[3], output_dims[0], output_dims[1],
-      output_dims[2], params.filter_width, params.filter_height,
-      params.stride_width, params.stride_height,
-      data->reference_op_data.padding.width,
-      data->reference_op_data.padding.height, input->params.zero_point,
-      output->params.zero_point, data->reference_op_data.activation_min,
-      data->reference_op_data.activation_max, pool_type);
-  if (status) {
-    return kTfLiteError;
   }
 
   micro_context->DeallocateTempTfLiteTensor(output);

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_pooling.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_pooling.h
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,10 +25,15 @@ namespace tflite {
 
 struct XtensaOpDataPooling {
   OpDataPooling reference_op_data;
+
 #if defined(VISION_P6)
   uint8_t* p_context;  // persistent lib context for this instance saved here
   uint32_t context_size;
-#endif  // VISION_P6
+#endif  // defined(VISION_P6)
+
+#if defined(HIFI5)
+  int scratch_tensor_index;
+#endif  // defined(HIFI5)
 };
 
 #if defined(VISION_P6)
@@ -43,6 +48,28 @@ TfLiteStatus PoolEvalVision(TfLiteContext* context, TfLiteNode* node,
                             const TfLiteEvalTensor* input,
                             TfLiteEvalTensor* output);
 #endif
+
+#if defined(HIFI5)
+
+TfLiteStatus AveragePrepareHifi(TfLiteContext* context, TfLiteNode* node);
+TfLiteStatus AverageEvalQuantizedHifi(TfLiteContext* context,
+                                      const TfLiteNode* node,
+                                      const TfLitePoolParams* params,
+                                      const XtensaOpDataPooling* data,
+                                      const TfLiteEvalTensor* input,
+                                      TfLiteEvalTensor* output);
+
+TfLiteStatus MaxPrepareHifi(TfLiteContext* context, TfLiteNode* node);
+TfLiteStatus MaxEvalQuantizedHifi(TfLiteContext* context, TfLiteNode* node,
+                                  TfLitePoolParams* params,
+                                  const XtensaOpDataPooling* data,
+                                  const TfLiteEvalTensor* input,
+                                  TfLiteEvalTensor* output);
+
+#endif  // defined(HIFI5)
+
+void* XtensaPoolingInit(TfLiteContext* context, const char* buffer,
+                        size_t length);
 
 }  // namespace tflite
 

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -12,6 +12,7 @@ MICROLITE_CC_KERNEL_SRCS += \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_int8.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_vision.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/pad_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/pooling_int8.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/pooling_vision.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/reduce_vision.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/reshape_vision.cc \


### PR DESCRIPTION
@tensorflow/micro

Remove conditional compilation for kernel tests for the following platforms: Xtensa
Add optimized kernel reference fallback code for the following platforms: Xtensa

Int8 code separated out to work around Xtensa linker issue that allows dead inline code (which the compiler refused to inline) to increase benchmark binary size. See PR #1739 for details.

The following table shows the size changes for each benchmark binary as a result of this PR:
| Platform | Benchmark | Build | Text | Data | BSS |
| --- | --- | --- | --- | --- | --- |
| hifi4 | keyword | default | 0 | 0 | 0 |
| hifi5 | keyword | default | 0 | 0 | 0 |
| p6 | keyword | default | 0 | 0 | 0 |
| hifi4 | person detection | default | -152 | 0 | 0 |
| hifi5 | person detection | default | -128 | +16 | 0 |
| p6 | person detection | default | -224 | 0 | 0 |

bug=fixes #1778