### PR TITLE
Fix "fatal: detected dubious ownership in repository at '/github/workspace'"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Check
         uses: docker://ghcr.io/tflm-bot/tflm-ci:latest
         with:
-          args: /bin/sh -c "tensorflow/lite/micro/tools/ci_build/test_code_style.sh"
+          args: /bin/sh -c "git config --global --add safe.directory /github/workspace && tensorflow/lite/micro/tools/ci_build/test_code_style.sh"
 
   project_generation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Putting the git config command as part of running the docker container does the trick (tested on my fork of tflite-micro).

Why adding the `git config` command to the Dockerfile.micro (from https://github.com/tensorflow/tflite-micro/pull/1886) does not solve the issue is not clear at this time.

BUG=http://b/275010053
