### PR TITLE
Return the correct TfLiteStatus from interpreter->Invoke()

### DIFF
--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.cc
@@ -254,12 +254,13 @@ InterpreterWrapper::InterpreterWrapper(
 void InterpreterWrapper::PrintAllocations() { allocator_->PrintAllocations(); }
 
 int InterpreterWrapper::Invoke() {
-  if (interpreter_->Invoke() == kTfLiteError) {
+  TfLiteStatus status = interpreter_->Invoke();
+  if (status == kTfLiteError) {
     char err_strbuf[128];
     snprintf(err_strbuf, sizeof(err_strbuf), "Interpreter invocation failed.");
     ThrowRuntimeError(err_strbuf);
   }
-  return kTfLiteOk;
+  return status;
 }
 
 int InterpreterWrapper::Reset() { return interpreter_->Reset(); }


### PR DESCRIPTION
We would like to throw and exception on kTfLiteError (http://b/273622999) and pass-through all the other TfLiteStatus returned by calling interpreter->Invoke()

https://github.com/tensorflow/tflite-micro/pull/1907 changed the behavior to throw an exception on kTfLiteError but did not pass through all the other status.

In particular, this is important because streaming implementation with circular_buffers relies on kTfLiteAbort being appropriately propagated.

BUG=http://b/279055226
