### PR TITLE
Update SELECT_V2 to match TFLM kernel code

### DIFF
--- a/tensorflow/lite/micro/kernels/select.cc
+++ b/tensorflow/lite/micro/kernels/select.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
+namespace {
 
 constexpr int kInputTensorCondition = 0;
 constexpr int kInputTensorX = 1;
@@ -32,9 +33,6 @@ constexpr int kOutputTensor = 0;
 
 struct OpData {
   bool requires_broadcast;
-  // True if input condition is scalar or input condition has rank one and
-  // matches the first dimension of other inputs.
-  bool has_low_rank_input_condition;
 };
 
 void* SelectInit(TfLiteContext* context, const char* buffer, size_t length) {
@@ -42,7 +40,6 @@ void* SelectInit(TfLiteContext* context, const char* buffer, size_t length) {
   auto* data = static_cast<OpData*>(
       context->AllocatePersistentBuffer(context, sizeof(OpData)));
   data->requires_broadcast = false;
-  data->has_low_rank_input_condition = false;
   return data;
 }
 
@@ -126,26 +123,28 @@ TfLiteStatus SelectPrepare(TfLiteContext* context, TfLiteNode* node) {
 
 TfLiteStatus SelectEval(TfLiteContext* context, TfLiteNode* node) {
   OpData* data = static_cast<OpData*>(node->user_data);
-  MicroContext* micro_context = GetMicroContext(context);
 
-  TfLiteTensor* input_condition =
-      micro_context->AllocateTempInputTensor(node, kInputTensorCondition);
+  const TfLiteEvalTensor* input_condition =
+      tflite::micro::GetEvalInput(context, node, kInputTensorCondition);
 
-  TfLiteTensor* input_x =
-      micro_context->AllocateTempInputTensor(node, kInputTensorX);
+  const TfLiteEvalTensor* input_x =
+      tflite::micro::GetEvalInput(context, node, kInputTensorX);
 
-  TfLiteTensor* input_y =
-      micro_context->AllocateTempInputTensor(node, kInputTensorY);
+  const TfLiteEvalTensor* input_y =
+      tflite::micro::GetEvalInput(context, node, kInputTensorY);
 
-  TfLiteTensor* output =
-      micro_context->AllocateTempOutputTensor(node, kOutputTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
 
-#define TF_LITE_SELECT(type, op)                                           \
-  reference_ops::op(GetTensorShape(input_condition),                       \
-                    GetTensorData<bool>(input_condition),                  \
-                    GetTensorShape(input_x), GetTensorData<type>(input_x), \
-                    GetTensorShape(input_y), GetTensorData<type>(input_y), \
-                    GetTensorShape(output), GetTensorData<type>(output));
+#define TF_LITE_SELECT(type, op)                                         \
+  reference_ops::op(tflite::micro::GetTensorShape(input_condition),      \
+                    tflite::micro::GetTensorData<bool>(input_condition), \
+                    tflite::micro::GetTensorShape(input_x),              \
+                    tflite::micro::GetTensorData<type>(input_x),         \
+                    tflite::micro::GetTensorShape(input_y),              \
+                    tflite::micro::GetTensorData<type>(input_y),         \
+                    tflite::micro::GetTensorShape(output),               \
+                    tflite::micro::GetTensorData<type>(output));
 
 #define TF_LITE_SWITCH(type, op)                                     \
   switch (type) {                                                    \
@@ -164,10 +163,7 @@ TfLiteStatus SelectEval(TfLiteContext* context, TfLiteNode* node) {
       return kTfLiteError;                                           \
   }
 
-  if (data->has_low_rank_input_condition) {
-    MicroPrintf("Not yet implemented.");
-    return kTfLiteError;
-  } else if (data->requires_broadcast) {
+  if (data->requires_broadcast) {
     TF_LITE_SWITCH(input_x->type, BroadcastSelect5DSlow);
   } else {
     TF_LITE_SWITCH(input_x->type, Select);
@@ -175,13 +171,11 @@ TfLiteStatus SelectEval(TfLiteContext* context, TfLiteNode* node) {
 
 #undef TF_LITE_SELECT
 #undef TF_LITE_SWITCH
-  micro_context->DeallocateTempTfLiteTensor(input_condition);
-  micro_context->DeallocateTempTfLiteTensor(input_x);
-  micro_context->DeallocateTempTfLiteTensor(input_y);
-  micro_context->DeallocateTempTfLiteTensor(output);
 
   return kTfLiteOk;
 }
+
+}  // namespace
 
 // SelectV2 op selects values of 'x' if the corresponding value of 'condition'
 // is true or the value of 'y' if false. There are valid condition input sizes:


### PR DESCRIPTION
@tensorflow/micro

Eval method now uses TfLiteEvalTensor.

The `has_low_rank_input_condition` variable has been removed from OpData as SELECT_V2 does not use this variable.

All code outside of the registration has been placed into the anonymous namespace.

bug=fixes #2014