### PR TITLE
Block slow tests for hifi5 and hifi3z.

### DIFF
--- a/tensorflow/lite/micro/examples/micro_speech/Makefile.inc
+++ b/tensorflow/lite/micro/examples/micro_speech/Makefile.inc
@@ -226,8 +226,10 @@ include $(wildcard $(TENSORFLOW_ROOT)tensorflow/lite/micro/examples/micro_speech
 CCFLAGS := $(filter-out $(CC_WARNINGS),$(CCFLAGS))
 
 # Test the code for feature generation.
-$(eval $(call microlite_test,micro_features_generator_test,\
-$(MICRO_FEATURES_GENERATOR_TEST_SRCS),$(MICRO_FEATURES_GENERATOR_TEST_HDRS),$(MICRO_SPEECH_GENERATOR_INPUTS)))
+ifneq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi5 hifi3z))
+  $(eval $(call microlite_test,micro_features_generator_test,\
+  $(MICRO_FEATURES_GENERATOR_TEST_SRCS),$(MICRO_FEATURES_GENERATOR_TEST_HDRS),$(MICRO_SPEECH_GENERATOR_INPUTS)))
+endif
 
 # Tests loading and running a speech model.
 $(eval $(call microlite_test,micro_speech_test,\
@@ -235,7 +237,7 @@ $(MICRO_SPEECH_TEST_SRCS),$(MICRO_SPEECH_TEST_HDRS),$(MICRO_SPEECH_GENERATOR_INP
 
 # TODO(b/268568089): This test is taking very long time to finish; causing the
 # CI to run for a long time to finish.
-ifneq ($(TARGET_ARCH), hifimini)
+ifneq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifimini hifi5 hifi3z))
   # Test the code for feature generation.
   $(eval $(call microlite_test,simple_features_generator_test,\
   $(SIMPLE_FEATURES_GENERATOR_TEST_SRCS),$(SIMPLE_FEATURES_GENERATOR_TEST_HDRS),$(MICRO_SPEECH_GENERATOR_INPUTS)))
@@ -250,12 +252,16 @@ $(eval $(call microlite_test,audio_provider_mock_test,\
 $(AUDIO_PROVIDER_MOCK_TEST_SRCS),$(AUDIO_PROVIDER_MOCK_TEST_HDRS),$(MICRO_SPEECH_GENERATOR_INPUTS)))
 
 # Tests the feature provider module.
-$(eval $(call microlite_test,feature_provider_test,\
-$(FEATURE_PROVIDER_TEST_SRCS),$(FEATURE_PROVIDER_TEST_HDRS)))
+ifneq ($(TARGET_ARCH), hifi3z)
+  $(eval $(call microlite_test,feature_provider_test,\
+  $(FEATURE_PROVIDER_TEST_SRCS),$(FEATURE_PROVIDER_TEST_HDRS)))
+endif
 
 # Tests the feature provider module using the mock audio provider.
-$(eval $(call microlite_test,feature_provider_mock_test,\
-$(FEATURE_PROVIDER_MOCK_TEST_SRCS),$(FEATURE_PROVIDER_MOCK_TEST_HDRS),$(MICRO_SPEECH_GENERATOR_INPUTS)))
+ifneq ($(TARGET_ARCH), hifi3z)
+  $(eval $(call microlite_test,feature_provider_mock_test,\
+  $(FEATURE_PROVIDER_MOCK_TEST_SRCS),$(FEATURE_PROVIDER_MOCK_TEST_HDRS),$(MICRO_SPEECH_GENERATOR_INPUTS)))
+endif
 
 # Tests the command recognizer module.
 $(eval $(call microlite_test,recognize_commands_test,\

--- a/tensorflow/lite/micro/examples/person_detection/Makefile.inc
+++ b/tensorflow/lite/micro/examples/person_detection/Makefile.inc
@@ -56,7 +56,7 @@ include $(wildcard $(TENSORFLOW_ROOT)tensorflow/lite/micro/examples/person_detec
 
 # TODO(b/268568089): This test is taking very long time to finish; causing the
 # CI to run for a long time to finish.
-ifneq ($(TARGET_ARCH), hifimini)
+ifneq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifimini hifi3z))
   # Tests loading and running a vision model.
   $(eval $(call microlite_test,person_detection_test,\
   $(person_detection_TEST_SRCS),$(person_detection_TEST_HDRS),$(person_detection_GENERATOR_INPUTS)))

--- a/third_party/xtensa/examples/pytorch_to_tflite/Makefile.inc
+++ b/third_party/xtensa/examples/pytorch_to_tflite/Makefile.inc
@@ -11,7 +11,9 @@ ifeq ($(OPTIMIZED_KERNEL_DIR), xtensa)
     $(TENSORFLOW_ROOT)third_party/xtensa/examples/$(EXAMPLE_NAME)/pytorch_images_dog_jpg.h
 
    ## Tests loading and running a mobilenet v2 model.
-   $(eval $(call microlite_test,pytorch_to_tflite_test,\
-   $(PYTORCH_TO_TFLITE_TEST_SRCS),$(PYTORCH_TO_TFLITE_HDRS),$(PYTORCH_TO_TFLITE_GENERATOR_INPUTS)))
+   ifneq ($(TARGET_ARCH), hifi5)
+     $(eval $(call microlite_test,pytorch_to_tflite_test,\
+     $(PYTORCH_TO_TFLITE_TEST_SRCS),$(PYTORCH_TO_TFLITE_HDRS),$(PYTORCH_TO_TFLITE_GENERATOR_INPUTS)))
+   endif
 endif
 


### PR DESCRIPTION
We need to block the following tests as they are making the CI test pipeline to be very slow.

The following tests are taking much longed in `hifi3z`.
```
feature_provider_mock_test	20.291s
feature_provider_test	20.877s
person_detection_test	21.654s
micro_features_generator_test	33.685s
simple_features_generator_test	129.49s
```

The following tests are taking much longed in `hifi5`
```
micro_features_generator_test	11.8s
simple_features_generator_test	98.411s
pytorch_to_tflite_test	173.542s
```
BUG=http://b/273538414