### PR TITLE
adds PythonOpsResolver 

### DIFF
--- a/tensorflow/extra_rules.bzl
+++ b/tensorflow/extra_rules.bzl
@@ -4,6 +4,9 @@ def tflm_kernel_friends():
 def tflm_audio_frontend_friends():
     return []
 
+def tflm_python_op_resolver_friends():
+    return []
+
 def xtensa_fusion_f1_config():
     """Config setting for all Fusion F1 based cores."""
     return "//tensorflow/lite/micro/kernels:xtensa_fusion_f1_default"

--- a/tensorflow/lite/micro/kernels/split_test.cc
+++ b/tensorflow/lite/micro/kernels/split_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/debug_log.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"

--- a/tensorflow/lite/micro/python/interpreter/src/BUILD
+++ b/tensorflow/lite/micro/python/interpreter/src/BUILD
@@ -1,10 +1,41 @@
 load("@pybind11_bazel//:build_defs.bzl", "pybind_extension", "pybind_library")
 load("@tflm_pip_deps//:requirements.bzl", "requirement")
+load(
+    "//tensorflow/lite/micro:build_def.bzl",
+    "micro_copts",
+)
+load(
+    "//tensorflow:extra_rules.bzl",
+    "tflm_python_op_resolver_friends",
+)
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["-layering_check"],
     licenses = ["notice"],
+)
+
+package_group(
+    name = "op_resolver_friends",
+    packages = tflm_python_op_resolver_friends(),
+)
+
+cc_library(
+    name = "python_ops_resolver",
+    srcs = [
+        "python_ops_resolver.cc",
+    ],
+    hdrs = [
+        "python_ops_resolver.h",
+    ],
+    copts = micro_copts(),
+    visibility = [
+        ":op_resolver_friends",
+    ],
+    deps = [
+        "//tensorflow/lite/micro:micro_compatibility",
+        "//tensorflow/lite/micro:op_resolvers",
+        "//tensorflow/lite/micro/kernels:micro_ops",
+    ],
 )
 
 # Append _lib at the end to avoid naming collision with the extension below
@@ -24,6 +55,7 @@ pybind_library(
         "shared_library.h",
     ],
     deps = [
+        ":python_ops_resolver",
         "//tensorflow/lite/micro:micro_framework",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:recording_allocators",
@@ -46,10 +78,9 @@ pybind_extension(
 py_library(
     name = "tflm_runtime",
     srcs = ["tflm_runtime.py"],
-    data = [
-        ":interpreter_wrapper_pybind.so",
-    ],
+    data = [":interpreter_wrapper_pybind.so"],
     srcs_version = "PY3",
+    visibility = ["//visibility:public"],
     deps = [
         requirement("numpy"),
         "//tensorflow/lite/tools:flatbuffer_utils",

--- a/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
+++ b/tensorflow/lite/micro/python/interpreter/src/interpreter_wrapper.h
@@ -17,8 +17,8 @@ limitations under the License.
 
 #include <Python.h>
 
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
+#include "tensorflow/lite/micro/python/interpreter/src/python_ops_resolver.h"
 #include "tensorflow/lite/micro/recording_micro_allocator.h"
 
 namespace tflite {
@@ -42,7 +42,7 @@ class InterpreterWrapper {
   tflite::RecordingMicroAllocator* allocator_;
   const PyObject* model_;
   std::unique_ptr<uint8_t[]> memory_arena_;
-  tflite::AllOpsResolver all_ops_resolver_;
+  tflite::PythonOpsResolver python_ops_resolver_;
   tflite::MicroInterpreter* interpreter_;
 };
 

--- a/tensorflow/lite/micro/python/interpreter/src/python_ops_resolver.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/python_ops_resolver.cc
@@ -1,0 +1,123 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/micro/python/interpreter/src/python_ops_resolver.h"
+
+#include "tensorflow/lite/micro/kernels/micro_ops.h"
+
+namespace tflite {
+
+PythonOpsResolver::PythonOpsResolver() {
+  // Please keep this list of Builtin Operators in alphabetical order.
+  AddAbs();
+  AddAdd();
+  AddAddN();
+  AddArgMax();
+  AddArgMin();
+  AddAssignVariable();
+  AddAveragePool2D();
+  AddBatchToSpaceNd();
+  AddBroadcastArgs();
+  AddBroadcastTo();
+  AddCallOnce();
+  AddCast();
+  AddCeil();
+  AddCircularBuffer();
+  AddConcatenation();
+  AddConv2D();
+  AddCos();
+  AddCumSum();
+  AddDepthToSpace();
+  AddDepthwiseConv2D();
+  AddDequantize();
+  AddDetectionPostprocess();
+  AddDiv();
+  AddElu();
+  AddEqual();
+  AddEthosU();
+  AddExp();
+  AddExpandDims();
+  AddFill();
+  AddFloor();
+  AddFloorDiv();
+  AddFloorMod();
+  AddFullyConnected();
+  AddGather();
+  AddGatherNd();
+  AddGreater();
+  AddGreaterEqual();
+  AddHardSwish();
+  AddIf();
+  AddL2Normalization();
+  AddL2Pool2D();
+  AddLeakyRelu();
+  AddLess();
+  AddLessEqual();
+  AddLog();
+  AddLogicalAnd();
+  AddLogicalNot();
+  AddLogicalOr();
+  AddLogistic();
+  AddLogSoftmax();
+  AddMaxPool2D();
+  AddMaximum();
+  AddMean();
+  AddMinimum();
+  AddMirrorPad();
+  AddMul();
+  AddNeg();
+  AddNotEqual();
+  AddPack();
+  AddPad();
+  AddPadV2();
+  AddPrelu();
+  AddQuantize();
+  AddReadVariable();
+  AddReduceMax();
+  AddRelu();
+  AddRelu6();
+  AddReshape();
+  AddResizeBilinear();
+  AddResizeNearestNeighbor();
+  AddRound();
+  AddRsqrt();
+  AddSelectV2();
+  AddShape();
+  AddSin();
+  AddSlice();
+  AddSoftmax();
+  AddSpaceToBatchNd();
+  AddSpaceToDepth();
+  AddSplit();
+  AddSplitV();
+  AddSqrt();
+  AddSquare();
+  AddSquaredDifference();
+  AddSqueeze();
+  AddStridedSlice();
+  AddSub();
+  AddSum();
+  AddSvdf();
+  AddTanh();
+  AddTranspose();
+  AddTransposeConv();
+  AddUnidirectionalSequenceLSTM();
+  AddUnpack();
+  AddVarHandle();
+  AddWhile();
+  AddZerosLike();
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/python/interpreter/src/python_ops_resolver.h
+++ b/tensorflow/lite/micro/python/interpreter/src/python_ops_resolver.h
@@ -1,0 +1,36 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_LITE_MICRO_PYTHON_OPS_RESOLVER_H_
+#define TENSORFLOW_LITE_MICRO_PYTHON_OPS_RESOLVER_H_
+
+#include "tensorflow/lite/micro/compatibility.h"
+#include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
+
+namespace tflite {
+
+// PythonOpsResolver is used to register all the Ops for the TFLM Python
+// interpreter. This is ok since code size is not a concern from Python and
+// the goal is to be able to run any model supported by TFLM in a flexible way
+class PythonOpsResolver : public MicroMutableOpResolver<200> {
+ public:
+  PythonOpsResolver();
+
+ private:
+  TF_LITE_REMOVE_VIRTUAL_DELETE
+};
+
+}  // namespace tflite
+
+#endif  // TENSORFLOW_LITE_MICRO_PYTHON_OPS_RESOLVER_H_

--- a/tensorflow/lite/micro/test_helpers.cc
+++ b/tensorflow/lite/micro/test_helpers.cc
@@ -26,7 +26,6 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/compatibility.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
-#include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/memory_helpers.h"
 #include "tensorflow/lite/micro/micro_arena_constants.h"


### PR DESCRIPTION
This PR does the following: 

1. Introduces PythonOpsResolver Target 
2. removes a reference to AllOpsResolver in remaing places in TFLM repo outside of integration_tests

[doc for changes](https://docs.google.com/document/d/1vafCGaFGGBauAssAdFABtmgpiRju2V3isioZfLMgeEc/edit?resourcekey=0-pc-aJl3TPZ7NcO9RxrNsrA#)

[google3 cl](https://critique.corp.google.com/cl/531013669)

NO_CHECK_GITHUB_FILES= readability review g3