### PR TITLE
Optimized kernel reference fallbacks: DEPTHWISE_CONV

### DIFF
--- a/tensorflow/lite/micro/kernels/depthwise_conv.h
+++ b/tensorflow/lite/micro/kernels/depthwise_conv.h
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -64,6 +64,16 @@ TFLMRegistration Register_DEPTHWISE_CONV_2D_INT8();
 // int16 activations and int8 weights and uses the latency optimized
 // implementations.
 TFLMRegistration Register_DEPTHWISE_CONV_2D_INT16();
+
+#elif defined(XTENSA)
+// Returns a TfLiteRegistration_V1 struct for kernel variant that only supports
+// int8 activations and int8 weights and uses the latency optimized
+// implementations.
+TfLiteRegistration_V1 Register_DEPTHWISE_CONV_2D_INT8();
+
+inline TfLiteRegistration_V1 Register_DEPTHWISE_CONV_2D_INT16() {
+  return Register_DEPTHWISE_CONV_2D();
+}
 
 #else
 inline TFLMRegistration Register_DEPTHWISE_CONV_2D_INT8() {

--- a/tensorflow/lite/micro/kernels/depthwise_conv.h
+++ b/tensorflow/lite/micro/kernels/depthwise_conv.h
@@ -66,12 +66,12 @@ TFLMRegistration Register_DEPTHWISE_CONV_2D_INT8();
 TFLMRegistration Register_DEPTHWISE_CONV_2D_INT16();
 
 #elif defined(XTENSA)
-// Returns a TfLiteRegistration_V1 struct for kernel variant that only supports
+// Returns a TFLMRegistration struct for kernel variant that only supports
 // int8 activations and int8 weights and uses the latency optimized
 // implementations.
-TfLiteRegistration_V1 Register_DEPTHWISE_CONV_2D_INT8();
+TFLMRegistration Register_DEPTHWISE_CONV_2D_INT8();
 
-inline TfLiteRegistration_V1 Register_DEPTHWISE_CONV_2D_INT16() {
+inline TFLMRegistration Register_DEPTHWISE_CONV_2D_INT16() {
   return Register_DEPTHWISE_CONV_2D();
 }
 

--- a/tensorflow/lite/micro/kernels/depthwise_conv_common.cc
+++ b/tensorflow/lite/micro/kernels/depthwise_conv_common.cc
@@ -1,4 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -97,15 +97,15 @@ TfLiteStatus CalculateOpDataDepthwiseConv(
   MicroContext* micro_context = GetMicroContext(context);
 
   TfLiteTensor* input =
-      micro_context->AllocateTempInputTensor(node, kConvInputTensor);
+      micro_context->AllocateTempInputTensor(node, kDepthwiseConvInputTensor);
   TF_LITE_ENSURE(context, input != nullptr);
   TfLiteTensor* filter =
-      micro_context->AllocateTempInputTensor(node, kConvWeightsTensor);
+      micro_context->AllocateTempInputTensor(node, kDepthwiseConvWeightsTensor);
   TF_LITE_ENSURE(context, filter != nullptr);
   TfLiteTensor* bias =
-      micro_context->AllocateTempInputTensor(node, kConvBiasTensor);
+      micro_context->AllocateTempInputTensor(node, kDepthwiseConvBiasTensor);
   TfLiteTensor* output =
-      micro_context->AllocateTempOutputTensor(node, kConvOutputTensor);
+      micro_context->AllocateTempOutputTensor(node, kDepthwiseConvOutputTensor);
   TF_LITE_ENSURE(context, output != nullptr);
 
   // Note that quantized inference requires that all tensors have their
@@ -127,7 +127,9 @@ TfLiteStatus CalculateOpDataDepthwiseConv(
 
   micro_context->DeallocateTempTfLiteTensor(input);
   micro_context->DeallocateTempTfLiteTensor(filter);
-  micro_context->DeallocateTempTfLiteTensor(bias);
+  if (bias != nullptr) {
+    micro_context->DeallocateTempTfLiteTensor(bias);
+  }
   micro_context->DeallocateTempTfLiteTensor(output);
 
   return kTfLiteOk;

--- a/tensorflow/lite/micro/kernels/depthwise_conv_test.cc
+++ b/tensorflow/lite/micro/kernels/depthwise_conv_test.cc
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "tensorflow/lite/micro/kernels/depthwise_conv.h"
+
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
@@ -41,7 +43,7 @@ template <typename T>
 TfLiteStatus ValidateDepthwiseConvGoldensForRegistration(
     const T* expected_output_data, int output_length,
     TfLiteDepthwiseConvParams* conv_params, float tolerance, int tensors_size,
-    TfLiteTensor* tensors, const TfLiteRegistration_V1 registration) {
+    TfLiteTensor* tensors, const TFLMRegistration registration) {
   int inputs_array_data[] = {3, 0, 1, 2};
   TfLiteIntArray* inputs_array = IntArrayFromInts(inputs_array_data);
   int outputs_array_data[] = {1, 3};

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
@@ -116,7 +116,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 
 }  // namespace
 
-TfLiteRegistration_V1 Register_DEPTHWISE_CONV_2D() {
+TFLMRegistration Register_DEPTHWISE_CONV_2D() {
   return tflite::micro::RegisterOp(DepthwiseConvInitXtensa,
                                    DepthwiseConvPrepareXtensa, Eval);
 }

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_common_xtensa.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_common_xtensa.cc
@@ -1,0 +1,63 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/depthwise_conv.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h"
+
+namespace tflite {
+
+void* DepthwiseConvInitXtensa(TfLiteContext* context, const char* buffer,
+                              size_t length) {
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+  void* data = context->AllocatePersistentBuffer(
+      context, sizeof(XtensaDepthwiseConvOpData));
+#if defined(VISION_P6)
+  if (InitXtensaContext()) {
+    return nullptr;
+  }
+#endif  // defined(VISION_P6)
+
+  return data;
+}
+
+TfLiteStatus DepthwiseConvPrepareXtensa(TfLiteContext* context,
+                                        TfLiteNode* node) {
+  TF_LITE_ENSURE_OK(context, DepthwiseConvPrepare(context, node));
+
+#if defined(HIFI4) || defined(HIFI5) || defined(VISION_P6)
+  auto op_data = reinterpret_cast<XtensaDepthwiseConvOpData*>(node->user_data);
+  // optimized kernels can change this during Prepare
+  op_data->can_optimize = false;
+#endif  // defined(HIFI4) || defined(HIFI5) || defined(VISION_P6)
+
+#if defined(HIFI4) || defined(HIFI5)
+  TF_LITE_ENSURE_OK(context, DepthwiseConvPrepareHifi(context, node));
+#endif  // defined(HIFI4) || defined(HIFI5)
+
+#if defined(VISION_P6)
+  TF_LITE_ENSURE_OK(context, DepthwiseConvPrepareVision(context, node));
+#endif  // defined(VISION_P6)
+
+  return kTfLiteOk;
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
@@ -1,4 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,10 +16,8 @@ limitations under the License.
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/portable_tensor_utils.h"
 #include "tensorflow/lite/kernels/internal/quantization_util.h"
-#include "tensorflow/lite/kernels/internal/reference/depthwiseconv_float.h"
-#include "tensorflow/lite/kernels/internal/reference/depthwiseconv_uint8.h"
-#include "tensorflow/lite/kernels/internal/reference/integer_ops/depthwise_conv.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/padding.h"
@@ -32,25 +30,39 @@ limitations under the License.
 namespace tflite {
 TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
                                       TfLiteNode* node) {
-  XtensaDepthwiseConvOpData* data =
-      static_cast<XtensaDepthwiseConvOpData*>(node->user_data);
   const auto& params =
       *(static_cast<const TfLiteDepthwiseConvParams*>(node->builtin_data));
 
   MicroContext* micro_context = GetMicroContext(context);
 
+  TfLiteTensor* bias =
+      micro_context->AllocateTempInputTensor(node, kDepthwiseConvBiasTensor);
+  TfLiteTensor* input =
+      micro_context->AllocateTempInputTensor(node, kDepthwiseConvInputTensor);
+  TF_LITE_ENSURE(context, input != nullptr);
+
+  // Check if the Xtensa optimized code can be used
+  // HIFI4 & HIFI5 do not allow bias data pointer to be nullptr
+  // HIFI4 & HIFI5 do not support dilation
+  if (bias == nullptr || input->type != kTfLiteInt8 ||
+      params.dilation_width_factor != 1 || params.dilation_height_factor != 1) {
+    micro_context->DeallocateTempTfLiteTensor(input);
+    if (bias != nullptr) {
+      micro_context->DeallocateTempTfLiteTensor(bias);
+    }
+    return kTfLiteOk;
+  }
+
+  XtensaDepthwiseConvOpData* data =
+      static_cast<XtensaDepthwiseConvOpData*>(node->user_data);
+
   // Calculate scratch memory requirements and request scratch buffer
   TfLiteTensor* output =
-      micro_context->AllocateTempOutputTensor(node, kConvOutputTensor);
+      micro_context->AllocateTempOutputTensor(node, kDepthwiseConvOutputTensor);
   TF_LITE_ENSURE(context, output != nullptr);
-  TfLiteTensor* input =
-      micro_context->AllocateTempInputTensor(node, kConvInputTensor);
-  TF_LITE_ENSURE(context, input != nullptr);
   TfLiteTensor* filter =
-      micro_context->AllocateTempInputTensor(node, kConvWeightsTensor);
+      micro_context->AllocateTempInputTensor(node, kDepthwiseConvWeightsTensor);
   TF_LITE_ENSURE(context, filter != nullptr);
-
-  TF_LITE_ENSURE_EQ(context, input->type, kTfLiteInt8);
 
   const RuntimeShape& input_shape = GetTensorShape(input);
   const RuntimeShape& filter_shape = GetTensorShape(filter);
@@ -87,6 +99,10 @@ TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
   micro_context->DeallocateTempTfLiteTensor(input);
   micro_context->DeallocateTempTfLiteTensor(filter);
   micro_context->DeallocateTempTfLiteTensor(output);
+  micro_context->DeallocateTempTfLiteTensor(bias);
+
+  data->can_optimize = true;
+
   return kTfLiteOk;
 }
 
@@ -97,94 +113,87 @@ TfLiteStatus DepthwiseConvEvalHifi(TfLiteContext* context, TfLiteNode* node,
                                    const TfLiteEvalTensor* filter,
                                    const TfLiteEvalTensor* bias,
                                    TfLiteEvalTensor* output) {
-  // If dilation is not required use the optimized NN Library kernel.
-  // Otherwise call the reference implementation.
-  if ((params.dilation_width_factor == 1) &&
-      (params.dilation_height_factor == 1)) {
-    const int stride_width = params.stride_width;
-    const int stride_height = params.stride_height;
-    const int pad_width = data.reference_op_data.padding.width;
-    const int pad_height = data.reference_op_data.padding.height;
-    const int depth_multiplier = params.depth_multiplier;
-    const int32_t output_activation_min =
-        data.reference_op_data.output_activation_min;
-    const int32_t output_activation_max =
-        data.reference_op_data.output_activation_max;
-    TFLITE_DCHECK_LE(output_activation_min, output_activation_max);
+  const int stride_width = params.stride_width;
+  const int stride_height = params.stride_height;
+  const int pad_width = data.reference_op_data.padding.width;
+  const int pad_height = data.reference_op_data.padding.height;
+  const int depth_multiplier = params.depth_multiplier;
+  const int32_t output_activation_min =
+      data.reference_op_data.output_activation_min;
+  const int32_t output_activation_max =
+      data.reference_op_data.output_activation_max;
+  TFLITE_DCHECK_LE(output_activation_min, output_activation_max);
 
-    const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
-    const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
-    const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
-    const RuntimeShape& bias_shape = tflite::micro::GetTensorShape(bias);
-    TFLITE_DCHECK_EQ(input_shape.DimensionsCount(), 4);
-    TFLITE_DCHECK_EQ(filter_shape.DimensionsCount(), 4);
-    TFLITE_DCHECK_EQ(output_shape.DimensionsCount(), 4);
+  const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+  const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
+  const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+  const RuntimeShape& bias_shape = tflite::micro::GetTensorShape(bias);
+  TFLITE_DCHECK_EQ(input_shape.DimensionsCount(), 4);
+  TFLITE_DCHECK_EQ(filter_shape.DimensionsCount(), 4);
+  TFLITE_DCHECK_EQ(output_shape.DimensionsCount(), 4);
 
-    const int batches = MatchingDim(input_shape, 0, output_shape, 0);
-    const int output_depth = MatchingDim(filter_shape, 3, output_shape, 3);
-    const int input_height = input_shape.Dims(1);
-    const int input_width = input_shape.Dims(2);
-    const int input_depth = input_shape.Dims(3);
-    const int filter_height = filter_shape.Dims(1);
-    const int filter_width = filter_shape.Dims(2);
-    const int output_height = output_shape.Dims(1);
-    const int output_width = output_shape.Dims(2);
-    TFLITE_DCHECK_EQ(output_depth, input_depth * depth_multiplier);
-    TFLITE_DCHECK_EQ(bias_shape.FlatSize(), output_depth);
+  const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+  const int output_depth = MatchingDim(filter_shape, 3, output_shape, 3);
+  const int input_height = input_shape.Dims(1);
+  const int input_width = input_shape.Dims(2);
+  const int input_depth = input_shape.Dims(3);
+  const int filter_height = filter_shape.Dims(1);
+  const int filter_width = filter_shape.Dims(2);
+  const int output_height = output_shape.Dims(1);
+  const int output_width = output_shape.Dims(2);
+  TFLITE_DCHECK_EQ(output_depth, input_depth * depth_multiplier);
+  TFLITE_DCHECK_EQ(bias_shape.FlatSize(), output_depth);
 
-    const int8_t* input_data = tflite::micro::GetTensorData<int8_t>(input);
-    const int8_t* filter_data = tflite::micro::GetTensorData<int8_t>(filter);
-    const int32_t* bias_data = tflite::micro::GetTensorData<int32_t>(bias);
-    int8_t* output_data = tflite::micro::GetTensorData<int8_t>(output);
+  const int8_t* input_data = tflite::micro::GetTensorData<int8_t>(input);
+  const int32_t* bias_data = tflite::micro::GetTensorData<int32_t>(bias);
+  int8_t* output_data = tflite::micro::GetTensorData<int8_t>(output);
 
-    int32_t input_data_format = 0;
-    int32_t output_data_format = 0;
-
-    uint8_t* p_scratch = static_cast<uint8_t*>(
-        context->GetScratchBuffer(context, data.scratch_tensor_index));
-
-    for (int i = 0; i < batches; i++) {
-      TF_LITE_ENSURE_EQ(
-          context,
-          xa_nn_conv2d_depthwise_per_chan_sym8sxasym8s(
-              &output_data[i * output_height * output_width * output_depth],
-              filter_data,
-              &input_data[i * input_height * input_width * input_depth],
-              bias_data, input_height, input_width, input_depth, filter_height,
-              filter_width, depth_multiplier, stride_width, stride_height,
-              pad_width, pad_height, output_height, output_width,
-              -data.reference_op_data.input_zero_point,
-              data.reference_op_data.per_channel_output_multiplier,
-              data.reference_op_data.per_channel_output_shift,
-              data.reference_op_data.output_zero_point, input_data_format,
-              output_data_format, p_scratch),
-          0);
-    }
-
-    int out_length = batches * output_height * output_width * output_depth;
-    TF_LITE_ENSURE_EQ(context,
-                      xa_nn_vec_activation_min_max_8_8(
-                          output_data, output_data, output_activation_min,
-                          output_activation_max, out_length),
-                      0);
-
-    return kTfLiteOk;
+  const int8_t* filter_data;
+  if (filter->type == kTfLiteInt4) {
+    int8_t* unpacked_filter_data =
+        static_cast<int8_t*>(context->GetScratchBuffer(
+            context, data.reference_op_data.filter_buffer_index));
+    tflite::tensor_utils::UnpackDenseInt4IntoInt8(
+        tflite::micro::GetTensorData<int8_t>(filter),
+        tflite::micro::GetTensorShape(filter).FlatSize(), unpacked_filter_data);
+    filter_data = unpacked_filter_data;
+  } else {
+    filter_data = tflite::micro::GetTensorData<int8_t>(filter);
   }
 
-  reference_integer_ops::DepthwiseConvPerChannel(
-      DepthwiseConvParamsQuantized(params, data.reference_op_data),
-      data.reference_op_data.per_channel_output_multiplier,
-      data.reference_op_data.per_channel_output_shift,
-      tflite::micro::GetTensorShape(input),
-      tflite::micro::GetTensorData<int8_t>(input),
-      tflite::micro::GetTensorShape(filter),
-      tflite::micro::GetTensorData<int8_t>(filter),
-      tflite::micro::GetTensorShape(bias),
-      tflite::micro::GetTensorData<int32_t>(bias),
-      tflite::micro::GetTensorShape(output),
-      tflite::micro::GetTensorData<int8_t>(output));
+  int32_t input_data_format = 0;
+  int32_t output_data_format = 0;
+
+  uint8_t* p_scratch = static_cast<uint8_t*>(
+      context->GetScratchBuffer(context, data.scratch_tensor_index));
+
+  for (int i = 0; i < batches; i++) {
+    TF_LITE_ENSURE_EQ(
+        context,
+        xa_nn_conv2d_depthwise_per_chan_sym8sxasym8s(
+            &output_data[i * output_height * output_width * output_depth],
+            filter_data,
+            &input_data[i * input_height * input_width * input_depth],
+            bias_data, input_height, input_width, input_depth, filter_height,
+            filter_width, depth_multiplier, stride_width, stride_height,
+            pad_width, pad_height, output_height, output_width,
+            -data.reference_op_data.input_zero_point,
+            data.reference_op_data.per_channel_output_multiplier,
+            data.reference_op_data.per_channel_output_shift,
+            data.reference_op_data.output_zero_point, input_data_format,
+            output_data_format, p_scratch),
+        0);
+  }
+
+  int out_length = batches * output_height * output_width * output_depth;
+  TF_LITE_ENSURE_EQ(context,
+                    xa_nn_vec_activation_min_max_8_8(
+                        output_data, output_data, output_activation_min,
+                        output_activation_max, out_length),
+                    0);
 
   return kTfLiteOk;
 }
+
 }  // namespace tflite
 #endif  // defined(HIFI4) || defined(HIFI5)

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8.cc
@@ -1,0 +1,96 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/portable_tensor_utils.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/integer_ops/depthwise_conv.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/depthwise_conv.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h"
+
+namespace tflite {
+namespace {
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  const auto& params =
+      *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));
+  const auto& op_data =
+      *(reinterpret_cast<XtensaDepthwiseConvOpData*>(node->user_data));
+
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kDepthwiseConvOutputTensor);
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kDepthwiseConvInputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kDepthwiseConvWeightsTensor);
+  const TfLiteEvalTensor* bias =
+      (NumInputs(node) == 3)
+          ? tflite::micro::GetEvalInput(context, node, kDepthwiseConvBiasTensor)
+          : nullptr;
+
+#if defined(HIFI4) || defined(HIFI5) || defined(VISION_P6)
+  if (op_data.can_optimize) {
+    // optimized Xtensa code will unpack filter data if necessary
+#if defined(HIFI4) || defined(HIFI5)
+    return DepthwiseConvEvalHifi(context, node, params, op_data, input, filter,
+                                 bias, output);
+#elif defined(VISION_P6)
+    return DepthwiseConvEvalVision(context, node, params, op_data, input,
+                                   filter, bias, output);
+#endif  // defined(HIFI4) || defined(HIFI5)
+  }
+#endif  // defined(HIFI4) || defined(HIFI5) || defined(VISION_P6)
+
+  const int8_t* filter_data;
+  if (filter->type == kTfLiteInt4) {
+    int8_t* unpacked_filter_data =
+        static_cast<int8_t*>(context->GetScratchBuffer(
+            context, op_data.reference_op_data.filter_buffer_index));
+    tflite::tensor_utils::UnpackDenseInt4IntoInt8(
+        tflite::micro::GetTensorData<int8_t>(filter),
+        tflite::micro::GetTensorShape(filter).FlatSize(), unpacked_filter_data);
+    filter_data = unpacked_filter_data;
+  } else {
+    filter_data = tflite::micro::GetTensorData<int8_t>(filter);
+  }
+
+  reference_integer_ops::DepthwiseConvPerChannel(
+      DepthwiseConvParamsQuantized(params, op_data.reference_op_data),
+      op_data.reference_op_data.per_channel_output_multiplier,
+      op_data.reference_op_data.per_channel_output_shift,
+      tflite::micro::GetTensorShape(input),
+      tflite::micro::GetTensorData<int8_t>(input),
+      tflite::micro::GetTensorShape(filter), filter_data,
+      tflite::micro::GetTensorShape(bias),
+      tflite::micro::GetOptionalTensorData<int32_t>(bias),
+      tflite::micro::GetTensorShape(output),
+      tflite::micro::GetTensorData<int8_t>(output));
+  return kTfLiteOk;
+}
+
+}  // namespace
+
+TfLiteRegistration_V1 Register_DEPTHWISE_CONV_2D_INT8() {
+  return tflite::micro::RegisterOp(DepthwiseConvInitXtensa,
+                                   DepthwiseConvPrepareXtensa, Eval);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8.cc
@@ -88,7 +88,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 
 }  // namespace
 
-TfLiteRegistration_V1 Register_DEPTHWISE_CONV_2D_INT8() {
+TFLMRegistration Register_DEPTHWISE_CONV_2D_INT8() {
   return tflite::micro::RegisterOp(DepthwiseConvInitXtensa,
                                    DepthwiseConvPrepareXtensa, Eval);
 }

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h
@@ -1,4 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -37,6 +37,10 @@ struct XtensaDepthwiseConvOpData {
   uint8_t* p_context;  // persistent lib context for this instance saved here
   uint32_t context_size;
 #endif  // VISION_P6
+
+#if defined(HIFI4) || defined(HIFI5) || defined(VISION_P6)
+  bool can_optimize;
+#endif  // defined(HIFI4) || defined(HIFI5) || defined(VISION_P6)
 };
 
 #if defined(HIFI4) || defined(HIFI5)
@@ -50,8 +54,6 @@ TfLiteStatus DepthwiseConvEvalHifi(TfLiteContext* context, TfLiteNode* node,
                                    const TfLiteEvalTensor* bias,
                                    TfLiteEvalTensor* output);
 
-TfLiteStatus DepthwiseConvReferenceEvalInt8(TfLiteContext* context,
-                                            TfLiteNode* node);
 #endif  // defined(HIFI4) || defined(HIFI5)
 
 #if defined(VISION_P6)
@@ -68,6 +70,11 @@ TfLiteStatus DepthwiseConvEvalVision(TfLiteContext* context, TfLiteNode* node,
                                      TfLiteEvalTensor* output);
 
 #endif  // VISION_P6
+
+void* DepthwiseConvInitXtensa(TfLiteContext* context, const char* buffer,
+                              size_t length);
+TfLiteStatus DepthwiseConvPrepareXtensa(TfLiteContext* context,
+                                        TfLiteNode* node);
 
 }  // namespace tflite
 

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -6,7 +6,9 @@ MICROLITE_CC_KERNEL_SRCS += \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int16_reference.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int8_reference.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_common_xtensa.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_vision.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_common_xtensa.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_int8.cc \


### PR DESCRIPTION
@tensorflow/micro

Remove conditional compilation for kernel tests for the following platforms: Xtensa
Add optimized kernel reference fallback code for the following platforms: Xtensa

Resolves: `TODO(b/170322965)`

Added additional code coverage using multiple test registrations.
Added Xtensa INT8 optimized registrations.
Added more checks for optional bias tensor.

The following table shows the size changes for each benchmark binary as a result of this PR:
| Platform | Benchmark | Build | Text | Data | BSS |
| --- | --- | --- | --- | --- | --- |
| hifi4 | keyword | default | 0 | 0 | 0 |
| hifi5 | keyword | default | 0 | 0 | 0 |
| p6 | keyword | default | 0 | 0 | 0 |
| hifi4 | person detection | default | +1200 | -16 | 0 |
| hifi5 | person detection | default | +1632 | -16 | 0 |
| p6 | person detection | default | +4944 | 0 | 0 |

bug=fixes #1932
