### PR TITLE
ci(bazel): test targets in all directories, not just t/l/m/...

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_bazel.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_bazel.sh
@@ -26,9 +26,9 @@ source tensorflow/lite/micro/tools/ci_build/helper_functions.sh
 # covers non-test binary targets as well. These were previousbly covered by
 # having build_test but that was removed with #194.
 
-CC=clang readable_run bazel build tensorflow/lite/micro/... \
+CC=clang readable_run bazel build ... \
   --build_tag_filters=-no_oss
-CC=clang readable_run bazel test tensorflow/lite/micro/... \
+CC=clang readable_run bazel test ... \
   --test_tag_filters=-no_oss --build_tag_filters=-no_oss \
   --test_output=errors
 


### PR DESCRIPTION
bazel test all rule targets in all packages, rather than only those beneath the directory tensorflow/lite/micro/. This prepares for the addition of test targets to packages in other directories such as python/.

BUG=see above