### PR TITLE
Isolated the flatbuffer LoadFile issue.

### DIFF
--- a/tensorflow/lite/micro/tools/filereader/Makefile.inc
+++ b/tensorflow/lite/micro/tools/filereader/Makefile.inc
@@ -1,0 +1,8 @@
+XTENSA_FILE_READER_ROOT_DIR := tensorflow/lite/micro/tools/filereader
+
+XTENSA_FILE_READER_SRCS := $(XTENSA_FILE_READER_ROOT_DIR)/xtensa_file_reader.cc
+
+XTENSA_FILE_READER_HDRS := $(DOWNLOADS_DIR)/flatbuffers/include/flatbuffers/util.h
+
+$(eval $(call microlite_test,xtensa_file_reader,\
+$(XTENSA_FILE_READER_SRCS),$(XTENSA_FILE_READER_HDRS),))

--- a/tensorflow/lite/micro/tools/filereader/xtensa_file_reader.cc
+++ b/tensorflow/lite/micro/tools/filereader/xtensa_file_reader.cc
@@ -1,0 +1,29 @@
+#include <memory>
+
+#include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
+#include "flatbuffers/util.h"
+
+/*
+ * Generic model benchmark.  Evaluates runtime performance of a provided model
+ * with random inputs.
+ */
+
+namespace tflm {
+namespace xtensa {
+namespace readfile {
+
+namespace {
+
+int ReadFile(const char* model_file_name) {
+  std::string model_file;
+  // Read the file into a string using the included util API call:
+  flatbuffers::LoadFile(model_file_name, false, &model_file);
+  return 0;
+}
+
+}  // namespace
+}  // namespace readfile
+}  // namespace xtensa
+}  // namespace tflm
+
+int main(int argc, char** argv) { return tflm::xtensa::readfile::ReadFile(argv[1]); }

--- a/tensorflow/lite/micro/tools/filereader/xtensa_file_reader.cc
+++ b/tensorflow/lite/micro/tools/filereader/xtensa_file_reader.cc
@@ -1,7 +1,7 @@
 #include <memory>
 
 #include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
-#include "flatbuffers/util.h"
+#include "stdio.h"
 
 /*
  * Generic model benchmark.  Evaluates runtime performance of a provided model
@@ -16,8 +16,13 @@ namespace {
 
 int ReadFile(const char* model_file_name) {
   std::string model_file;
-  // Read the file into a string using the included util API call:
-  flatbuffers::LoadFile(model_file_name, false, &model_file);
+  FILE *fp = fopen(model_file_name, "r");
+  char filecontent[1000];
+  while (fgets(filecontent, 1000, fp) != nullptr){
+    model_file = model_file.append(filecontent);
+  }
+  printf("%s", model_file.c_str());
+  fclose(fp);
   return 0;
 }
 

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -470,7 +470,7 @@ $(DOWNLOADS_DIR)/kissfft/tools/kiss_fftr.c \
 $(DOWNLOADS_DIR)/kissfft/tools/kiss_fftr.h \
 $(DOWNLOADS_DIR)/ruy/ruy/profiler/instrumentation.h
 
-THIRD_PARTY_CC_SRCS :=
+THIRD_PARTY_CC_SRCS := $(DOWNLOADS_DIR)/flatbuffers/src/util.cpp
 THIRD_PARTY_KERNEL_CC_SRCS :=
 
 # Load custom kernels.
@@ -627,6 +627,9 @@ include ${MICRO_LITE_GEN_MUTABLE_OP_RESOLVER_TEST}
 # Load the benchmarks.
 include $(MICRO_LITE_BENCHMARKS)
 
+# Load xtensa filereader
+include $(TENSORFLOW_ROOT)tensorflow/lite/micro/tools/filereader/Makefile.inc
+
 # Load custom kernel tests.
 include $(MAKEFILE_DIR)/additional_tests.inc
 
@@ -639,7 +642,7 @@ MICROLITE_LIB_OBJS := $(addprefix $(CORE_OBJDIR), \
 $(patsubst %.S,%.o,$(patsubst %.cc,%.o,$(patsubst %.c,%.o,$(MICROLITE_CC_SRCS)))))
 
 MICROLITE_THIRD_PARTY_OBJS := $(addprefix $(THIRD_PARTY_OBJDIR), \
-$(patsubst %.S,%.o,$(patsubst %.cc,%.o,$(patsubst %.c,%.o,$(THIRD_PARTY_CC_SRCS)))))
+$(patsubst %.S,%.o,$(patsubst %.cc,%.o,$(patsubst %.cpp,%.o,$(patsubst %.c,%.o,$(THIRD_PARTY_CC_SRCS))))))
 
 MICROLITE_THIRD_PARTY_KERNEL_OBJS := $(addprefix $(THIRD_PARTY_KERNEL_OBJDIR), \
 $(patsubst %.S,%.o,$(patsubst %.cc,%.o,$(patsubst %.c,%.o,$(THIRD_PARTY_KERNEL_CC_SRCS)))))
@@ -658,6 +661,10 @@ $(CORE_OBJDIR)%.o: %.c $(THIRD_PARTY_TARGETS)
 $(CORE_OBJDIR)%.o: %.S $(THIRD_PARTY_TARGETS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CCFLAGS) $(CORE_OPTIMIZATION_LEVEL) $(INCLUDES) -c $< -o $@
+
+$(THIRD_PARTY_OBJDIR)%.o: %.cpp $(THIRD_PARTY_TARGETS)
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(CORE_OPTIMIZATION_LEVEL) $(INCLUDES) -c $< -o $@
 
 $(THIRD_PARTY_OBJDIR)%.o: %.cc $(THIRD_PARTY_TARGETS)
 	@mkdir -p $(dir $@)

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -470,7 +470,7 @@ $(DOWNLOADS_DIR)/kissfft/tools/kiss_fftr.c \
 $(DOWNLOADS_DIR)/kissfft/tools/kiss_fftr.h \
 $(DOWNLOADS_DIR)/ruy/ruy/profiler/instrumentation.h
 
-THIRD_PARTY_CC_SRCS := $(DOWNLOADS_DIR)/flatbuffers/src/util.cpp
+THIRD_PARTY_CC_SRCS :=
 THIRD_PARTY_KERNEL_CC_SRCS :=
 
 # Load custom kernels.


### PR DESCRIPTION
To compile the code 

```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa \
TARGET_ARCH=hifi4 XTENSA_TOOLS_VERSION=RI-2020.4-linux XTENSA_CORE=HIFI_190304_swupgrade  \
xtensa_file_reader -j24
```

It is surfacing the following compilation errors 
```
tensorflow/lite/micro/tools/make/downloads/flatbuffers/src/util.cpp:77:24: error: implicit instantiation of undefined template 'std::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> >'
    std::ostringstream oss;
                       ^
/usr/local/google/home/dtanmay/xtensa/RI-2020.4-linux/HIFI_190304_swupgrade/xtensa-elf/include/xcc/c++/c++11/iosfwd:517:8: note: template is declared here
        class basic_ostringstream;
              ^
tensorflow/lite/micro/tools/make/downloads/flatbuffers/src/util.cpp:206:5: error: use of undeclared identifier 'mkdir'
    mkdir(filepath.c_str(), S_IRWXU|S_IRGRP|S_IXGRP);
    ^
tensorflow/lite/micro/tools/make/downloads/flatbuffers/src/util.cpp:221:29: error: use of undeclared identifier 'realpath'
      char *abs_path_temp = realpath(filepath.c_str(), nullptr);
```

To run 
```
 xt-run ./gen/xtensa_hifi4_default/bin/xtensa_file_reader /usr/local/google/home/dtanmay/CLionProjects/tflite-micro/tensorflow/lite/micro/examples/hello_world/models/hello_world_int8.tflite  --xtensa-core=HIFI_190304_swupgrade
```