### PR TITLE
Revert "Workaround for failing arm-gcc download (#1950)"

### DIFF
--- a/tensorflow/lite/micro/tools/make/arm_gcc_download.sh
+++ b/tensorflow/lite/micro/tools/make/arm_gcc_download.sh
@@ -83,9 +83,7 @@ else
 
   TEMPDIR=$(mktemp -d)
   TEMPFILE=${TEMPDIR}/temp_file
-  # TODO(b/200052821) and TODO(#508): remove no-check-certificate once it is no
-  # longer required.
-  wget ${GCC_URL} --no-check-certificate -O ${TEMPFILE} >&2
+  wget ${GCC_URL} -O ${TEMPFILE} >&2
   check_md5 ${TEMPFILE} ${EXPECTED_MD5}
 
   mkdir ${DOWNLOADED_GCC_PATH}


### PR DESCRIPTION
This reverts commit b3e202b1d139834116a57008ab0d809797d8caac.

BUG=https://github.com/tensorflow/tflite-micro/issues/508

It should be working again now!