### PR TITLE
refactor(python): rename extension module to _runtime

### DIFF
--- a/tensorflow/lite/micro/examples/mnist_lstm/BUILD
+++ b/tensorflow/lite/micro/examples/mnist_lstm/BUILD
@@ -37,7 +37,7 @@ py_test(
     python_version = "PY3",
     tags = [
         "noasan",
-        "nomsan",  # Python doesn't like these symbols from interpreter_wrapper_pybind.so
+        "nomsan",  # Python doesn't like these symbols
         "noubsan",
     ],
     deps = [

--- a/tensorflow/lite/micro/examples/recipes/BUILD
+++ b/tensorflow/lite/micro/examples/recipes/BUILD
@@ -21,7 +21,7 @@ py_test(
     srcs_version = "PY3",
     tags = [
         "noasan",
-        "nomsan",  # Python doesn't like these symbols from interpreter_wrapper_pybind.so
+        "nomsan",  # Python doesn't like these symbols
         "noubsan",
     ],
     deps = [

--- a/tensorflow/lite/micro/kernels/testdata/BUILD
+++ b/tensorflow/lite/micro/kernels/testdata/BUILD
@@ -55,7 +55,7 @@ py_test(
     python_version = "PY3",
     tags = [
         "noasan",
-        "nomsan",  # Python doesn't like these symbols from interpreter_wrapper_pybind.so
+        "nomsan",  # Python doesn't like these symbols
         "noubsan",
     ],
     deps = [

--- a/tensorflow/lite/micro/python/interpreter/src/BUILD
+++ b/tensorflow/lite/micro/python/interpreter/src/BUILD
@@ -40,13 +40,12 @@ cc_library(
 )
 
 pybind_extension(
-    name = "interpreter_wrapper_pybind",
-    # target = interpreter_wrapper_pybind.so because pybind_extension()
-    # appends suffix.
+    name = "_runtime",
+    # target = _runtime.so because pybind_extension() appends suffix
     srcs = [
+        "_runtime.cc",
         "interpreter_wrapper.cc",
         "interpreter_wrapper.h",
-        "interpreter_wrapper_pybind.cc",
         "numpy_utils.cc",
         "numpy_utils.h",
         "pybind11_lib.h",
@@ -78,7 +77,7 @@ py_library(
         "runtime.py",
     ],
     data = [
-        ":interpreter_wrapper_pybind.so",
+        ":_runtime.so",
     ],
     srcs_version = "PY3",
     visibility = ["//visibility:public"],

--- a/tensorflow/lite/micro/python/interpreter/src/_runtime.cc
+++ b/tensorflow/lite/micro/python/interpreter/src/_runtime.cc
@@ -22,8 +22,8 @@ limitations under the License.
 namespace py = pybind11;
 using tflite::InterpreterWrapper;
 
-PYBIND11_MODULE(interpreter_wrapper_pybind, m) {
-  m.doc() = "TFLM interpreter";
+PYBIND11_MODULE(_runtime, m) {
+  m.doc() = "TFLite Micro Runtime Extension";
 
   py::class_<InterpreterWrapper>(m, "InterpreterWrapper")
       .def(py::init([](const py::bytes& data,

--- a/tensorflow/lite/micro/python/interpreter/src/runtime.py
+++ b/tensorflow/lite/micro/python/interpreter/src/runtime.py
@@ -16,7 +16,7 @@
 
 import os
 
-from tflite_micro.tensorflow.lite.micro.python.interpreter.src import interpreter_wrapper_pybind
+from tflite_micro.tensorflow.lite.micro.python.interpreter.src import _runtime
 from tflite_micro.tensorflow.lite.tools import flatbuffer_utils
 
 
@@ -40,8 +40,10 @@ class Interpreter(object):
     print("Number of resource variables the model uses = ",
           num_resource_variables)
 
-    self._interpreter = interpreter_wrapper_pybind.InterpreterWrapper(
-        model_data, custom_op_registerers, arena_size, num_resource_variables)
+    self._interpreter = _runtime.InterpreterWrapper(model_data,
+                                                    custom_op_registerers,
+                                                    arena_size,
+                                                    num_resource_variables)
 
   @classmethod
   def from_file(self, model_path, custom_op_registerers=[], arena_size=None):

--- a/tensorflow/lite/micro/python/interpreter/tests/BUILD
+++ b/tensorflow/lite/micro/python/interpreter/tests/BUILD
@@ -9,7 +9,7 @@ py_test(
     python_version = "PY3",
     tags = [
         "noasan",
-        "nomsan",  # Python doesn't like these symbols from interpreter_wrapper_pybind.so
+        "nomsan",  # Python doesn't like these symbols
         "noubsan",
     ],
     deps = [

--- a/tensorflow/lite/micro/tools/BUILD
+++ b/tensorflow/lite/micro/tools/BUILD
@@ -54,7 +54,7 @@ py_test(
     python_version = "PY3",
     tags = [
         "noasan",
-        "nomsan",  # Python doesn't like these symbols from interpreter_wrapper_pybind.so
+        "nomsan",  # Python doesn't like these symbols
         "noubsan",
     ],
     deps = [


### PR DESCRIPTION
Rename extension module `interpreter_wrapper_pybind` to `_runtime`. It is
conventional for an extension module to use the same name as its corresponding
pure-Python wrapper module, but with a leading underscore.

BUG=part of #1484
