### PR TITLE
Adding next steps to stale messages.

### DIFF
--- a/.github/workflows/stale_handler.yml
+++ b/.github/workflows/stale_handler.yml
@@ -12,9 +12,11 @@ jobs:
       - uses: actions/stale@v7
         with:
           stale-issue-message: >
-            "This issue is being marked as stale due to inactivity."
+            "This issue is being marked as stale due to inactivity. Remove label or 
+            comment to prevent closure in 5 days."
           stale-pr-message: >
-            "This PR is being marked as stale due to inactivity."
+            "This PR is being marked as stale due to inactivity. Remove label or 
+            comment to prevent closure in 5 days."
           close-issue-message: >
             "This issue is being closed because it has been marked as
              stale for 5 days with no further activity."


### PR DESCRIPTION
Adding instructions to stale messages that removing the label or commenting on the PR/Issue will stop it from being closed.

BUG=https://issuetracker.google.com/issues/275601069