### PR TITLE
Optimize Xtensa CONV2D circular buffer copy.

### DIFF
--- a/tensorflow/lite/micro/tools/make/ext_libs/xa_nnlib_hifi4.patch
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xa_nnlib_hifi4.patch
@@ -1,0 +1,128 @@
+diff '--color=auto' -ru a/algo/kernels/cnn/hifi4/xa_nn_conv2d_std_circ_buf.c b/algo/kernels/cnn/hifi4/xa_nn_conv2d_std_circ_buf.c
+--- a/algo/kernels/cnn/hifi4/xa_nn_conv2d_std_circ_buf.c	2022-12-02 08:12:39.000000000 +0000
++++ b/algo/kernels/cnn/hifi4/xa_nn_conv2d_std_circ_buf.c	2023-04-19 09:01:48.965265887 +0000
+@@ -642,7 +642,8 @@
+ }
+ 
+ // Add x_stride (but not more than kernel_width) x (input_height x input_channels) new planes to circular buffer
+-VOID conv2d_std_update_cir_buf(
++// Slow version of conv2d_std_update_cir_buf with fewer requirements
++VOID conv2d_std_update_cir_buf_slow(
+     WORD32 input_channels,
+     WORD32 input_channels_pad,
+     WORD32 input_bytewidth,
+@@ -742,6 +743,89 @@
+   *pp_inp = (VOID *)p_inp;
+ }
+ 
++// Add x_stride (but not more than kernel_width) x (input_height x input_channels) new planes to circular buffer
++VOID conv2d_std_update_cir_buf(
++    WORD32 input_channels,
++    WORD32 input_channels_pad,
++    WORD32 input_bytewidth,
++    WORD32 input_width,
++    WORD32 input_height,
++    WORD32 y_padding,
++    WORD32 y_b_pad,
++    WORD32 x_padding,
++    WORD32 kernel_width,
++    WORD32 x_stride,
++    VOID **pp_inp,
++    WORD32 idx_beg_inp_width_pad,
++    xa_nn_conv_state_t *p_state)
++{
++  if (y_padding != 0 || y_b_pad != 0 || x_padding != 0) {
++    conv2d_std_update_cir_buf_slow(
++      input_channels,
++      input_channels_pad,
++      input_bytewidth,
++      input_width,
++      input_height,
++      y_padding,
++      y_b_pad,
++      x_padding,
++      kernel_width,
++      x_stride,
++      pp_inp,
++      idx_beg_inp_width_pad,
++      p_state
++    );
++    return;
++  }
++
++  WORD32 i,k;
++  WORD8 *p_inp = (WORD8 *)*pp_inp;
++  WORD32 planes_to_add = x_stride > kernel_width ? kernel_width : x_stride;
++  WORD32 planes_to_keep = kernel_width - planes_to_add;
++
++  // Copy 'planes_to_add' planes of data to circular buffer
++  AE_ADDCIRC16X4_XC((ae_int16x4 *)p_state->cir_buf.p_curr, planes_to_add * input_channels_pad * input_bytewidth);
++  WORD8 *p_dst = (WORD8 *)p_state->cir_buf.p_curr;
++  AE_ADDCIRC16X4_XC((ae_int16x4 *)p_dst, planes_to_keep * input_channels_pad * input_bytewidth);
++
++  // Set next 'input_height' rows of cir_buf with zero (from x_padding) and/or input data and/or zero (from x-right padding)
++  WORD32 idx_end_inp_width_pad = idx_beg_inp_width_pad + planes_to_add;
++  WORD32 copy_inp_width = planes_to_add;
++  WORD32 to_skip_inp_width = x_stride - planes_to_add;     // Non-zero for x_stride > kernel_width
++
++  int size = input_channels * input_bytewidth;
++  if (size <= 32) {
++    for(i=0;i<input_height;i++)
++    {
++      for(k=0;k<copy_inp_width;k++)
++      {
++        for (int j = 0; j < size; ++j) {
++          p_dst[j] = p_inp[j];
++        }
++        AE_ADDCIRC16X4_XC((ae_int16x4 *)p_dst, input_channels_pad * input_bytewidth);
++        p_inp += input_channels * input_bytewidth;
++      }
++      AE_ADDCIRC16X4_XC((ae_int16x4 *)p_dst, planes_to_keep * input_channels_pad * input_bytewidth);
++      p_inp += (input_width - copy_inp_width) * input_channels * input_bytewidth;
++    }
++  } else {
++    for(i=0;i<input_height;i++)
++    {
++      for(k=0;k<copy_inp_width;k++)
++      {
++        memcpy(p_dst, p_inp, input_channels * input_bytewidth);
++        AE_ADDCIRC16X4_XC((ae_int16x4 *)p_dst, input_channels_pad * input_bytewidth);
++        p_inp += input_channels * input_bytewidth;
++      }
++      AE_ADDCIRC16X4_XC((ae_int16x4 *)p_dst, planes_to_keep * input_channels_pad * input_bytewidth);
++      p_inp += (input_width - copy_inp_width) * input_channels * input_bytewidth;
++    }
++  }
++  p_inp += (-input_height * input_width + copy_inp_width + to_skip_inp_width) * input_channels * input_bytewidth;
++
++  *pp_inp = (VOID *)p_inp;
++}
++
+ VOID xa_nn_dilated_conv2d_std_load_cir_buf_asym8(
+     WORD32 input_channels,
+     WORD32 input_channels_pad,
+diff '--color=auto' -ru a/algo/kernels/cnn/hifi4/xa_nn_conv2d_std_state.h b/algo/kernels/cnn/hifi4/xa_nn_conv2d_std_state.h
+--- a/algo/kernels/cnn/hifi4/xa_nn_conv2d_std_state.h	2022-12-02 08:12:39.000000000 +0000
++++ b/algo/kernels/cnn/hifi4/xa_nn_conv2d_std_state.h	2023-04-19 08:59:09.153500521 +0000
+@@ -214,6 +214,21 @@
+     VOID **pp_inp,
+     xa_nn_conv_state_t *p_state);
+ 
++VOID conv2d_std_update_cir_buf_slow(
++    WORD32 input_channels,
++    WORD32 input_channels_pad,
++    WORD32 input_bytewidth,
++    WORD32 input_width,
++    WORD32 input_height,
++    WORD32 y_padding,
++    WORD32 y_b_pad,
++    WORD32 x_padding,
++    WORD32 kernel_width,
++    WORD32 x_stride,
++    VOID **pp_inp,
++    WORD32 idx_beg_inp_width_pad,
++    xa_nn_conv_state_t *p_state);
++
+ VOID conv2d_std_update_cir_buf(
+     WORD32 input_channels,
+     WORD32 input_channels_pad,


### PR DESCRIPTION
In Xtensa's CONV2D kernel, data is shuffled around and padded so the 2D convolution turns into sequential vector products. Unfortunately, this process is somewhat slow, and the overhead is especially high for small vector lengths.

This patch introduces the following:

- Faster code path for no padding (since our models use VALID padding, i.e., no padding at all)
- Manual loop if array is small and memcpy if array is large
- Skip memset on padded channels as the corresponding kernels are already zero


BUG=249796929