### PR TITLE
Remove unused build rule in micro/tools

### DIFF
--- a/tensorflow/lite/micro/tools/BUILD
+++ b/tensorflow/lite/micro/tools/BUILD
@@ -1,5 +1,5 @@
 load("@tflm_pip_deps//:requirements.bzl", "requirement")
-load("@pybind11_bazel//:build_defs.bzl", "pybind_extension", "pybind_library")
+load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
 
 package(
     default_visibility = ["//:__subpackages__"],


### PR DESCRIPTION
We have an unused pybind rule in the micro/tools BUILD file.

BUG=cleanup