### PR TITLE
inline generated mutable op resolver getter function

### DIFF
--- a/tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver/templates/micro_mutable_op_resolver.h.mako
+++ b/tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver/templates/micro_mutable_op_resolver.h.mako
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,11 +15,13 @@ limitations under the License.
 
 // Generated based on ${model}.
 
+#pragma once
+
 #include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 
 constexpr int kNumberOperators = ${number_of_ops};
 
-tflite::MicroMutableOpResolver<kNumberOperators> get_resolver()
+inline tflite::MicroMutableOpResolver<kNumberOperators> get_resolver()
 {
   tflite::MicroMutableOpResolver<kNumberOperators> micro_op_resolver;
 


### PR DESCRIPTION
BUG=Depending on the usage of the generated micro mutable getter function, it could lead to multiple defined symbols.