### PR TITLE
Change Add Op INT32 unit testing numbers

### DIFF
--- a/tensorflow/lite/micro/kernels/add_test.cc
+++ b/tensorflow/lite/micro/kernels/add_test.cc
@@ -244,9 +244,9 @@ TF_LITE_MICRO_TEST(FloatAddWithScalarBroadcast) {
 
 TF_LITE_MICRO_TEST(Int32AddNoActivation) {
   int inout_shape[] = {4, 1, 2, 2, 1};
-  const int32_t input1_values[] = {-2, 2147483647, -1, 1146622854};
-  const int32_t input2_values[] = {3, 1, -2147483648, -726978367};
-  const int32_t golden_values[] = {1, -2147483648, 2147483647, 419644487};
+  const int32_t input1_values[] = {-2, 2147483646, -1, 1146622854};
+  const int32_t input2_values[] = {3, 1, -2147483647, -726978367};
+  const int32_t golden_values[] = {1, 2147483647, -2147483648, 419644487};
   constexpr int kOutputDimsCount = 4;
   int32_t output_data[kOutputDimsCount];
   tflite::testing::TestAddInt32(inout_shape, input1_values, inout_shape,


### PR DESCRIPTION
The current unit test for the Add Op INT32 case included testing out of bounds addition.

This causes the test to fail with asan and ubsan, so removing the undefined behavior.
Changed values to just test adding functionality of two valid ranged numbers.
Assuming the test cases still want to test positive + positive and negative + negative cases so just decrementing the value to avoid the out of bounds, but still at INT32 limit.

BUG=[277268203](https://b.corp.google.com/issues/277268203)