### PR TITLE
Fix for edge case in assign_variable.cc

### DIFF
--- a/tensorflow/lite/micro/kernels/assign_variable.cc
+++ b/tensorflow/lite/micro/kernels/assign_variable.cc
@@ -60,9 +60,15 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   MicroGraph& graph_info = micro_context->graph();
 
   MicroResourceVariables* resources = graph_info.GetResourceVariables();
-  TF_LITE_ENSURE_OK(context,
-                    resources->Allocate(input_resource_id_tensor->data.i32[0],
-                                        context, input_value));
+  // If the data field of this tensor is nullptr, we assume that this is a case
+  // of using resource variables in another subgraph, and the resource_id
+  // will be valid during Eval time. In case it wasn't valid, this will
+  // still be caught during Invoke. More info in b/277231654.
+  if (input_resource_id_tensor->data.i32 != nullptr) {
+    TF_LITE_ENSURE_OK(context,
+                      resources->Allocate(input_resource_id_tensor->data.i32[0],
+                                          context, input_value));
+  }
 
   micro_context->DeallocateTempTfLiteTensor(input_value);
   return kTfLiteOk;


### PR DESCRIPTION
In cases where a tflite model is created with multiple subgraphs and make use of resource variables, you can end up in a situation where you pass a `RESOURCE` tensor as an input tensor to another subgraph (instead of using `VAR_HANDLE` `shared_name` to find).
In these cases, TFLM crashes during Prepare() phase of `ASSIGN_VARIABLE`, since there was no corresponding `VAR_HANDLE` op in the subgraph which sets the data field of the corresponding linking tensor to a proper value/pointer.

However, this is valid during Eval() time as the passed input tensor would have a valid data field which properly references to a resource_id.
More detailed info in the doc linked in bug.
BUG=[277231654](https://b.corp.google.com/issues/277231654)

Tested this on a follow up PR which introduces the simple keras model to showcase the fail (keras model test fails/passes confirmed with this fix).