### PR TITLE
refactor: fix incorrect comment in interface of KernelRunner

### DIFF
--- a/tensorflow/lite/micro/kernels/kernel_runner.h
+++ b/tensorflow/lite/micro/kernels/kernel_runner.h
@@ -43,9 +43,9 @@ class KernelRunner {
   TfLiteStatus InitAndPrepare(const char* init_data = nullptr,
                               size_t length = 0);
 
-  // Calls init, prepare, and invoke on a given TfLiteRegistration_V1 pointer.
-  // After successful invoke, results will be available in the output tensor as
-  // passed into the constructor of this class.
+  // Calls invoke on a given TfLiteRegistration_V1 pointer. After successful
+  // invoke, results will be available in the output tensor as passed into the
+  // constructor of this class.
   TfLiteStatus Invoke();
 
   // Calls Free on a given TfLiteRegistration_V1 pointer(if it's implemented).


### PR DESCRIPTION
Fix the incorrect function comment on KernelRunner::Invoke(),
which says it calls a kernel registration's init and
prepare---implying the call InitAndPrepare is optional. In fact,
Invoke() does not call init and prepare; it only calls invoke.

Bug=see description
