### PR TITLE
Add a target architecture for a generic RISCV32 CPU.

### DIFF
--- a/tensorflow/lite/micro/testing/size_riscv32_binary.sh
+++ b/tensorflow/lite/micro/testing/size_riscv32_binary.sh
@@ -1,0 +1,63 @@
+#!/bin/bash -e
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Neasures the size of a riscv binary by parsing the output of
+# the 'size' program. If an optional list of symbols is provided, the symbols' sizes
+# are excluded from the total. This is useful when the binary contains symbols
+# that are only used during testing.
+#
+# First argument is the binary location.
+# Second argument is a regular expression for symbols that need to be excluded
+# from the measurement
+declare -r TEST_TMPDIR=/tmp/test_${1}_binary/
+declare -r MICRO_LOG_PATH=${TEST_TMPDIR}/$1
+declare -r MICRO_LOG_FILENAME=${MICRO_LOG_PATH}/logs.txt
+mkdir -p ${MICRO_LOG_PATH}
+raw_size=$(riscv64-unknown-elf-size $1)
+# Skip the title row
+sizes=$(echo "${raw_size}" | sed -n '2 p')
+text_size=$(echo "$sizes" | awk '{print $1}')
+data_size=$(echo "$sizes" | awk '{print $2}')
+bss_size=$(echo "$sizes" | awk '{print $3}')
+total_size=$(echo "$sizes" | awk '{print $4}')
+symbols=$(riscv64-unknown-elf-nm -S $1 | grep -w $2)
+while IFS= read -r line; do
+  symbol_size=$((16#$(echo $line | awk '{print $2}')))
+  symbol_type=$(echo $line | awk '{print $3}')
+  symbol_name=$(echo $line | awk '{print $4}')
+  total_size=$(("$total_size"-"$symbol_size"))
+  if [[ "$symbol_type" =~ [Dd] ]]; then
+    data_size=$(("$data_size"-"$symbol_size"))
+  elif [[ "$symbol_type" =~ [TtRr] ]]; then
+    # Text symbols
+    # Readonly symbols are usually counted as text 
+    text_size=$(("$text_size"-"$symbol_size"))
+  elif [[ "$symbol_type" =~ [Bb] ]]; then
+    # BSS symbols
+    bss_size=$(("$bss_size"-"$symbol_size"))
+  elif [[ "$symbol_type" =~ [Gg] ]]; then
+    # Data symbols
+    data_size=$(("$data_size"-"$symbol_size"))
+  else
+    echo "The symbol ${symbol_name}'s type isn't recognized"
+    exit 1
+  fi
+done <<< "$symbols"
+str="text   data   bss   total
+$text_size $data_size $bss_size $total_size"
+echo "$str"
+exit 0
+

--- a/tensorflow/lite/micro/tools/make/targets/riscv32_generic_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/riscv32_generic_makefile.inc
@@ -1,0 +1,42 @@
+# Settings for RISCV 32-bit toolchain.
+TARGET_ARCH := riscv32
+TARGET_TOOLCHAIN_PREFIX := riscv64-unknown-elf-
+
+TARGET_DEFAULT_TOOLCHAIN_ROOT := $(DOWNLOADS_DIR)/riscv_toolchain/bin/
+TARGET_TOOLCHAIN_ROOT := $(TARGET_DEFAULT_TOOLCHAIN_ROOT)
+ifeq ($(TARGET_TOOLCHAIN_ROOT), $(TARGET_DEFAULT_TOOLCHAIN_ROOT))
+  $(eval $(call add_third_party_download,$(RISCV_TOOLCHAIN_URL),$(RISCV_TOOLCHAIN_MD5),riscv_toolchain,))
+endif
+
+export PATH := $(TARGET_TOOLCHAIN_ROOT):$(PATH)
+
+PLATFORM_FLAGS = \
+  -march=rv32imac \
+  -mabi=ilp32 \
+  -mcmodel=medany \
+  -mexplicit-relocs \
+  -fno-builtin-printf \
+  -DTF_LITE_MCU_DEBUG_LOG \
+  -DTF_LITE_USE_GLOBAL_CMATH_FUNCTIONS \
+  -funsigned-char \
+  -fno-delete-null-pointer-checks \
+  -fomit-frame-pointer
+
+CXXFLAGS += $(PLATFORM_FLAGS) \
+  -fpermissive \
+  -fno-use-cxa-atexit \
+  -DTF_LITE_USE_GLOBAL_MIN \
+  -DTF_LITE_USE_GLOBAL_MAX
+
+CCFLAGS += $(PLATFORM_FLAGS)
+
+BUILD_TYPE := micro
+
+LDFLAGS += --specs=nano.specs
+
+# This disables the "linker relaxation" optimization, which produced incorrect code.
+# TODO: Check whether this is fixed in newer versions of the toolchain.
+LDFLAGS += -mno-relax
+TEST_SCRIPT := $(TENSORFLOW_ROOT)tensorflow/lite/micro/testing/test_with_qemu.sh riscv32 rv32
+SIZE_SCRIPT := ${TENSORFLOW_ROOT}tensorflow/lite/micro/testing/size_riscv32_binary.sh
+


### PR DESCRIPTION
Also add a script to test a binary with QEMU and a script to measure the size of a binary.

BUG=277663402