### PR TITLE
Fix issue creation when generate_integration_tests fails.

### DIFF
--- a/.github/workflows/generate_integration_tests.yml
+++ b/.github/workflows/generate_integration_tests.yml
@@ -24,7 +24,7 @@ jobs:
     name: Generate Integration Tests
     steps:
       - uses: actions/setup-python@v4
-        with: 
+        with:
           python-version: '3.10'
       - uses: actions/checkout@v2
       - name: Install dependencies
@@ -35,17 +35,6 @@ jobs:
       - name: Test
         run: |
           tensorflow/lite/micro/tools/ci_build/test_generate_integration_tests.sh
-      - name: error trapping
-        if: ${{ failure() }}
-        env:
-          WORKFLOW: ${{ github.workflow }}
-          RUN_NUMBER: ${{ github.run_number }}
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          FLAG_LABEL: ci:bot_issue
-        run: |
-          pip3 install PyGithub
-          python3 ci/issue_on_error.py
 
   issue-on-error:
     needs: [generate_integration_tests]

--- a/.github/workflows/issue_on_error.yml
+++ b/.github/workflows/issue_on_error.yml
@@ -1,15 +1,15 @@
 name: Issue On Error
 
-# This workflow can be called from other workflows in order to generate 
+# This workflow can be called from other workflows in order to generate
 # an issue on failure.
 #
 # With only the required inputs issue will have the title of the failing workflow
 # and a link to it.
 #
-# If the optional pr_number and link are provided the title and link will be for 
+# If the optional pr_number and link are provided the title and link will be for
 # the PR.
-# 
-# Either type of issue will be tagged (by default with ci:bot_issue). 
+#
+# Either type of issue will be tagged (by default with ci:bot_issue).
 # If an issue already exists, a comment will be added with a timestamp of the
 # new failure and a link.
 

--- a/.github/workflows/tests_post.yml
+++ b/.github/workflows/tests_post.yml
@@ -53,4 +53,4 @@ jobs:
               name: 'ci:run_full'
             })
         continue-on-error: true
-      
+


### PR DESCRIPTION
PR #1641 moved all the issue generation into a single workflow. However, that changed missed removing the code in generate_integration_tests.yml.

Also, removed some trailing whitespace in the workflow files.

BUG=fix issue creation on nightly workflow failure.
