### PR TITLE
Update internal name for Window OP

### DIFF
--- a/python/tflite_micro/signal/ops/window_op.py
+++ b/python/tflite_micro/signal/ops/window_op.py
@@ -78,6 +78,7 @@ def _window_wrapper(window_fn, default_name):
 
   return _window
 
+
 # TODO(b/286250473): change back name to "window" after name clash resolved
 window = _window_wrapper(gen_window_op.signal_window, "signal_window")
 

--- a/python/tflite_micro/signal/ops/window_op.py
+++ b/python/tflite_micro/signal/ops/window_op.py
@@ -79,6 +79,6 @@ def _window_wrapper(window_fn, default_name):
   return _window
 
 
-window = _window_wrapper(gen_window_op.window, "window")
+window = _window_wrapper(gen_window_op.signal_window, "signal_window")
 
-tf.no_gradient("window")
+tf.no_gradient("signal_window")

--- a/python/tflite_micro/signal/ops/window_op.py
+++ b/python/tflite_micro/signal/ops/window_op.py
@@ -78,7 +78,7 @@ def _window_wrapper(window_fn, default_name):
 
   return _window
 
-
+# TODO(b/286250473): change back name to "window" after name clash resolved
 window = _window_wrapper(gen_window_op.signal_window, "signal_window")
 
 tf.no_gradient("signal_window")

--- a/signal/tensorflow_core/kernels/window_kernel.cc
+++ b/signal/tensorflow_core/kernels/window_kernel.cc
@@ -49,7 +49,7 @@ class WindowOp : public tensorflow::OpKernel {
   int shift_;
 };
 
-REGISTER_KERNEL_BUILDER(Name("Window").Device(tensorflow::DEVICE_CPU),
+REGISTER_KERNEL_BUILDER(Name("SignalWindow").Device(tensorflow::DEVICE_CPU),
                         WindowOp);
 
 }  // namespace signal

--- a/signal/tensorflow_core/kernels/window_kernel.cc
+++ b/signal/tensorflow_core/kernels/window_kernel.cc
@@ -49,6 +49,7 @@ class WindowOp : public tensorflow::OpKernel {
   int shift_;
 };
 
+// TODO(b/286250473): change back name to "Window" after name clash resolved
 REGISTER_KERNEL_BUILDER(Name("SignalWindow").Device(tensorflow::DEVICE_CPU),
                         WindowOp);
 

--- a/signal/tensorflow_core/ops/window_op.cc
+++ b/signal/tensorflow_core/ops/window_op.cc
@@ -36,7 +36,7 @@ Status WindowShape(InferenceContext* c) {
   return OkStatus();
 }
 
-REGISTER_OP("Window")
+REGISTER_OP("SignalWindow")
     .Attr("shift: int")
     .Input("input: int16")
     .Input("weights: int16")

--- a/signal/tensorflow_core/ops/window_op.cc
+++ b/signal/tensorflow_core/ops/window_op.cc
@@ -36,6 +36,7 @@ Status WindowShape(InferenceContext* c) {
   return OkStatus();
 }
 
+// TODO(b/286250473): change back name to "Window" after name clash resolved
 REGISTER_OP("SignalWindow")
     .Attr("shift: int")
     .Input("input: int16")

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -563,7 +563,7 @@ class MicroMutableOpResolver : public MicroOpResolver {
   }
 
   TfLiteStatus AddWindow() {
-    return AddCustom("Window", tflite::tflm_signal::Register_WINDOW());
+    return AddCustom("SignalWindow", tflite::tflm_signal::Register_WINDOW());
   }
 
   TfLiteStatus AddZerosLike() {

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -563,6 +563,7 @@ class MicroMutableOpResolver : public MicroOpResolver {
   }
 
   TfLiteStatus AddWindow() {
+    // TODO(b/286250473): change back name to "Window" and remove namespace
     return AddCustom("SignalWindow", tflite::tflm_signal::Register_WINDOW());
   }
 


### PR DESCRIPTION
We have some name clash issues with the current Window OP name.

We will be changing it from "Window"->"SignalWindow" until the names clashes are resolved and revert back afterwards.

This is an internal implementation detail, so user level API has no change from current usage, i.e. still use (op_resolver.AddWindow() and window_op.window)

BUG=[286250473](http://b/286250473)