### PR TITLE
Change %PRIu32 --> %u

### DIFF
--- a/tensorflow/lite/micro/micro_profiler.cc
+++ b/tensorflow/lite/micro/micro_profiler.cc
@@ -56,8 +56,7 @@ void MicroProfiler::Log() const {
 #if !defined(TF_LITE_STRIP_ERROR_STRINGS)
   for (int i = 0; i < num_events_; ++i) {
     uint32_t ticks = end_ticks_[i] - start_ticks_[i];
-    MicroPrintf("%s took %" PRIu32 " ticks (%d ms).", tags_[i], ticks,
-                TicksToMs(ticks));
+    MicroPrintf("%s took %u ticks (%d ms).", tags_[i], ticks, TicksToMs(ticks));
   }
 #endif
 }


### PR DESCRIPTION
PRIu32 doesn't play nicely with arm-gcc (not sure why).

without this change, running keyword\_benchmark on corstone\_m\_300 gives outputs like:
```
FULLY_CONNECTED took lu ticks (1056 ms).
```

and with this change I see:
```
FULLY_CONNECTED took 1056 ticks (0 ms).
```

BUG=cleanup
