### PR TITLE
Bug fix: create_tflm_tree.py: error: unrecognized arguments: --output_dir .

### DIFF
--- a/tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py
+++ b/tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py
@@ -225,7 +225,7 @@ def _rename_cc_to_cpp(output_dir):
 def main():
   parser = argparse.ArgumentParser(
       description="Starting script for TFLM project generation")
-  parser.add_argument("output_dir",
+  parser.add_argument("--output_dir",
                       help="Output directory for generated TFLM tree")
   parser.add_argument("--no_copy",
                       action="store_true",


### PR DESCRIPTION
### **Issue :**
![image](https://user-images.githubusercontent.com/86905474/223228957-08125493-76f6-4f78-bf72-1ecca7cbd9c0.png)
while creating a TFLM project tree `using create_tflm_tree.py` script got error, **create_tflm_tree.py: error: unrecognized arguments: --output_dir**

### **Fixed :**
**`--` was missing in front of `output_dir` when adding `output_dir` command line argument in parser at line 228**. For this reason `output_dir` was not being recognised as a command line argument. Adding `--` in front of `output_dir` at line 228 solves this issue.

