### PR TITLE
Adding stale handling to Issues and PRs.

### DIFF
--- a/.github/workflows/stale_handler.yml
+++ b/.github/workflows/stale_handler.yml
@@ -1,0 +1,30 @@
+name: 'Stale Handler'
+# This workflow will create a message and add a 'stale' tag to PRs and Issues.
+# This will happen after 40 days for both Issues and PRs.
+# For issues only, five days after the stale tag has been added,
+# the issue will be closed. 
+on:
+  schedule:
+    - cron: '0 10 * * *'
+  
+  workflow_dispatch: {}
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v7
+        with:
+          stale-issue-message: >
+            "This issue is stale. It has been open 40
+            days with no activity. Remove the stale label or
+            comment or this will be closed in 5 days"
+          stale-pr-message: >
+            "This PR is stale. It has been open 40 days
+             with no activity."
+          close-issue-message: >
+            "This issue was closed because it has been 
+            stalled for 5 days with no activity."
+          days-before-stale: 40
+          days-before-close: 5
+          days-before-pr-close: -1

--- a/.github/workflows/stale_handler.yml
+++ b/.github/workflows/stale_handler.yml
@@ -1,12 +1,8 @@
 name: 'Stale Handler'
-# This workflow will create a message and add a 'stale' tag to PRs and Issues.
-# This will happen after 40 days for both Issues and PRs.
-# For issues only, five days after the stale tag has been added,
-# the issue will be closed. 
 on:
   schedule:
     - cron: '0 10 * * *'
-  
+
   workflow_dispatch: {}
 
 jobs:
@@ -16,15 +12,16 @@ jobs:
       - uses: actions/stale@v7
         with:
           stale-issue-message: >
-            "This issue is stale. It has been open 40
-            days with no activity. Remove the stale label or
-            comment or this will be closed in 5 days"
+            "This issue is being marked as stale due to inactivity."
           stale-pr-message: >
-            "This PR is stale. It has been open 40 days
-             with no activity."
+            "This PR is being marked as stale due to inactivity."
           close-issue-message: >
-            "This issue was closed because it has been 
-            stalled for 5 days with no activity."
-          days-before-stale: 40
-          days-before-close: 5
-          days-before-pr-close: -1
+            "This issue is being closed because it has been marked as
+             stale for 5 days with no further activity."
+          close-pr-message: >
+            "This PR is being closed because it has been marked as
+             stale for 5 days with no further activity."
+          days-before-issue-stale: 25
+          days-before-issue-close: 5
+          days-before-pr-stale: 40
+          days-before-pr-close: 5


### PR DESCRIPTION
This workflow will add a `stale` label to PRs and Issues after inactivity, and then close if there is no further updates after 5 days.
 
BUG=https://issuetracker.google.com/issues/270658503