### PR TITLE
numpy to ci part 2

### DIFF
--- a/.github/workflows/cortex_m.yml
+++ b/.github/workflows/cortex_m.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           pip3 install Pillow
           pip3 install Wave
+          pip3 install numpy
       - name: Test
         run: |
           tensorflow/lite/micro/tools/ci_build/test_cortex_m_generic.sh
@@ -53,6 +54,7 @@ jobs:
         run: |
           pip3 install Pillow
           pip3 install Wave
+          pip3 install numpy
       - name: Test
         run: |
           tensorflow/lite/micro/tools/ci_build/test_cortex_m_corstone_300.sh


### PR DESCRIPTION
I think this is needed because of this pr https://github.com/tensorflow/tflite-micro/pull/1887#event-8978968178 and cortex_m tests are failing.

BUG=numpy missing in ci