### PR TITLE
refactor: fix signed vs. unsigned comparison compiler warnings

### DIFF
--- a/tensorflow/lite/experimental/microfrontend/lib/filterbank_test.cc
+++ b/tensorflow/lite/experimental/microfrontend/lib/filterbank_test.cc
@@ -77,7 +77,7 @@ TF_LITE_MICRO_TEST(FilterbankTest_CheckChannelFrequencyStarts) {
 
   const int16_t expected[] = {0, 4, 8};
   TF_LITE_MICRO_EXPECT_EQ(state.num_channels + 1,
-                          sizeof(expected) / sizeof(expected[0]));
+                          static_cast<int>(sizeof(expected) / sizeof(expected[0])));
   int i;
   for (i = 0; i <= state.num_channels; ++i) {
     TF_LITE_MICRO_EXPECT_EQ(state.channel_frequency_starts[i], expected[i]);
@@ -94,7 +94,7 @@ TF_LITE_MICRO_TEST(FilterbankTest_CheckChannelWeightStarts) {
 
   const int16_t expected[] = {0, 8, 16};
   TF_LITE_MICRO_EXPECT_EQ(state.num_channels + 1,
-                          sizeof(expected) / sizeof(expected[0]));
+                          static_cast<int>(sizeof(expected) / sizeof(expected[0])));
   int i;
   for (i = 0; i <= state.num_channels; ++i) {
     TF_LITE_MICRO_EXPECT_EQ(state.channel_weight_starts[i], expected[i]);
@@ -111,7 +111,7 @@ TF_LITE_MICRO_TEST(FilterbankTest_CheckChannelWidths) {
 
   const int16_t expected[] = {8, 8, 8};
   TF_LITE_MICRO_EXPECT_EQ(state.num_channels + 1,
-                          sizeof(expected) / sizeof(expected[0]));
+                          static_cast<int>(sizeof(expected) / sizeof(expected[0])));
   int i;
   for (i = 0; i <= state.num_channels; ++i) {
     TF_LITE_MICRO_EXPECT_EQ(state.channel_widths[i], expected[i]);
@@ -131,9 +131,8 @@ TF_LITE_MICRO_TEST(FilterbankTest_CheckWeights) {
                               0, 4020, 3226, 2456, 1708, 983, 277, 0};
   TF_LITE_MICRO_EXPECT_EQ(state.channel_weight_starts[state.num_channels] +
                               state.channel_widths[state.num_channels],
-                          sizeof(expected) / sizeof(expected[0]));
-  int i;
-  for (i = 0; i < sizeof(expected) / sizeof(expected[0]); ++i) {
+                          static_cast<int>(sizeof(expected) / sizeof(expected[0])));
+  for (size_t i = 0; i < sizeof(expected) / sizeof(expected[0]); ++i) {
     TF_LITE_MICRO_EXPECT_EQ(state.weights[i], expected[i]);
   }
 
@@ -151,9 +150,8 @@ TF_LITE_MICRO_TEST(FilterbankTest_CheckUnweights) {
                               0, 76,  870,  1640, 2388, 3113, 3819, 0};
   TF_LITE_MICRO_EXPECT_EQ(state.channel_weight_starts[state.num_channels] +
                               state.channel_widths[state.num_channels],
-                          sizeof(expected) / sizeof(expected[0]));
-  int i;
-  for (i = 0; i < sizeof(expected) / sizeof(expected[0]); ++i) {
+                          static_cast<int>(sizeof(expected) / sizeof(expected[0])));
+  for (size_t i = 0; i < sizeof(expected) / sizeof(expected[0]); ++i) {
     TF_LITE_MICRO_EXPECT_EQ(state.unweights[i], expected[i]);
   }
 
@@ -187,7 +185,7 @@ TF_LITE_MICRO_TEST(FilterbankTest_CheckAccumulateChannels) {
   FilterbankAccumulateChannels(&state, kEnergy);
 
   TF_LITE_MICRO_EXPECT_EQ(state.num_channels + 1,
-                          sizeof(kWork) / sizeof(kWork[0]));
+                          static_cast<int>(sizeof(kWork) / sizeof(kWork[0])));
   int i;
   for (i = 0; i <= state.num_channels; ++i) {
     TF_LITE_MICRO_EXPECT_EQ(state.work[i], kWork[i]);
@@ -207,7 +205,7 @@ TF_LITE_MICRO_TEST(FilterbankTest_CheckSqrt) {
 
   const uint32_t expected[] = {247311, 508620};
   TF_LITE_MICRO_EXPECT_EQ(state.num_channels,
-                          sizeof(expected) / sizeof(expected[0]));
+                          static_cast<int>(sizeof(expected) / sizeof(expected[0])));
   int i;
   for (i = 0; i < state.num_channels; ++i) {
     TF_LITE_MICRO_EXPECT_EQ(scaled_filterbank[i], expected[i]);

--- a/tensorflow/lite/experimental/microfrontend/lib/frontend_test.cc
+++ b/tensorflow/lite/experimental/microfrontend/lib/frontend_test.cc
@@ -69,8 +69,7 @@ TF_LITE_MICRO_TEST(FrontendTest_CheckOutputValues) {
 
   const uint16_t expected[] = {479, 425};
   TF_LITE_MICRO_EXPECT_EQ(output.size, sizeof(expected) / sizeof(expected[0]));
-  int i;
-  for (i = 0; i < output.size; ++i) {
+  for (size_t i = 0; i < output.size; ++i) {
     TF_LITE_MICRO_EXPECT_EQ(output.values[i], expected[i]);
   }
 
@@ -94,8 +93,7 @@ TF_LITE_MICRO_TEST(FrontendTest_CheckConsecutiveWindow) {
 
   const int16_t expected[] = {436, 378};
   TF_LITE_MICRO_EXPECT_EQ(output.size, sizeof(expected) / sizeof(expected[0]));
-  int i;
-  for (i = 0; i < output.size; ++i) {
+  for (size_t i = 0; i < output.size; ++i) {
     TF_LITE_MICRO_EXPECT_EQ(output.values[i], expected[i]);
   }
 
@@ -122,7 +120,7 @@ TF_LITE_MICRO_TEST(FrontendTest_CheckNotEnoughSamples) {
           kStepSamples,
       &num_samples_read);
 
-  TF_LITE_MICRO_EXPECT_EQ(output.size, 0);
+  TF_LITE_MICRO_EXPECT_EQ(output.size, 0u);
   TF_LITE_MICRO_EXPECT(output.values == nullptr);
 
   FrontendFreeStateContents(&state);

--- a/tensorflow/lite/experimental/microfrontend/lib/log_scale_test.cc
+++ b/tensorflow/lite/experimental/microfrontend/lib/log_scale_test.cc
@@ -37,8 +37,7 @@ TF_LITE_MICRO_TEST(LogScaleTest_CheckOutputValues) {
                                    kCorrectionBits);
 
   const uint16_t expected[] = {479, 425};
-  int i;
-  for (i = 0; i < sizeof(expected) / sizeof(expected[0]); ++i) {
+  for (size_t i = 0; i < sizeof(expected) / sizeof(expected[0]); ++i) {
     TF_LITE_MICRO_EXPECT_EQ(output[i], expected[i]);
   }
 }
@@ -54,8 +53,7 @@ TF_LITE_MICRO_TEST(LogScaleTest_CheckOutputValuesNoLog) {
                                    kCorrectionBits);
 
   const uint16_t expected[] = {65535, 45998};
-  int i;
-  for (i = 0; i < sizeof(expected) / sizeof(expected[0]); ++i) {
+  for (size_t i = 0; i < sizeof(expected) / sizeof(expected[0]); ++i) {
     TF_LITE_MICRO_EXPECT_EQ(output[i], expected[i]);
   }
 }

--- a/tensorflow/lite/experimental/microfrontend/lib/noise_reduction_test.cc
+++ b/tensorflow/lite/experimental/microfrontend/lib/noise_reduction_test.cc
@@ -49,7 +49,7 @@ TF_LITE_MICRO_TEST(NoiseReductionTest_TestNoiseReductionEstimate) {
 
   const uint32_t expected[] = {6321887, 31248341};
   TF_LITE_MICRO_EXPECT_EQ(state.num_channels,
-                          sizeof(expected) / sizeof(expected[0]));
+                          static_cast<int>(sizeof(expected) / sizeof(expected[0])));
   int i;
   for (i = 0; i < state.num_channels; ++i) {
     TF_LITE_MICRO_EXPECT_EQ(state.estimate[i], expected[i]);
@@ -69,7 +69,7 @@ TF_LITE_MICRO_TEST(NoiseReductionTest_TestNoiseReduction) {
 
   const uint32_t expected[] = {241137, 478104};
   TF_LITE_MICRO_EXPECT_EQ(state.num_channels,
-                          sizeof(expected) / sizeof(expected[0]));
+                          static_cast<int>(sizeof(expected) / sizeof(expected[0])));
   int i;
   for (i = 0; i < state.num_channels; ++i) {
     TF_LITE_MICRO_EXPECT_EQ(signal[i], expected[i]);

--- a/tensorflow/lite/experimental/microfrontend/lib/pcan_gain_control_test.cc
+++ b/tensorflow/lite/experimental/microfrontend/lib/pcan_gain_control_test.cc
@@ -53,7 +53,7 @@ TF_LITE_MICRO_TEST(PcanGainControlTest_TestPcanGainControl) {
 
   const uint32_t expected[] = {3578, 1533};
   TF_LITE_MICRO_EXPECT_EQ(state.num_channels,
-                          sizeof(expected) / sizeof(expected[0]));
+                          static_cast<int>(sizeof(expected) / sizeof(expected[0])));
   int i;
   for (i = 0; i < state.num_channels; ++i) {
     TF_LITE_MICRO_EXPECT_EQ(signal[i], expected[i]);

--- a/tensorflow/lite/experimental/microfrontend/lib/window_test.cc
+++ b/tensorflow/lite/experimental/microfrontend/lib/window_test.cc
@@ -53,8 +53,7 @@ TF_LITE_MICRO_TEST(WindowState_CheckCoefficients) {
                               3843, 3541, 3145, 2681, 2177, 1664, 1176,
                               743,  391,  144,  16};
   TF_LITE_MICRO_EXPECT_EQ(state.size, sizeof(expected) / sizeof(expected[0]));
-  int i;
-  for (i = 0; i < state.size; ++i) {
+  for (size_t i = 0; i < state.size; ++i) {
     TF_LITE_MICRO_EXPECT_EQ(state.coefficients[i], expected[i]);
   }
 
@@ -95,8 +94,7 @@ TF_LITE_MICRO_TEST(WindowState_CheckOutputValues) {
       0, 1151,   0, -5944, 0, 13311,  0, -21448, 0, 28327, 0, -32256, 0, 32255,
       0, -28328, 0, 21447, 0, -13312, 0, 5943,   0, -1152, 0};
   TF_LITE_MICRO_EXPECT_EQ(state.size, sizeof(expected) / sizeof(expected[0]));
-  int i;
-  for (i = 0; i < state.size; ++i) {
+  for (size_t i = 0; i < state.size; ++i) {
     TF_LITE_MICRO_EXPECT_EQ(state.output[i], expected[i]);
   }
 
@@ -138,8 +136,7 @@ TF_LITE_MICRO_TEST(WindowState_CheckConsecutiveWindow) {
       0, -1152, 0, 5943,   0, -13312, 0, 21447, 0, -28328, 0, 32255, 0, -32256,
       0, 28327, 0, -21448, 0, 13311,  0, -5944, 0, 1151,   0};
   TF_LITE_MICRO_EXPECT_EQ(state.size, sizeof(expected) / sizeof(expected[0]));
-  int i;
-  for (i = 0; i < state.size; ++i) {
+  for (size_t i = 0; i < state.size; ++i) {
     TF_LITE_MICRO_EXPECT_EQ(state.output[i], expected[i]);
   }
 

--- a/tensorflow/lite/micro/kernels/test_data_generation/generate_circular_buffer_flexbuffers_data.cc
+++ b/tensorflow/lite/micro/kernels/test_data_generation/generate_circular_buffer_flexbuffers_data.cc
@@ -37,9 +37,9 @@ void generate(const char* name) {
   // for the raw data, and so we reinterpret_cast.
   const uint8_t* init_data =
       reinterpret_cast<const uint8_t*>(fbb.GetBuffer().data());
-  int fbb_size = fbb.GetBuffer().size();
+  size_t fbb_size = fbb.GetBuffer().size();
 
-  printf("const int g_gen_data_size_%s = %d;\n", name, fbb_size);
+  printf("const int g_gen_data_size_%s = %zu;\n", name, fbb_size);
   printf("const unsigned char g_gen_data_%s[] = { ", name);
   for (size_t i = 0; i < fbb_size; i++) {
     printf("0x%02x, ", init_data[i]);

--- a/tensorflow/lite/micro/kernels/test_data_generation/generate_detection_postprocess_flexbuffers_data.cc
+++ b/tensorflow/lite/micro/kernels/test_data_generation/generate_detection_postprocess_flexbuffers_data.cc
@@ -49,9 +49,9 @@ void generate(const char* name, bool use_regular_nms) {
   // for the raw data, and so we reinterpret_cast.
   const uint8_t* init_data =
       reinterpret_cast<const uint8_t*>(fbb.GetBuffer().data());
-  int fbb_size = fbb.GetBuffer().size();
+  size_t fbb_size = fbb.GetBuffer().size();
 
-  printf("const int g_gen_data_size_%s = %d;\n", name, fbb_size);
+  printf("const int g_gen_data_size_%s = %zu;\n", name, fbb_size);
   printf("alignas(4) const unsigned char g_gen_data_%s[] = { ", name);
   for (size_t i = 0; i < fbb_size; i++) {
     printf("0x%02x, ", init_data[i]);


### PR DESCRIPTION
Fix various compiler warnings about signed vs. unsigned comparisons, in
preparation for enabling -Werror.

Fix by making the most straightforward, local changes. Improving the test
framework, changing types in data structures, and or adding some utility
functions might yield prettier code.

BUG=part of #2057
