### PR TITLE
changed to pull_request_target to allow git command to tty

### DIFF
--- a/.github/workflows/tests_post.yml
+++ b/.github/workflows/tests_post.yml
@@ -4,7 +4,7 @@ name: Post Tests
 # issue against the PR/commit so will be caught.
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 


### PR DESCRIPTION
post-merge.yml is failing due to the git commands there not being able to get a tty. I think this is because this needs a pull_request_target trigger instead of pull_request. 