### PR TITLE
build: upgrade C++ std used in py/cc_deps_link_test

### DIFF
--- a/python/tests/BUILD
+++ b/python/tests/BUILD
@@ -5,11 +5,10 @@ cc_test(
         "cc_deps_link_test.cc",
     ],
     copts = [
-        "-std=c++14",
-        # Compiling against upstream Tensorflow headers requires -std=c++14
-        # due (at least) to its dependency on Eigen, which raises the error
-        # "This compiler appears to be too told to be supported by Eigen"
-        # via the preprocessor, as well as several compilation errors.
+        "-std=c++17",
+        # Compiling against upstream Tensorflow headers requires -std=c++17 due
+        # (at least) to Tensorflow's use of the type trait
+        # std::is_arithmetic_v, which was introduced in C++17.
         #
         # TODO(b/271210933): Harmonize this with a global solution
         # throughout the repository. Presumably this same issue will be


### PR DESCRIPTION
In preparation for upgrading the Tensorflow Python package dependency, upgrade
the C++ standard used when compiling //python/tests:cc_deps_link_test from
C++14 to C++17. cc_deps_link_test tests linking against the Tensorflow Python
package's extension module.

Bug=#1966.