### PR TITLE
Flatten kernel namespace: ABS et al

### DIFF
--- a/tensorflow/lite/micro/kernels/elementwise.cc
+++ b/tensorflow/lite/micro/kernels/elementwise.cc
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,9 +25,6 @@ limitations under the License.
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {
-namespace ops {
-namespace micro {
-namespace elementwise {
 namespace {
 
 constexpr int kAbsNameId = 0;
@@ -351,13 +348,11 @@ TfLiteStatus RsqrtEval(TfLiteContext* context, TfLiteNode* node) {
           context, node, [](float f) { return 1.f / std::sqrt(f); },
           /*validate_input_func=*/nullptr, type);
     case kTfLiteInt8:
-      return EvalImplQuantized<int8_t>(context, node,
-                                       elementwise::RsqrtEvalQuantized,
-                                       elementwise::validate_input_func, type);
+      return EvalImplQuantized<int8_t>(context, node, RsqrtEvalQuantized,
+                                       validate_input_func, type);
     case kTfLiteInt16:
-      return EvalImplQuantized<int16_t>(context, node,
-                                        elementwise::RsqrtEvalQuantized,
-                                        elementwise::validate_input_func, type);
+      return EvalImplQuantized<int16_t>(context, node, RsqrtEvalQuantized,
+                                        validate_input_func, type);
 
     default:
       MicroPrintf("Current data type %s is not supported.",
@@ -375,60 +370,47 @@ TfLiteStatus LogicalNotEval(TfLiteContext* context, TfLiteNode* node) {
 }
 
 }  // namespace
-}  // namespace elementwise
 
 TfLiteRegistration_V1 Register_ABS() {
   return tflite::micro::RegisterOp(
-      elementwise::ElementWiseAbsRsqrtInit,
-      elementwise::PrepareAbsRsqrt<elementwise::IsAbsSupportedType,
-                                   elementwise::kAbsNameId>,
-      elementwise::AbsEval);
+      ElementWiseAbsRsqrtInit, PrepareAbsRsqrt<IsAbsSupportedType, kAbsNameId>,
+      AbsEval);
 }
 
 TfLiteRegistration_V1 Register_SIN() {
   return tflite::micro::RegisterOp(
-      nullptr, elementwise::GenericPrepare<elementwise::IsNumericSupportedType>,
-      elementwise::SinEval);
+      nullptr, GenericPrepare<IsNumericSupportedType>, SinEval);
 }
 
 TfLiteRegistration_V1 Register_COS() {
   return tflite::micro::RegisterOp(
-      nullptr, elementwise::GenericPrepare<elementwise::IsNumericSupportedType>,
-      elementwise::CosEval);
+      nullptr, GenericPrepare<IsNumericSupportedType>, CosEval);
 }
 
 TfLiteRegistration_V1 Register_LOG() {
   return tflite::micro::RegisterOp(
-      nullptr, elementwise::GenericPrepare<elementwise::IsNumericSupportedType>,
-      elementwise::LogEval);
+      nullptr, GenericPrepare<IsNumericSupportedType>, LogEval);
 }
 
 TfLiteRegistration_V1 Register_SQRT() {
   return tflite::micro::RegisterOp(
-      nullptr, elementwise::GenericPrepare<elementwise::IsNumericSupportedType>,
-      elementwise::SqrtEval);
+      nullptr, GenericPrepare<IsNumericSupportedType>, SqrtEval);
 }
 
 TfLiteRegistration_V1 Register_RSQRT() {
   return tflite::micro::RegisterOp(
-      elementwise::ElementWiseAbsRsqrtInit,
-      elementwise::PrepareAbsRsqrt<elementwise::IsRsqrtSupportedType,
-                                   elementwise::kRsrqtNameId>,
-      elementwise::RsqrtEval);
+      ElementWiseAbsRsqrtInit,
+      PrepareAbsRsqrt<IsRsqrtSupportedType, kRsrqtNameId>, RsqrtEval);
 }
 
 TfLiteRegistration_V1 Register_SQUARE() {
   return tflite::micro::RegisterOp(
-      nullptr, elementwise::GenericPrepare<elementwise::IsNumericSupportedType>,
-      elementwise::SquareEval);
+      nullptr, GenericPrepare<IsNumericSupportedType>, SquareEval);
 }
 
 TfLiteRegistration_V1 Register_LOGICAL_NOT() {
   return tflite::micro::RegisterOp(
-      nullptr, elementwise::GenericPrepare<elementwise::IsLogicalSupportedType>,
-      elementwise::LogicalNotEval);
+      nullptr, GenericPrepare<IsLogicalSupportedType>, LogicalNotEval);
 }
 
-}  // namespace micro
-}  // namespace ops
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/elementwise_test.cc
+++ b/tensorflow/lite/micro/kernels/elementwise_test.cc
@@ -163,9 +163,8 @@ TF_LITE_MICRO_TEST(Abs) {
   const float input[] = {0.01, -0.01, 10, -10};
   const float golden[] = {0.01, 0.01, 10, 10};
   float output_data[output_dims_count];
-  tflite::testing::TestElementwiseFloat(tflite::ops::micro::Register_ABS(),
-                                        shape, input, shape, golden,
-                                        output_data);
+  tflite::testing::TestElementwiseFloat(tflite::Register_ABS(), shape, input,
+                                        shape, golden, output_data);
 }
 
 TF_LITE_MICRO_TEST(AbsInt8) {
@@ -185,9 +184,9 @@ TF_LITE_MICRO_TEST(AbsInt8) {
   const int input_zero_point = 127 - data_max;
   const int output_zero_point = -128;
   tflite::testing::TestElementwiseQuantized<int8_t>(
-      tflite::ops::micro::Register_ABS(), shape, input_data, input_quantized,
-      input_scale, input_zero_point, shape, golden, output_quantized,
-      output_scale, output_zero_point);
+      tflite::Register_ABS(), shape, input_data, input_quantized, input_scale,
+      input_zero_point, shape, golden, output_quantized, output_scale,
+      output_zero_point);
 }
 
 TF_LITE_MICRO_TEST(AbsInt8SameScale) {
@@ -204,8 +203,8 @@ TF_LITE_MICRO_TEST(AbsInt8SameScale) {
   const float scale = (data_max - data_min) / 255.0f;
   const int zero_point = 127 - data_max;
   tflite::testing::TestElementwiseQuantized(
-      tflite::ops::micro::Register_ABS(), shape, input_data, input_quantized,
-      scale, zero_point, shape, golden, output_quantized, scale, -128);
+      tflite::Register_ABS(), shape, input_data, input_quantized, scale,
+      zero_point, shape, golden, output_quantized, scale, -128);
 }
 
 TF_LITE_MICRO_TEST(AbsInt16) {
@@ -222,9 +221,8 @@ TF_LITE_MICRO_TEST(AbsInt16) {
   const float input_scale = input_max / std::numeric_limits<int16_t>::max();
   const float output_scale = output_max / std::numeric_limits<int16_t>::max();
   tflite::testing::TestElementwiseQuantized(
-      tflite::ops::micro::Register_ABS(), shape, input_data, input_quantized,
-      input_scale, /*input_zero_point*/ 0, shape, golden, output_quantized,
-      output_scale,
+      tflite::Register_ABS(), shape, input_data, input_quantized, input_scale,
+      /*input_zero_point*/ 0, shape, golden, output_quantized, output_scale,
       /*output_zero_point*/ 0);
 }
 
@@ -234,9 +232,8 @@ TF_LITE_MICRO_TEST(Sin) {
   const float input[] = {0, 3.1415926, -3.1415926, 1};
   const float golden[] = {0, 0, 0, 0.84147};
   float output_data[output_dims_count];
-  tflite::testing::TestElementwiseFloat(tflite::ops::micro::Register_SIN(),
-                                        shape, input, shape, golden,
-                                        output_data);
+  tflite::testing::TestElementwiseFloat(tflite::Register_SIN(), shape, input,
+                                        shape, golden, output_data);
 }
 
 TF_LITE_MICRO_TEST(Cos) {
@@ -245,9 +242,8 @@ TF_LITE_MICRO_TEST(Cos) {
   const float input[] = {0, 3.1415926, -3.1415926, 1};
   const float golden[] = {1, -1, -1, 0.54030};
   float output_data[output_dims_count];
-  tflite::testing::TestElementwiseFloat(tflite::ops::micro::Register_COS(),
-                                        shape, input, shape, golden,
-                                        output_data);
+  tflite::testing::TestElementwiseFloat(tflite::Register_COS(), shape, input,
+                                        shape, golden, output_data);
 }
 
 TF_LITE_MICRO_TEST(Log) {
@@ -256,9 +252,8 @@ TF_LITE_MICRO_TEST(Log) {
   const float input[] = {1, 2.7182818, 0.5, 2};
   const float golden[] = {0, 1, -0.6931472, 0.6931472};
   float output_data[output_dims_count];
-  tflite::testing::TestElementwiseFloat(tflite::ops::micro::Register_LOG(),
-                                        shape, input, shape, golden,
-                                        output_data);
+  tflite::testing::TestElementwiseFloat(tflite::Register_LOG(), shape, input,
+                                        shape, golden, output_data);
 }
 
 TF_LITE_MICRO_TEST(Sqrt) {
@@ -267,9 +262,8 @@ TF_LITE_MICRO_TEST(Sqrt) {
   const float input[] = {0, 1, 2, 4};
   const float golden[] = {0, 1, 1.41421, 2};
   float output_data[output_dims_count];
-  tflite::testing::TestElementwiseFloat(tflite::ops::micro::Register_SQRT(),
-                                        shape, input, shape, golden,
-                                        output_data);
+  tflite::testing::TestElementwiseFloat(tflite::Register_SQRT(), shape, input,
+                                        shape, golden, output_data);
 }
 
 TF_LITE_MICRO_TEST(Rsqrt) {
@@ -278,9 +272,8 @@ TF_LITE_MICRO_TEST(Rsqrt) {
   const float input[] = {1, 2, 4, 9};
   const float golden[] = {1, 0.7071, 0.5, 0.33333};
   float output_data[output_dims_count];
-  tflite::testing::TestElementwiseFloat(tflite::ops::micro::Register_RSQRT(),
-                                        shape, input, shape, golden,
-                                        output_data);
+  tflite::testing::TestElementwiseFloat(tflite::Register_RSQRT(), shape, input,
+                                        shape, golden, output_data);
 }
 
 TF_LITE_MICRO_TEST(RsqrtInt8) {
@@ -299,9 +292,9 @@ TF_LITE_MICRO_TEST(RsqrtInt8) {
   const int input_zero_point = 127 - data_max;
   const int output_zero_point = -128;
   tflite::testing::TestElementwiseQuantized<int8_t>(
-      tflite::ops::micro::Register_RSQRT(), shape, input_data, input_quantized,
-      input_scale, input_zero_point, shape, golden, output_quantized,
-      output_scale, output_zero_point);
+      tflite::Register_RSQRT(), shape, input_data, input_quantized, input_scale,
+      input_zero_point, shape, golden, output_quantized, output_scale,
+      output_zero_point);
 }
 
 TF_LITE_MICRO_TEST(RsqrtInt16) {
@@ -319,9 +312,9 @@ TF_LITE_MICRO_TEST(RsqrtInt16) {
   const int input_zero_point = 0;
   const int output_zero_point = 0;
   tflite::testing::TestElementwiseQuantized<int16_t>(
-      tflite::ops::micro::Register_RSQRT(), shape, input_data, input_quantized,
-      input_scale, input_zero_point, shape, golden, output_quantized,
-      output_scale, output_zero_point);
+      tflite::Register_RSQRT(), shape, input_data, input_quantized, input_scale,
+      input_zero_point, shape, golden, output_quantized, output_scale,
+      output_zero_point);
 }
 
 TF_LITE_MICRO_TEST(RsqrtCloseTo0Int8) {
@@ -340,9 +333,9 @@ TF_LITE_MICRO_TEST(RsqrtCloseTo0Int8) {
   const int input_zero_point = 127 - data_max;
   const int output_zero_point = -128;
   tflite::testing::TestElementwiseQuantized<int8_t>(
-      tflite::ops::micro::Register_RSQRT(), shape, input_data, input_quantized,
-      input_scale, input_zero_point, shape, golden, output_quantized,
-      output_scale, output_zero_point);
+      tflite::Register_RSQRT(), shape, input_data, input_quantized, input_scale,
+      input_zero_point, shape, golden, output_quantized, output_scale,
+      output_zero_point);
 }
 
 TF_LITE_MICRO_TEST(RsqrtNanInt8) {
@@ -362,9 +355,9 @@ TF_LITE_MICRO_TEST(RsqrtNanInt8) {
   const int output_zero_point = -128;
 
   tflite::testing::TestElementwiseQuantized<int8_t>(
-      tflite::ops::micro::Register_RSQRT(), shape, input_data, input_quantized,
-      input_scale, input_zero_point, shape, golden, output_quantized,
-      output_scale, output_zero_point, kTfLiteError);
+      tflite::Register_RSQRT(), shape, input_data, input_quantized, input_scale,
+      input_zero_point, shape, golden, output_quantized, output_scale,
+      output_zero_point, kTfLiteError);
 }
 
 TF_LITE_MICRO_TEST(Square) {
@@ -373,9 +366,8 @@ TF_LITE_MICRO_TEST(Square) {
   const float input[] = {1, 2, 0.5, -3.0};
   const float golden[] = {1, 4.0, 0.25, 9.0};
   float output_data[output_dims_count];
-  tflite::testing::TestElementwiseFloat(tflite::ops::micro::Register_SQUARE(),
-                                        shape, input, shape, golden,
-                                        output_data);
+  tflite::testing::TestElementwiseFloat(tflite::Register_SQUARE(), shape, input,
+                                        shape, golden, output_data);
 }
 
 TF_LITE_MICRO_TEST(LogicalNot) {
@@ -384,9 +376,8 @@ TF_LITE_MICRO_TEST(LogicalNot) {
   const bool input[] = {true, false, false, true};
   const bool golden[] = {false, true, true, false};
   bool output_data[output_dims_count];
-  tflite::testing::TestElementwiseBool(
-      tflite::ops::micro::Register_LOGICAL_NOT(), shape, input, shape, golden,
-      output_data);
+  tflite::testing::TestElementwiseBool(tflite::Register_LOGICAL_NOT(), shape,
+                                       input, shape, golden, output_data);
 }
 
 TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/kernels/micro_ops.h
+++ b/tensorflow/lite/micro/kernels/micro_ops.h
@@ -31,6 +31,7 @@ namespace tflite {
 // (https://abseil.io/tips/130). Any new ops (or cleanup of existing ops should
 // have their Register function declarations in the tflite namespace.
 
+TfLiteRegistration_V1 Register_ABS();
 TfLiteRegistration_V1 Register_ADD();
 TfLiteRegistration_V1 Register_ADD_N();
 TfLiteRegistration_V1 Register_ARG_MAX();
@@ -47,6 +48,7 @@ TfLiteRegistration_V1 Register_CEIL();
 TfLiteRegistration_V1* Register_CIRCULAR_BUFFER();
 TfLiteRegistration_V1 Register_CONCATENATION();
 TfLiteRegistration_V1 Register_CONV_2D();
+TfLiteRegistration_V1 Register_COS();
 TfLiteRegistration_V1 Register_CUMSUM();
 TfLiteRegistration_V1 Register_DEPTH_TO_SPACE();
 TfLiteRegistration_V1 Register_DEPTHWISE_CONV_2D();
@@ -73,8 +75,10 @@ TfLiteRegistration_V1 Register_L2_POOL_2D();
 TfLiteRegistration_V1 Register_LEAKY_RELU();
 TfLiteRegistration_V1 Register_LESS();
 TfLiteRegistration_V1 Register_LESS_EQUAL();
+TfLiteRegistration_V1 Register_LOG();
 TfLiteRegistration_V1 Register_LOG_SOFTMAX();
 TfLiteRegistration_V1 Register_LOGICAL_AND();
+TfLiteRegistration_V1 Register_LOGICAL_NOT();
 TfLiteRegistration_V1 Register_LOGICAL_OR();
 TfLiteRegistration_V1 Register_LOGISTIC();
 TfLiteRegistration_V1 Register_MAX_POOL_2D();
@@ -96,14 +100,18 @@ TfLiteRegistration_V1 Register_RELU();
 TfLiteRegistration_V1 Register_RELU6();
 TfLiteRegistration_V1 Register_RESIZE_BILINEAR();
 TfLiteRegistration_V1 Register_RESIZE_NEAREST_NEIGHBOR();
+TfLiteRegistration_V1 Register_RSQRT();
 TfLiteRegistration_V1 Register_SELECT_V2();
 TfLiteRegistration_V1 Register_SHAPE();
+TfLiteRegistration_V1 Register_SIN();
 TfLiteRegistration_V1 Register_SLICE();
 TfLiteRegistration_V1 Register_SOFTMAX();
 TfLiteRegistration_V1 Register_SPACE_TO_BATCH_ND();
 TfLiteRegistration_V1 Register_SPACE_TO_DEPTH();
 TfLiteRegistration_V1 Register_SPLIT();
 TfLiteRegistration_V1 Register_SPLIT_V();
+TfLiteRegistration_V1 Register_SQRT();
+TfLiteRegistration_V1 Register_SQUARE();
 TfLiteRegistration_V1 Register_SQUARED_DIFFERENCE();
 TfLiteRegistration_V1 Register_SQUEEZE();
 TfLiteRegistration_V1 Register_STRIDED_SLICE();
@@ -122,17 +130,8 @@ TfLiteRegistration_V1 Register_ZEROS_LIKE();
 
 namespace ops {
 namespace micro {
-
-TfLiteRegistration_V1 Register_ABS();
-TfLiteRegistration_V1 Register_COS();
-TfLiteRegistration_V1 Register_LOG();
-TfLiteRegistration_V1 Register_LOGICAL_NOT();
 TfLiteRegistration_V1 Register_RESHAPE();
 TfLiteRegistration_V1 Register_ROUND();
-TfLiteRegistration_V1 Register_RSQRT();
-TfLiteRegistration_V1 Register_SIN();
-TfLiteRegistration_V1 Register_SQRT();
-TfLiteRegistration_V1 Register_SQUARE();
 }  // namespace micro
 }  // namespace ops
 }  // namespace tflite

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -115,8 +115,7 @@ class MicroMutableOpResolver : public MicroOpResolver {
   // MicroMutableOpResolver object.
 
   TfLiteStatus AddAbs() {
-    return AddBuiltin(BuiltinOperator_ABS, tflite::ops::micro::Register_ABS(),
-                      ParseAbs);
+    return AddBuiltin(BuiltinOperator_ABS, Register_ABS(), ParseAbs);
   }
 
   TfLiteStatus AddAdd(
@@ -190,8 +189,7 @@ class MicroMutableOpResolver : public MicroOpResolver {
   }
 
   TfLiteStatus AddCos() {
-    return AddBuiltin(BuiltinOperator_COS, tflite::ops::micro::Register_COS(),
-                      ParseCos);
+    return AddBuiltin(BuiltinOperator_COS, tflite::Register_COS(), ParseCos);
   }
 
   TfLiteStatus AddCumSum() {
@@ -327,8 +325,7 @@ class MicroMutableOpResolver : public MicroOpResolver {
   }
 
   TfLiteStatus AddLog() {
-    return AddBuiltin(BuiltinOperator_LOG, tflite::ops::micro::Register_LOG(),
-                      ParseLog);
+    return AddBuiltin(BuiltinOperator_LOG, Register_LOG(), ParseLog);
   }
 
   TfLiteStatus AddLogicalAnd() {
@@ -337,8 +334,7 @@ class MicroMutableOpResolver : public MicroOpResolver {
   }
 
   TfLiteStatus AddLogicalNot() {
-    return AddBuiltin(BuiltinOperator_LOGICAL_NOT,
-                      tflite::ops::micro::Register_LOGICAL_NOT(),
+    return AddBuiltin(BuiltinOperator_LOGICAL_NOT, Register_LOGICAL_NOT(),
                       ParseLogicalNot);
   }
 
@@ -459,8 +455,7 @@ class MicroMutableOpResolver : public MicroOpResolver {
   }
 
   TfLiteStatus AddRsqrt() {
-    return AddBuiltin(BuiltinOperator_RSQRT,
-                      tflite::ops::micro::Register_RSQRT(), ParseRsqrt);
+    return AddBuiltin(BuiltinOperator_RSQRT, Register_RSQRT(), ParseRsqrt);
   }
 
   TfLiteStatus AddSelectV2() {
@@ -473,8 +468,7 @@ class MicroMutableOpResolver : public MicroOpResolver {
   }
 
   TfLiteStatus AddSin() {
-    return AddBuiltin(BuiltinOperator_SIN, tflite::ops::micro::Register_SIN(),
-                      ParseSin);
+    return AddBuiltin(BuiltinOperator_SIN, Register_SIN(), ParseSin);
   }
 
   TfLiteStatus AddSlice() {
@@ -510,13 +504,11 @@ class MicroMutableOpResolver : public MicroOpResolver {
   }
 
   TfLiteStatus AddSqrt() {
-    return AddBuiltin(BuiltinOperator_SQRT, tflite::ops::micro::Register_SQRT(),
-                      ParseSqrt);
+    return AddBuiltin(BuiltinOperator_SQRT, Register_SQRT(), ParseSqrt);
   }
 
   TfLiteStatus AddSquare() {
-    return AddBuiltin(BuiltinOperator_SQUARE,
-                      tflite::ops::micro::Register_SQUARE(), ParseSquare);
+    return AddBuiltin(BuiltinOperator_SQUARE, Register_SQUARE(), ParseSquare);
   }
 
   TfLiteStatus AddSquaredDifference() {


### PR DESCRIPTION
@tensorflow/micro

Flatten namespace for kernel operator ABS, COS, LOG, LOGICAL_NOT, RSQRT, SIN, SQRT, SQUARE 
Update unit tests namespace usage
Update MicroOpResolver namespace usage

bug=fixes #1877