### PR TITLE
docs: clarify the guidance for BUG=#nn in PR descriptions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,16 +96,12 @@ We strongly recommend that contributors:
 
     *   [Write Good Pull Request Descriptions](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
 
-        *   We require that all PR descriptions link to the github issue created
-            in step 1.
+        *   We require that all PR descriptions link to the GitHub issue
+            created in step 1 via the text `BUG=#nn` on a line by itself [^1]. This
+            is enforced by CI.
 
-        *   While github offers flexibility in linking
-            [commits and issues](https://github.blog/2011-04-09-issues-2-0-the-next-generation/#commits-issues),
-            we require that the PR description have a separate line with
-            `BUG=#nn`.
-
-        *   We will be adding internal checks that automate this requirement by
-            matching the PR description to the regexp: `(Fixes|Issue) #`
+            [^1]: This despite GitHub having additional forms of
+            [linked references](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls).
 
 1.  Unit tests are critical to a healthy codebase. PRs without tests should be
     the exception rather than the norm. And contributions to improve, simplify,


### PR DESCRIPTION
Clarify the guidance for linking a PR description to its bug number. The last
bullet was obsolete and confusing now that we require the specific text
`BUG=#nn`, as was mentioned in the second bullet.

BUG=see description
