### PR TITLE
Update RISCV workflows to use docker container with qemu.

### DIFF
--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -1,4 +1,3 @@
-
 name: RISC-V
 
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule
@@ -21,17 +20,13 @@ jobs:
     name: RISC-V Continuous Builds
     steps:
       - uses: actions/setup-python@v4
-        with: 
+        with:
           python-version: '3.10'
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: |
-          pip3 install Pillow
-          pip3 install Wave
-          pip3 install numpy
+      - uses: actions/checkout@v3
       - name: Test
-        run: |
-          tensorflow/lite/micro/tools/ci_build/test_riscv.sh
+        uses: docker://ghcr.io/tflm-bot/tflm-ci:latest
+        with:
+          args: /bin/sh -c tensorflow/lite/micro/tools/ci_build/test_riscv.sh
 
   issue-on-error:
     needs: [riscv_daily]

--- a/.github/workflows/riscv_postmerge.yml
+++ b/.github/workflows/riscv_postmerge.yml
@@ -31,12 +31,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: ${{ inputs.trigger-sha }}
-    - name: Install dependencies
-      run: |
-        pip3 install Pillow
-        pip3 install Wave
-        pip3 install numpy
-    - name: Test
     - name: Test
       uses: docker://ghcr.io/tflm-bot/tflm-ci:latest
       with:

--- a/.github/workflows/riscv_postmerge.yml
+++ b/.github/workflows/riscv_postmerge.yml
@@ -7,7 +7,7 @@
 # This file can not be run stand-alone. It is called from tests_post.yml as part of
 # the ci automation.
 
-name: Risc-v Postmerge
+name: RISC-V Postmerge
 
 on:
   workflow_call:
@@ -37,6 +37,7 @@ jobs:
         pip3 install Wave
         pip3 install numpy
     - name: Test
-      run: |
-        cd ../
-        tflite-micro/tensorflow/lite/micro/tools/ci_build/test_riscv.sh tflite-micro/
+    - name: Test
+      uses: docker://ghcr.io/tflm-bot/tflm-ci:latest
+      with:
+        args: /bin/sh -c tensorflow/lite/micro/tools/ci_build/test_riscv.sh


### PR DESCRIPTION
This is a first step towards switching RISCV CI to using qemu instead of Renode.

qemu build and install takes a long time, so we currently use it via the TFLM CI docker container (#1904).

Once this PR is merged, #2035 should be ready to go.

Note that changes to the GitHub workflows can not be fully tested until they are merged. I manually triggered the continuous build from my fork of tflite-micro to catch any obvious errors: https://github.com/advaitjain/tflite-micro/actions/runs/5247123996

BUG=http://b/286622884#comment5