### PR TITLE
remove usage of AllOpsResolver

### DIFF
--- a/tensorflow/lite/micro/examples/memory_footprint/README.md
+++ b/tensorflow/lite/micro/examples/memory_footprint/README.md
@@ -97,12 +97,6 @@ above method is 9732 bytes.
 One common issue that leads to unnecessary large code size is forgetting to only
 register only kernels that a model needs and ending up registering all kernels.
 
-TFLM provides a convenient `tflite::AllOpsResolver` that register for all
-kernels that TFLM supports. This is useful when at the exploration stage and the
-model is not fixed yet. However, as its name suggests, it will inlcude all
-kernels into the binary and the deadcode removal of linker will not be able to
-remove those kernels that is never used.
-
 Therefore, when moving off the exploration stage, it is better to only register
 for kernels that the model needs to have a smaller footprint. The following code
 snipet shows how to do so using the keyword detection as an example:

--- a/tensorflow/lite/micro/examples/micro_speech/main_functions.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/main_functions.cc
@@ -62,11 +62,7 @@ void setup() {
 
   // Pull in only the operation implementations we need.
   // This relies on a complete list of all the ops needed by this graph.
-  // An easier approach is to just use the AllOpsResolver, but this will
-  // incur some penalty in code space for op implementations that are not
-  // needed by this graph.
-  //
-  // tflite::AllOpsResolver resolver;
+  
   // NOLINTNEXTLINE(runtime-global-variables)
   static tflite::MicroMutableOpResolver<4> micro_op_resolver;
   if (micro_op_resolver.AddDepthwiseConv2D() != kTfLiteOk) {

--- a/tensorflow/lite/micro/examples/micro_speech/main_functions.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/main_functions.cc
@@ -62,7 +62,7 @@ void setup() {
 
   // Pull in only the operation implementations we need.
   // This relies on a complete list of all the ops needed by this graph.
-  
+
   // NOLINTNEXTLINE(runtime-global-variables)
   static tflite::MicroMutableOpResolver<4> micro_op_resolver;
   if (micro_op_resolver.AddDepthwiseConv2D() != kTfLiteOk) {

--- a/tensorflow/lite/micro/examples/micro_speech/micro_speech_test.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/micro_speech_test.cc
@@ -37,11 +37,7 @@ TF_LITE_MICRO_TEST(TestInvoke) {
 
   // Pull in only the operation implementations we need.
   // This relies on a complete list of all the ops needed by this graph.
-  // An easier approach is to just use the AllOpsResolver, but this will
-  // incur some penalty in code space for op implementations that are not
-  // needed by this graph.
-  //
-  // tflite::AllOpsResolver resolver;
+
   tflite::MicroMutableOpResolver<4> micro_op_resolver;
   micro_op_resolver.AddDepthwiseConv2D();
   micro_op_resolver.AddFullyConnected();

--- a/tensorflow/lite/micro/examples/network_tester/network_tester_test.cc
+++ b/tensorflow/lite/micro/examples/network_tester/network_tester_test.cc
@@ -13,12 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 #include "tensorflow/lite/micro/examples/network_tester/expected_output_data.h"
 #include "tensorflow/lite/micro/examples/network_tester/input_data.h"
 #include "tensorflow/lite/micro/examples/network_tester/network_model.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
 #include "tensorflow/lite/micro/micro_log.h"
+#include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
 #include "tensorflow/lite/schema/schema_generated.h"

--- a/tensorflow/lite/micro/examples/network_tester/network_tester_test.cc
+++ b/tensorflow/lite/micro/examples/network_tester/network_tester_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "tensorflow/lite/micro/all_ops_resolver.h"
+#include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 #include "tensorflow/lite/micro/examples/network_tester/expected_output_data.h"
 #include "tensorflow/lite/micro/examples/network_tester/input_data.h"
 #include "tensorflow/lite/micro/examples/network_tester/network_model.h"
@@ -93,7 +93,12 @@ TF_LITE_MICRO_TEST(TestInvoke) {
     return kTfLiteError;
   }
 
-  tflite::AllOpsResolver resolver;
+  tflite::MicroMutableOpResolver<5> resolver;
+  resolver.AddAveragePool2D(tflite::Register_AVERAGE_POOL_2D_INT8());
+  resolver.AddConv2D(tflite::Register_CONV_2D_INT8());
+  resolver.AddDepthwiseConv2D(tflite::Register_DEPTHWISE_CONV_2D_INT8());
+  resolver.AddReshape();
+  resolver.AddSoftmax(tflite::Register_SOFTMAX_INT8());
 
   tflite::MicroInterpreter interpreter(model, resolver, tensor_arena,
                                        TENSOR_ARENA_SIZE);

--- a/tensorflow/lite/micro/examples/person_detection/main_functions.cc
+++ b/tensorflow/lite/micro/examples/person_detection/main_functions.cc
@@ -60,11 +60,7 @@ void setup() {
 
   // Pull in only the operation implementations we need.
   // This relies on a complete list of all the ops needed by this graph.
-  // An easier approach is to just use the AllOpsResolver, but this will
-  // incur some penalty in code space for op implementations that are not
-  // needed by this graph.
-  //
-  // tflite::AllOpsResolver resolver;
+  
   // NOLINTNEXTLINE(runtime-global-variables)
   static tflite::MicroMutableOpResolver<5> micro_op_resolver;
   micro_op_resolver.AddAveragePool2D(tflite::Register_AVERAGE_POOL_2D_INT8());

--- a/tensorflow/lite/micro/examples/person_detection/main_functions.cc
+++ b/tensorflow/lite/micro/examples/person_detection/main_functions.cc
@@ -60,7 +60,7 @@ void setup() {
 
   // Pull in only the operation implementations we need.
   // This relies on a complete list of all the ops needed by this graph.
-  
+
   // NOLINTNEXTLINE(runtime-global-variables)
   static tflite::MicroMutableOpResolver<5> micro_op_resolver;
   micro_op_resolver.AddAveragePool2D(tflite::Register_AVERAGE_POOL_2D_INT8());

--- a/tensorflow/lite/micro/kernels/activations_test.cc
+++ b/tensorflow/lite/micro/kernels/activations_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/add_test.cc
+++ b/tensorflow/lite/micro/kernels/add_test.cc
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/arg_min_max_test.cc
+++ b/tensorflow/lite/micro/kernels/arg_min_max_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/call_once_test.cc
+++ b/tensorflow/lite/micro/kernels/call_once_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
 #include "tensorflow/lite/micro/mock_micro_graph.h"

--- a/tensorflow/lite/micro/kernels/cast_test.cc
+++ b/tensorflow/lite/micro/kernels/cast_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/ceil_test.cc
+++ b/tensorflow/lite/micro/kernels/ceil_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/circular_buffer_test.cc
+++ b/tensorflow/lite/micro/kernels/circular_buffer_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/circular_buffer_flexbuffers_generated_data.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/kernels/micro_ops.h"

--- a/tensorflow/lite/micro/kernels/detection_postprocess_test.cc
+++ b/tensorflow/lite/micro/kernels/detection_postprocess_test.cc
@@ -17,9 +17,9 @@ limitations under the License.
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
+#include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
-#include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 
 // See: tensorflow/lite/micro/kernels/detection_postprocess_test/README.md
 #include "tensorflow/lite/micro/kernels/detection_postprocess_flexbuffers_generated_data.h"

--- a/tensorflow/lite/micro/kernels/detection_postprocess_test.cc
+++ b/tensorflow/lite/micro/kernels/detection_postprocess_test.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
+#include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 
 // See: tensorflow/lite/micro/kernels/detection_postprocess_test/README.md
 #include "tensorflow/lite/micro/kernels/detection_postprocess_flexbuffers_generated_data.h"
@@ -105,7 +106,8 @@ void TestDetectionPostprocess(int* input_dims_data1, const float* input_data1,
   tensors[5] = CreateTensor(output_data3, output_dims3);
   tensors[6] = CreateTensor(output_data4, output_dims4);
 
-  ::tflite::AllOpsResolver resolver;
+  MicroMutableOpResolver<1> resolver;
+  TF_LITE_MICRO_EXPECT_EQ(resolver.AddDetectionPostprocess(), kTfLiteOk);
   const TfLiteRegistration_V1* registration =
       resolver.FindOp("TFLite_Detection_PostProcess");
   TF_LITE_MICRO_EXPECT(registration != nullptr);

--- a/tensorflow/lite/micro/kernels/elementwise_test.cc
+++ b/tensorflow/lite/micro/kernels/elementwise_test.cc
@@ -14,7 +14,6 @@ limitations under the License.
 ==============================================================================*/
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/debug_log.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"

--- a/tensorflow/lite/micro/kernels/exp_test.cc
+++ b/tensorflow/lite/micro/kernels/exp_test.cc
@@ -16,7 +16,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/expand_dims_test.cc
+++ b/tensorflow/lite/micro/kernels/expand_dims_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/floor_test.cc
+++ b/tensorflow/lite/micro/kernels/floor_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/fully_connected_test.cc
+++ b/tensorflow/lite/micro/kernels/fully_connected_test.cc
@@ -18,7 +18,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 #include "tensorflow/lite/micro/test_helpers.h"

--- a/tensorflow/lite/micro/kernels/gather_nd_test.cc
+++ b/tensorflow/lite/micro/kernels/gather_nd_test.cc
@@ -14,7 +14,6 @@ limitations under the License.
 ==============================================================================*/
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/gather_test.cc
+++ b/tensorflow/lite/micro/kernels/gather_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/hard_swish_test.cc
+++ b/tensorflow/lite/micro/kernels/hard_swish_test.cc
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/if_test.cc
+++ b/tensorflow/lite/micro/kernels/if_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/micro_arena_constants.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
@@ -170,8 +169,10 @@ TF_LITE_MICRO_TEST(IfShouldNotOverwriteTensorAcrossSubgraphs) {
   const tflite::Model* model =
       tflite::testing::GetModelWithIfAndSubgraphInputTensorOverlap();
 
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
-  op_resolver.AddIf();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
+
   tflite::MicroInterpreter interpreter(model, op_resolver, arena, kArenaSize);
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, interpreter.AllocateTensors());
 

--- a/tensorflow/lite/micro/kernels/l2norm_test.cc
+++ b/tensorflow/lite/micro/kernels/l2norm_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/logical_test.cc
+++ b/tensorflow/lite/micro/kernels/logical_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/logistic_test.cc
+++ b/tensorflow/lite/micro/kernels/logistic_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/maximum_minimum_test.cc
+++ b/tensorflow/lite/micro/kernels/maximum_minimum_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/mirror_pad_test.cc
+++ b/tensorflow/lite/micro/kernels/mirror_pad_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/neg_test.cc
+++ b/tensorflow/lite/micro/kernels/neg_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/pad_test.cc
+++ b/tensorflow/lite/micro/kernels/pad_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/reduce_test.cc
+++ b/tensorflow/lite/micro/kernels/reduce_test.cc
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/resize_bilinear_test.cc
+++ b/tensorflow/lite/micro/kernels/resize_bilinear_test.cc
@@ -14,7 +14,6 @@ limitations under the License.
 ==============================================================================*/
 
 #include "tensorflow/lite/c/builtin_op_data.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/resize_nearest_neighbor_test.cc
+++ b/tensorflow/lite/micro/kernels/resize_nearest_neighbor_test.cc
@@ -14,7 +14,6 @@ limitations under the License.
 ==============================================================================*/
 
 #include "tensorflow/lite/c/builtin_op_data.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/round_test.cc
+++ b/tensorflow/lite/micro/kernels/round_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/select_test.cc
+++ b/tensorflow/lite/micro/kernels/select_test.cc
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/shape_test.cc
+++ b/tensorflow/lite/micro/kernels/shape_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/slice_test.cc
+++ b/tensorflow/lite/micro/kernels/slice_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/softmax_test.cc
+++ b/tensorflow/lite/micro/kernels/softmax_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/split_v_test.cc
+++ b/tensorflow/lite/micro/kernels/split_v_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/debug_log.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"

--- a/tensorflow/lite/micro/kernels/strided_slice_test.cc
+++ b/tensorflow/lite/micro/kernels/strided_slice_test.cc
@@ -16,7 +16,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/kernels/while_test.cc
+++ b/tensorflow/lite/micro/kernels/while_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/micro_arena_constants.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"

--- a/tensorflow/lite/micro/kernels/zeros_like_test.cc
+++ b/tensorflow/lite/micro/kernels/zeros_like_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"

--- a/tensorflow/lite/micro/memory_arena_threshold_test.cc
+++ b/tensorflow/lite/micro/memory_arena_threshold_test.cc
@@ -15,7 +15,8 @@ limitations under the License.
 
 #include <stdint.h>
 
-#include "tensorflow/lite/micro/all_ops_resolver.h"
+#include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
+#include "tensorflow/lite/micro/kernels/svdf.h"
 #include "tensorflow/lite/micro/memory_helpers.h"
 #include "tensorflow/lite/micro/memory_planner/greedy_memory_planner.h"
 #include "tensorflow/lite/micro/models/keyword_scrambled_model_data.h"
@@ -221,9 +222,17 @@ void ValidateModelAllocationThresholds(
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestKeywordModelMemoryThreshold) {
-  tflite::AllOpsResolver all_ops_resolver;
+  tflite::MicroMutableOpResolver<4> op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(
+      op_resolver.AddFullyConnected(tflite::Register_FULLY_CONNECTED_INT8()),
+      kTfLiteOk);
+  TF_LITE_MICRO_EXPECT_EQ(op_resolver.AddQuantize(), kTfLiteOk);
+  TF_LITE_MICRO_EXPECT_EQ(
+      op_resolver.AddSoftmax(tflite::Register_SOFTMAX_INT8_INT16()), kTfLiteOk);
+  TF_LITE_MICRO_EXPECT_EQ(op_resolver.AddSvdf(tflite::Register_SVDF_INT8()),
+                          kTfLiteOk);
   tflite::RecordingMicroInterpreter interpreter(
-      tflite::GetModel(g_keyword_scrambled_model_data), all_ops_resolver,
+      tflite::GetModel(g_keyword_scrambled_model_data), op_resolver,
       keyword_model_tensor_arena, kKeywordModelTensorArenaSize);
 
   interpreter.AllocateTensors();
@@ -253,10 +262,17 @@ TF_LITE_MICRO_TEST(TestKeywordModelMemoryThreshold) {
 }
 
 TF_LITE_MICRO_TEST(TestConvModelMemoryThreshold) {
-  tflite::AllOpsResolver all_ops_resolver;
+  tflite::MicroMutableOpResolver<6> op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(op_resolver.AddConv2D(), kTfLiteOk);
+  TF_LITE_MICRO_EXPECT_EQ(op_resolver.AddQuantize(), kTfLiteOk);
+  TF_LITE_MICRO_EXPECT_EQ(op_resolver.AddMaxPool2D(), kTfLiteOk);
+  TF_LITE_MICRO_EXPECT_EQ(op_resolver.AddReshape(), kTfLiteOk);
+  TF_LITE_MICRO_EXPECT_EQ(op_resolver.AddFullyConnected(), kTfLiteOk);
+  TF_LITE_MICRO_EXPECT_EQ(op_resolver.AddDequantize(), kTfLiteOk);
+
   tflite::RecordingMicroInterpreter interpreter(
-      tflite::GetModel(kTestConvModelData), all_ops_resolver,
-      test_conv_tensor_arena, kTestConvModelArenaSize);
+      tflite::GetModel(kTestConvModelData), op_resolver, test_conv_tensor_arena,
+      kTestConvModelArenaSize);
 
   interpreter.AllocateTensors();
 

--- a/tensorflow/lite/micro/memory_arena_threshold_test.cc
+++ b/tensorflow/lite/micro/memory_arena_threshold_test.cc
@@ -15,10 +15,10 @@ limitations under the License.
 
 #include <stdint.h>
 
-#include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 #include "tensorflow/lite/micro/kernels/svdf.h"
 #include "tensorflow/lite/micro/memory_helpers.h"
 #include "tensorflow/lite/micro/memory_planner/greedy_memory_planner.h"
+#include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 #include "tensorflow/lite/micro/models/keyword_scrambled_model_data.h"
 #include "tensorflow/lite/micro/recording_micro_allocator.h"
 #include "tensorflow/lite/micro/recording_micro_interpreter.h"

--- a/tensorflow/lite/micro/micro_allocator_test.cc
+++ b/tensorflow/lite/micro/micro_allocator_test.cc
@@ -271,7 +271,9 @@ TF_LITE_MICRO_TEST(TestMissingQuantization) {
 
 TF_LITE_MICRO_TEST(TestFailsWhenModelStartsTwice) {
   const tflite::Model* model = tflite::testing::GetSimpleMockModel();
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
   constexpr size_t arena_size = 1024;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator =
@@ -284,7 +286,9 @@ TF_LITE_MICRO_TEST(TestFailsWhenModelStartsTwice) {
 TF_LITE_MICRO_TEST(TestFailsWithWrongSequence) {
   const tflite::Model* model = tflite::testing::GetSimpleMockModel();
   tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
   tflite::SubgraphAllocations* subgraph_allocations = nullptr;
   constexpr size_t arena_size = 1024;
   uint8_t arena[arena_size];
@@ -305,7 +309,9 @@ TF_LITE_MICRO_TEST(TestFailsWithWrongSequence) {
 TF_LITE_MICRO_TEST(TestMockModelAllocation) {
   const tflite::Model* model = tflite::testing::GetSimpleMockModel();
   tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
   constexpr size_t arena_size = 1024 + 16;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator =
@@ -351,7 +357,9 @@ TF_LITE_MICRO_TEST(TestMockModelAllocation) {
 TF_LITE_MICRO_TEST(TestMockModelAllocationInTwoSeparateArenas) {
   const tflite::Model* model = tflite::testing::GetSimpleMockModel();
   tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
   constexpr size_t arena_size = 1024;
   uint8_t persistent_arena[arena_size];
   uint8_t non_persistent_arena[arena_size];
@@ -395,7 +403,9 @@ TF_LITE_MICRO_TEST(TestMockModelAllocationInTwoSeparateArenas) {
 TF_LITE_MICRO_TEST(TestMockModelAllocationWithGivenMemoryPlanner) {
   const tflite::Model* model = tflite::testing::GetSimpleMockModel();
   tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
   constexpr size_t arena_size = 1024;
   uint8_t arena[arena_size];
   tflite::GreedyMemoryPlanner memory_planner;
@@ -442,7 +452,9 @@ TF_LITE_MICRO_TEST(TestMockModelAllocationWithGivenMemoryPlanner) {
 TF_LITE_MICRO_TEST(TestMultiTenantAllocation) {
   // The `OpResolver` is shared among different models in this test for
   // simplicity but in practice you could have different `OpResolver`.
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
 
   // Create a shared allocator.
   constexpr size_t arena_size = 4096;
@@ -481,7 +493,9 @@ TF_LITE_MICRO_TEST(TestMultiTenantAllocation) {
 TF_LITE_MICRO_TEST(TestMultiTenantAllocationInTwoSeparateArenas) {
   // The `OpResolver` is shared among different models in this test for
   // simplicity but in practice you could have different `OpResolver`.
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
 
   // Create a shared allocator.
   constexpr size_t arena_size = 4096;
@@ -521,7 +535,9 @@ TF_LITE_MICRO_TEST(TestMultiTenantAllocationInTwoSeparateArenas) {
 TF_LITE_MICRO_TEST(TestAllocationForModelsWithBranches) {
   const tflite::Model* model = tflite::testing::GetSimpleModelWithBranch();
   tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
   constexpr size_t arena_size = 4096;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator =
@@ -570,7 +586,9 @@ TF_LITE_MICRO_TEST(TestAllocationForModelsWithBranches) {
 TF_LITE_MICRO_TEST(TestAllocationForComplexModelAllocation) {
   const tflite::Model* model = tflite::testing::GetComplexMockModel();
   tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
   constexpr size_t arena_size = 2048;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator =
@@ -632,7 +650,9 @@ TF_LITE_MICRO_TEST(OfflinePlannerBranchesAllOnline) {
   int version = 1;
   int subgraph = 0;
   constexpr int number_tensors = 4;
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
   const int32_t metadata_buffer[tflite::testing::kOfflinePlannerHeaderSize +
                                 number_tensors] = {version, subgraph,
                                                    number_tensors,  // header
@@ -699,7 +719,9 @@ TF_LITE_MICRO_TEST(OfflinePlannerBranchesAllOnline) {
 
 TF_LITE_MICRO_TEST(OfflinePlannerBasic) {
   constexpr int number_tensors = 4;
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
   const int32_t metadata_buffer[tflite::testing::kOfflinePlannerHeaderSize +
                                 number_tensors] = {1,         0, number_tensors,
                                                    /*t0=*/0,
@@ -749,7 +771,9 @@ TF_LITE_MICRO_TEST(OfflinePlannerBasic) {
 
 TF_LITE_MICRO_TEST(OfflinePlannerOverlappingAllocation) {
   constexpr int number_tensors = 4;
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
   const int32_t metadata_buffer[tflite::testing::kOfflinePlannerHeaderSize +
                                 number_tensors] = {/*version=*/1,
                                                    /*subgraph=*/0,
@@ -802,7 +826,9 @@ TF_LITE_MICRO_TEST(OfflinePlannerOverlappingAllocation) {
 
 TF_LITE_MICRO_TEST(OfflinePlannerOfflineOnline) {
   constexpr int number_tensors = 5;
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
   const int32_t metadata_buffer[tflite::testing::kOfflinePlannerHeaderSize +
                                 number_tensors] = {/*version=*/1,
                                                    /*subgraph=*/0,
@@ -999,7 +1025,9 @@ TF_LITE_MICRO_TEST(TestAllocateTfLiteTensorWithReset) {
 
 TF_LITE_MICRO_TEST(TestOperatorInputsNotInSubgraphInputs) {
   constexpr int number_tensors = 5;
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
   const int32_t metadata_buffer[tflite::testing::kOfflinePlannerHeaderSize +
                                 number_tensors] = {/*version=*/1,
                                                    /*subgraph=*/0,
@@ -1060,7 +1088,9 @@ TF_LITE_MICRO_TEST(TestOperatorInputsNotInSubgraphInputs) {
 
 TF_LITE_MICRO_TEST(TestTypicalFirstOpAndSecondOpWithScratchTensors) {
   constexpr int number_tensors = 6;
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
   const int32_t metadata_buffer[tflite::testing::kOfflinePlannerHeaderSize +
                                 number_tensors] = {/*version=*/1,
                                                    /*subgraph=*/0,
@@ -1126,7 +1156,9 @@ TF_LITE_MICRO_TEST(TestTypicalFirstOpAndSecondOpWithScratchTensors) {
 }
 
 TF_LITE_MICRO_TEST(TestModelWithUnusedTensors) {
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
 
   const tflite::Model* model = tflite::testing::GetModelWithUnusedInputs();
 
@@ -1162,7 +1194,9 @@ TF_LITE_MICRO_TEST(TestModelWithUnusedTensors) {
 }
 
 TF_LITE_MICRO_TEST(TestModelWithUnusedOperatorOutputs) {
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
 
   const tflite::Model* model =
       tflite::testing::GetModelWithUnusedOperatorOutputs();
@@ -1225,7 +1259,9 @@ TF_LITE_MICRO_TEST(TestMockModelAllocationByNonPersistentMemoryPlannerShim) {
   tflite::NonPersistentMemoryPlannerShim planner(non_persistent_buffer_plan);
 
   tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
   constexpr size_t arena_size = 1024;
   uint8_t arena[arena_size];
   tflite::MicroAllocator* allocator =

--- a/tensorflow/lite/micro/micro_interpreter_test.cc
+++ b/tensorflow/lite/micro/micro_interpreter_test.cc
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include <cstdint>
 
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/arena_allocator/recording_single_arena_buffer_allocator.h"
 #include "tensorflow/lite/micro/compatibility.h"
 #include "tensorflow/lite/micro/micro_arena_constants.h"
@@ -28,6 +27,7 @@ limitations under the License.
 
 namespace tflite {
 namespace {
+
 constexpr size_t buffer_arena_size = 256 * 1024;
 uint8_t arena_buffer[buffer_arena_size];
 class MockProfiler : public MicroProfilerInterface {
@@ -59,8 +59,9 @@ TF_LITE_MICRO_TESTS_BEGIN
 TF_LITE_MICRO_TEST(TestInterpreter) {
   const tflite::Model* model = tflite::testing::GetSimpleMockModel();
   TF_LITE_MICRO_EXPECT(nullptr != model);
-
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
 
   constexpr size_t allocator_buffer_size = 2000;
   uint8_t allocator_buffer[allocator_buffer_size];
@@ -108,7 +109,9 @@ TF_LITE_MICRO_TEST(TestInterpreter) {
 }
 
 TF_LITE_MICRO_TEST(TestMultiTenantInterpreter) {
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
   constexpr size_t arena_size = 8192;
   uint8_t arena[arena_size];
 
@@ -198,7 +201,9 @@ TF_LITE_MICRO_TEST(TestKernelMemoryPlanning) {
   const tflite::Model* model = tflite::testing::GetSimpleStatefulModel();
   TF_LITE_MICRO_EXPECT(nullptr != model);
 
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
 
   constexpr size_t allocator_buffer_size = 4096 + 1024;
   uint8_t allocator_buffer[allocator_buffer_size];
@@ -249,7 +254,9 @@ TF_LITE_MICRO_TEST(TestIncompleteInitialization) {
   const tflite::Model* model = tflite::testing::GetComplexMockModel();
   TF_LITE_MICRO_EXPECT(nullptr != model);
 
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
 
   constexpr size_t allocator_buffer_size = 2048;
   uint8_t allocator_buffer[allocator_buffer_size];
@@ -264,7 +271,9 @@ TF_LITE_MICRO_TEST(InterpreterWithProfilerShouldProfileOps) {
   const tflite::Model* model = tflite::testing::GetComplexMockModel();
   TF_LITE_MICRO_EXPECT(nullptr != model);
 
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
 
   constexpr size_t allocator_buffer_size = 2048;
   uint8_t allocator_buffer[allocator_buffer_size];
@@ -290,7 +299,9 @@ TF_LITE_MICRO_TEST(TestIncompleteInitializationAllocationsWithSmallArena) {
   const tflite::Model* model = tflite::testing::GetComplexMockModel();
   TF_LITE_MICRO_EXPECT(nullptr != model);
 
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
 
   // This test is designed to create the following classes/buffers successfully
   // on the arena:
@@ -351,7 +362,9 @@ TF_LITE_MICRO_TEST(TestInterpreterDoesNotAllocateUntilInvoke) {
   const tflite::Model* model = tflite::testing::GetComplexMockModel();
   TF_LITE_MICRO_EXPECT(nullptr != model);
 
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
 
   constexpr size_t allocator_buffer_size = 1024 * 10;
   uint8_t allocator_buffer[allocator_buffer_size];
@@ -420,7 +433,9 @@ TF_LITE_MICRO_TEST(TestInterpreterMultipleInputs) {
   const tflite::Model* model = tflite::testing::GetSimpleMultipleInputsModel();
   TF_LITE_MICRO_EXPECT(nullptr != model);
 
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
 
   constexpr size_t allocator_buffer_size = 2000;
   uint8_t allocator_buffer[allocator_buffer_size];
@@ -483,7 +498,10 @@ TF_LITE_MICRO_TEST(TestInterpreterNullInputsAndOutputs) {
       tflite::testing::GetSimpleModelWithNullInputsAndOutputs();
   TF_LITE_MICRO_EXPECT(nullptr != model);
 
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, op_resolver.AddCallOnce());
 
   constexpr size_t allocator_buffer_size = 2000;
   uint8_t allocator_buffer[allocator_buffer_size];
@@ -505,7 +523,9 @@ TF_LITE_MICRO_TEST(TestArenaUsedBytes) {
   const tflite::Model* model = tflite::testing::GetModelWith256x256Tensor();
   TF_LITE_MICRO_EXPECT(nullptr != model);
 
-  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
   tflite::MicroInterpreter interpreter(model, op_resolver, tflite::arena_buffer,
                                        tflite::buffer_arena_size);
   TF_LITE_MICRO_EXPECT_EQ(interpreter.AllocateTensors(), kTfLiteOk);

--- a/tensorflow/lite/micro/recording_micro_allocator_test.cc
+++ b/tensorflow/lite/micro/recording_micro_allocator_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/micro/recording_micro_allocator.h"
 
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/micro_allocator.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
@@ -37,7 +36,7 @@ TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(TestRecordsTfLiteEvalTensorArrayData) {
   tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
-  tflite::AllOpsResolver all_ops_resolver;
+  tflite::testing::TestingOpResolver ops_resolver;
   const tflite::Model* model = tflite::GetModel(kTestConvModelData);
   uint8_t arena[kTestConvArenaSize];
 
@@ -77,7 +76,7 @@ TF_LITE_MICRO_TEST(TestRecordsTfLiteEvalTensorArrayData) {
 
 TF_LITE_MICRO_TEST(TestRecordsNodeAndRegistrationArrayData) {
   tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
-  tflite::AllOpsResolver all_ops_resolver;
+  tflite::testing::TestingOpResolver ops_resolver;
   const tflite::Model* model = tflite::GetModel(kTestConvModelData);
   uint8_t arena[kTestConvArenaSize];
 
@@ -110,7 +109,7 @@ TF_LITE_MICRO_TEST(TestRecordsNodeAndRegistrationArrayData) {
 
 TF_LITE_MICRO_TEST(TestRecordsMultiTenantAllocations) {
   tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
-  tflite::AllOpsResolver all_ops_resolver;
+  tflite::testing::TestingOpResolver ops_resolver;
   const tflite::Model* model = tflite::GetModel(kTestConvModelData);
 
   // Double the arena size to allocate two models inside of it:
@@ -267,7 +266,7 @@ TF_LITE_MICRO_TEST(TestRecordsPersistentBufferData) {
 
 TF_LITE_MICRO_TEST(TestMultiSubgraphModel) {
   tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
-  tflite::AllOpsResolver all_ops_resolver;
+  tflite::testing::TestingOpResolver ops_resolver;
   const tflite::Model* model =
       tflite::testing::GetSimpleModelWithNullInputsAndOutputs();
   const int arena_size = 2048;

--- a/tensorflow/lite/micro/test_helper_custom_ops.cc
+++ b/tensorflow/lite/micro/test_helper_custom_ops.cc
@@ -26,7 +26,6 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/compatibility.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 #include "tensorflow/lite/schema/schema_generated.h"

--- a/tensorflow/lite/micro/test_helper_custom_ops.h
+++ b/tensorflow/lite/micro/test_helper_custom_ops.h
@@ -23,7 +23,6 @@ limitations under the License.
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/compatibility.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 #include "tensorflow/lite/portable_type_to_tflitetype.h"
 #include "tensorflow/lite/schema/schema_generated.h"

--- a/tensorflow/lite/micro/test_helpers.cc
+++ b/tensorflow/lite/micro/test_helpers.cc
@@ -1654,16 +1654,20 @@ TfLiteStatus NoOp::Invoke(TfLiteContext* context, TfLiteNode* node) {
 
 bool NoOp::freed_ = false;
 
-AllOpsResolver GetOpResolver() {
-  AllOpsResolver op_resolver;
-  op_resolver.AddCustom("mock_custom", MockCustom::GetMutableRegistration());
-  op_resolver.AddCustom("simple_stateful_op",
-                        SimpleStatefulOp::GetMutableRegistration());
-  op_resolver.AddCustom("multiple_inputs_op",
-                        MultipleInputs::GetMutableRegistration());
-  op_resolver.AddCustom("no_op", NoOp::GetMutableRegistration());
-  op_resolver.AddCustom("custom_packer_op", PackerOp::GetMutableRegistration());
-  return op_resolver;
+TfLiteStatus GetTestingOpResolver(
+    tflite::testing::TestingOpResolver& op_resolver) {
+  TF_LITE_ENSURE_STATUS(op_resolver.AddCustom(
+      "mock_custom", MockCustom::GetMutableRegistration()));
+  TF_LITE_ENSURE_STATUS(op_resolver.AddCustom(
+      "simple_stateful_op", SimpleStatefulOp::GetMutableRegistration()));
+  TF_LITE_ENSURE_STATUS(op_resolver.AddCustom(
+      "multiple_inputs_op", MultipleInputs::GetMutableRegistration()));
+  TF_LITE_ENSURE_STATUS(
+      op_resolver.AddCustom("no_op", NoOp::GetMutableRegistration()));
+  TF_LITE_ENSURE_STATUS(op_resolver.AddCustom(
+      "custom_packer_op", PackerOp::GetMutableRegistration()));
+  TF_LITE_ENSURE_STATUS(op_resolver.AddIf());
+  return kTfLiteOk;
 }
 
 const Model* GetModelWithUnusedInputs() {

--- a/tensorflow/lite/micro/test_helpers.h
+++ b/tensorflow/lite/micro/test_helpers.h
@@ -23,7 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/compatibility.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
+#include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 #include "tensorflow/lite/portable_type_to_tflitetype.h"
 #include "tensorflow/lite/schema/schema_generated.h"
@@ -32,6 +32,7 @@ namespace tflite {
 namespace testing {
 
 constexpr int kOfflinePlannerHeaderSize = 3;
+using TestingOpResolver = tflite::MicroMutableOpResolver<10>;
 
 struct NodeConnection_ {
   std::initializer_list<int32_t> input;
@@ -102,7 +103,7 @@ class NoOp {
 };
 
 // Returns an Op Resolver that can be used in the testing code.
-AllOpsResolver GetOpResolver();
+TfLiteStatus GetTestingOpResolver(TestingOpResolver& op_resolver);
 
 // Returns a simple example flatbuffer TensorFlow Lite model. Contains 1 input,
 // 1 layer of weights, 1 output Tensor, and 1 operator.

--- a/third_party/xtensa/examples/micro_speech_lstm/micro_speech_lstm_test.cc
+++ b/third_party/xtensa/examples/micro_speech_lstm/micro_speech_lstm_test.cc
@@ -60,11 +60,6 @@ TF_LITE_MICRO_TEST(TestInvoke) {
 
   // Pull in only the operation implementations we need.
   // This relies on a complete list of all the ops needed by this graph.
-  // An easier approach is to just use the AllOpsResolver, but this will
-  // incur some penalty in code space for op implementations that are not
-  // needed by this graph.
-  //
-  // tflite::AllOpsResolver resolver;
   tflite::MicroMutableOpResolver<4> micro_op_resolver;
   micro_op_resolver.AddUnidirectionalSequenceLSTM();
   micro_op_resolver.AddReshape();


### PR DESCRIPTION
Gets rid of all references/usage of AllOpsResolver in the TFLM repo

[corresponding google3 cl](https://critique.corp.google.com/cl/528512732)

BUG=[b/280326818](https://b.corp.google.com/issues/280326818)