### PR TITLE
build(bazel): use --std=c++17 by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,15 +14,12 @@
 # ==============================================================================
 #
 # TFLM Bazel configuration file.
-#
-# Other build options:
-#     asan:             Build with the clang address sanitizer
-#     msan:             Build with the clang memory sanitizer
-#     ubsan:            Build with the clang undefined behavior sanitizer
-#
 
-# Address sanitizer
-# bazel build --config asan
+# Use the following C++ standard
+build --cxxopt -std=c++17
+
+# When building with the address sanitizer
+# E.g., bazel build --config asan
 build:asan --repo_env CC=clang
 build:asan --strip=never
 build:asan --copt -fsanitize=address
@@ -32,8 +29,8 @@ build:asan --copt -O3
 build:asan --copt -fno-omit-frame-pointer
 build:asan --linkopt -fsanitize=address
 
-# Memory sanitizer
-# bazel build --config msan
+# When building with the memory sanitizer
+# E.g., bazel build --config msan
 build:msan --repo_env CC=clang
 build:msan --strip=never
 build:msan --copt -fsanitize=memory
@@ -43,8 +40,8 @@ build:msan --copt -O3
 build:msan --copt -fno-omit-frame-pointer
 build:msan --linkopt -fsanitize=memory
 
-# Undefined Behavior Sanitizer
-# bazel build --config ubsan
+# When building with the undefined behavior sanitizer
+# E.g., bazel build --config ubsan
 build:ubsan --repo_env CC=clang
 build:ubsan --strip=never
 build:ubsan --copt -fsanitize=undefined

--- a/python/tests/BUILD
+++ b/python/tests/BUILD
@@ -4,17 +4,6 @@ cc_test(
     srcs = [
         "cc_deps_link_test.cc",
     ],
-    copts = [
-        "-std=c++17",
-        # Compiling against upstream Tensorflow headers requires -std=c++17 due
-        # (at least) to Tensorflow's use of the type trait
-        # std::is_arithmetic_v, which was introduced in C++17.
-        #
-        # TODO(b/271210933): Harmonize this with a global solution
-        # throughout the repository. Presumably this same issue will be
-        # encountered by other code compiling against upstream Tensorflow,
-        # such as custom operator implementations.
-    ],
     deps = [
         "@tensorflow_cc_deps//:cc_library",
     ],

--- a/python/tflite_micro/signal/tflm_signal.bzl
+++ b/python/tflite_micro/signal/tflm_signal.bzl
@@ -38,7 +38,7 @@ def py_tflm_signal_library(
         native.cc_library(
             name = library_name,
             srcs = cc_op_defs,
-            copts = ["--std=c++17"] + select({
+            copts = select({
                 "//conditions:default": ["-pthread"],
             }),
             alwayslink = 1,
@@ -50,7 +50,7 @@ def py_tflm_signal_library(
 
         native.cc_binary(
             name = binary_name,
-            copts = ["--std=c++17"] + select({
+            copts = select({
                 "//conditions:default": ["-pthread"],
             }),
             linkshared = 1,
@@ -83,6 +83,6 @@ def tflm_signal_kernel_library(
         srcs = srcs,
         hdrs = hdrs,
         deps = deps,
-        copts = copts + ["--std=c++17"],
+        copts = copts,
         alwayslink = alwayslink,
     )

--- a/tensorflow/lite/BUILD
+++ b/tensorflow/lite/BUILD
@@ -7,7 +7,6 @@ cc_library(
     name = "array",
     srcs = ["array.cc"],
     hdrs = ["array.h"],
-    copts = ["-std=c++17"],
     deps = [
         "//tensorflow/lite/core/c:common",
     ],

--- a/tensorflow/lite/micro/build_def.bzl
+++ b/tensorflow/lite/micro/build_def.bzl
@@ -4,9 +4,6 @@ def micro_copts():
         "-Werror",
         "-Wnon-virtual-dtor",
         "-DFLATBUFFERS_LOCALE_INDEPENDENT=0",
-        # bazel is not an embedded build so ok to use c++17.
-        # http://b/287269351#comment2 has additional context.
-        "-std=c++17",
     ]
 
 def generate_cc_arrays(name, src, out, visibility = None):


### PR DESCRIPTION
Make all bazel builds use --std=c++17 by default.

BUG=fixes #2058