### PR TITLE
Generate integration_test Makefile with correct prefixed file path in GENERATOR_INPUT/SRCS.

### DIFF
--- a/tensorflow/lite/micro/tools/generate_test_for_model.py
+++ b/tensorflow/lite/micro/tools/generate_test_for_model.py
@@ -220,14 +220,14 @@ class TestDataGenerator:
     makefile.write(src_prefix + '_GENERATOR_INPUTS := \\\n')
     for model_path in self.model_paths:
       makefile.write(
-          model_path.split('third_party/tflite_micro/')[-1] + ' \\\n')
+          '$(TENSORFLOW_ROOT)' + model_path.split('third_party/tflite_micro/')[-1] + ' \\\n')
     for csv_input in self.csv_filenames:
       makefile.write(
-          csv_input.split('third_party/tflite_micro/')[-1] + ' \\\n')
+          '$(TENSORFLOW_ROOT)' + csv_input.split('third_party/tflite_micro/')[-1] + ' \\\n')
     makefile.write('\n')
     makefile.write(src_prefix + '_SRCS := \\\n')
     makefile.write(
-        self.output_dir.split('third_party/tflite_micro/')[-1] + '/' +
+        '$(TENSORFLOW_ROOT)' + self.output_dir.split('third_party/tflite_micro/')[-1] + '/' +
         test_file + '  \\\n')
     makefile.write(
         "$(TENSORFLOW_ROOT)tensorflow/lite/micro/python/interpreter/src/python_ops_resolver.cc \\\n"

--- a/tensorflow/lite/micro/tools/generate_test_for_model.py
+++ b/tensorflow/lite/micro/tools/generate_test_for_model.py
@@ -219,16 +219,18 @@ class TestDataGenerator:
           -2] + '_' + output_dir_list[-1]
     makefile.write(src_prefix + '_GENERATOR_INPUTS := \\\n')
     for model_path in self.model_paths:
-      makefile.write(
-          '$(TENSORFLOW_ROOT)' + model_path.split('third_party/tflite_micro/')[-1] + ' \\\n')
+      makefile.write('$(TENSORFLOW_ROOT)' +
+                     model_path.split('third_party/tflite_micro/')[-1] +
+                     ' \\\n')
     for csv_input in self.csv_filenames:
-      makefile.write(
-          '$(TENSORFLOW_ROOT)' + csv_input.split('third_party/tflite_micro/')[-1] + ' \\\n')
+      makefile.write('$(TENSORFLOW_ROOT)' +
+                     csv_input.split('third_party/tflite_micro/')[-1] +
+                     ' \\\n')
     makefile.write('\n')
     makefile.write(src_prefix + '_SRCS := \\\n')
-    makefile.write(
-        '$(TENSORFLOW_ROOT)' + self.output_dir.split('third_party/tflite_micro/')[-1] + '/' +
-        test_file + '  \\\n')
+    makefile.write('$(TENSORFLOW_ROOT)' +
+                   self.output_dir.split('third_party/tflite_micro/')[-1] +
+                   '/' + test_file + '  \\\n')
     makefile.write(
         "$(TENSORFLOW_ROOT)tensorflow/lite/micro/python/interpreter/src/python_ops_resolver.cc \\\n"
     )


### PR DESCRIPTION
BUG=http://b/282976218

Command used to generate the test and verifyed it is working :
```
bazel-bin/tensorflow/lite/micro/integration_tests/generate_per_layer_tests --input_tflite_file=/tmp/seanet_cca_quantized.tflite --output_dir=tensorflow/lite/micro/integration_tests/seanet/transpose_conv
```