### PR TITLE
examples/hello_world/evaluate_test.cc: Fixed typo

### DIFF
--- a/tensorflow/lite/micro/examples/hello_world/evaluate_test.cc
+++ b/tensorflow/lite/micro/examples/hello_world/evaluate_test.cc
@@ -57,7 +57,7 @@ TfLiteStatus LoadFloatModelAndPerformInference() {
 
   // Make sure the input has the properties we expect
   if (input == nullptr) {
-    MicroPrintf("Input tensor in null.");
+    MicroPrintf("Input tensor is null.");
     return kTfLiteError;
   }
 
@@ -118,7 +118,7 @@ TfLiteStatus LoadQuantModelAndPerformInference() {
 
   // Make sure the input has the properties we expect
   if (input == nullptr) {
-    MicroPrintf("Input tensor in null.");
+    MicroPrintf("Input tensor is null.");
     return kTfLiteError;
   }
 


### PR DESCRIPTION
Fixed basic spelling mistake in `examples/hello_world/evaluate_test.cc`.

BUG=fix comments