### PR TITLE
Adds TFLMRegistration to newly created MicroCommon.h

### DIFF
--- a/tensorflow/lite/micro/BUILD
+++ b/tensorflow/lite/micro/BUILD
@@ -225,11 +225,9 @@ cc_library(
 cc_library(
     name = "op_resolvers",
     srcs = [
-        "all_ops_resolver.cc",
         "micro_op_resolver.cc",
     ],
     hdrs = [
-        "all_ops_resolver.h",
         "micro_mutable_op_resolver.h",
         "micro_op_resolver.h",
     ],

--- a/tensorflow/lite/micro/BUILD
+++ b/tensorflow/lite/micro/BUILD
@@ -73,6 +73,17 @@ cc_library(
 )
 
 cc_library(
+    name = "micro_common",
+    hdrs = [
+        "micro_common.h",
+    ],
+    copts = micro_copts(),
+    deps = [
+        "//tensorflow/lite/c:common",
+    ],
+)
+
+cc_library(
     name = "fake_micro_context",
     srcs = [
         "fake_micro_context.cc",
@@ -214,9 +225,11 @@ cc_library(
 cc_library(
     name = "op_resolvers",
     srcs = [
+        "all_ops_resolver.cc",
         "micro_op_resolver.cc",
     ],
     hdrs = [
+        "all_ops_resolver.h",
         "micro_mutable_op_resolver.h",
         "micro_op_resolver.h",
     ],

--- a/tensorflow/lite/micro/micro_common.h
+++ b/tensorflow/lite/micro/micro_common.h
@@ -5,7 +5,7 @@
 
 // TFLMRegistration defines the API that TFLM kernels need to implement.
 // This will be replacing the current TfLiteRegistration_V1 struct with
-// something more compatible Embedded enviroment TFLM is used in. 
+// something more compatible Embedded enviroment TFLM is used in.
 struct TFLMRegistration {
   void* (*init)(TfLiteContext* context, const char* buffer, size_t length);
   void (*free)(TfLiteContext* context, void* buffer);

--- a/tensorflow/lite/micro/micro_common.h
+++ b/tensorflow/lite/micro/micro_common.h
@@ -4,7 +4,7 @@
 #include "tensorflow/lite/c/common.h"
 
 // TFLMRegistration defines the API that TFLM kernels need to implement.
-// This will be replacing the current TfLiteRegistration_V1 struct with 
+// This will be replacing the current TfLiteRegistration_V1 struct with
 // something more compatible Embedded enviroment TFLM is used in. 
 struct TFLMRegistration {
   void* (*init)(TfLiteContext* context, const char* buffer, size_t length);

--- a/tensorflow/lite/micro/micro_common.h
+++ b/tensorflow/lite/micro/micro_common.h
@@ -1,0 +1,19 @@
+#ifndef THIRD_PARTY_TFLITE_MICRO_TENSORFLOW_LITE_MICRO_MICRO_COMMON_H_
+#define THIRD_PARTY_TFLITE_MICRO_TENSORFLOW_LITE_MICRO_MICRO_COMMON_H_
+
+#include "tensorflow/lite/c/common.h"
+
+// TFLMRegistration defines the API that TFLM kernels need to implement.
+// This will be replacing the current TfLiteRegistration_V1 struct with 
+// something more compatible Embedded enviroment TFLM is used in. 
+struct TFLMRegistration {
+  void* (*init)(TfLiteContext* context, const char* buffer, size_t length);
+  void (*free)(TfLiteContext* context, void* buffer);
+  TfLiteStatus (*prepare)(TfLiteContext* context, TfLiteNode* node);
+  TfLiteStatus (*invoke)(TfLiteContext* context, TfLiteNode* node);
+  void (*reset)(TfLiteContext* context, void* buffer);
+  int32_t builtin_code;
+  const char* custom_name;
+};
+
+#endif  // THIRD_PARTY_TFLITE_MICRO_TENSORFLOW_LITE_MICRO_MICRO_COMMON_H_

--- a/tensorflow/lite/micro/micro_common.h
+++ b/tensorflow/lite/micro/micro_common.h
@@ -1,3 +1,17 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
 #ifndef THIRD_PARTY_TFLITE_MICRO_TENSORFLOW_LITE_MICRO_MICRO_COMMON_H_
 #define THIRD_PARTY_TFLITE_MICRO_TENSORFLOW_LITE_MICRO_MICRO_COMMON_H_
 


### PR DESCRIPTION
Adds TFLMRegistration to newly created MicroCommon.h

First change in set of changes  to move TFLM entirely away from TfLite Registration struct and add reset into TFLM  explained @ the bottom of the following [Doc](https://docs.google.com/document/d/1giWrZQk1DnC1v-9uDDoos2zNBO06SLI7RatsOMu3RY8/edit?resourcekey=0-wkLBasqHyTZm3POas69tLQ#)

BUG=[b/279811848](https://b.corp.google.com/issues/279811848)
