### PR TITLE
github context dump on ci:inspect

### DIFF
--- a/.github/workflows/inspect_github.yml
+++ b/.github/workflows/inspect_github.yml
@@ -1,0 +1,16 @@
+name: Inspect Github 
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+jobs:
+  dump-github-context:
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:inspect') }}
+    steps:
+      - name: Dump GitHub Context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"


### PR DESCRIPTION
Provides a dump of the github context object when `ci:inspect` label applied to help with troubleshooting or authoring new workflows.

This requires a new label `ci:inspect` be added to the repo.

BUG=https://issuetracker.google.com/issues/277793595