### PR TITLE
build(bazel): treat compiler warnings as errors by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,6 +18,9 @@
 # Use the following C++ standard
 build --cxxopt -std=c++17
 
+# Treat warnings as errors
+build --copt -Werror
+
 # When building with the address sanitizer
 # E.g., bazel build --config asan
 build:asan --repo_env CC=clang

--- a/tensorflow/lite/micro/build_def.bzl
+++ b/tensorflow/lite/micro/build_def.bzl
@@ -1,7 +1,6 @@
 def micro_copts():
     return [
         "-Wall",
-        "-Werror",
         "-Wnon-virtual-dtor",
         "-DFLATBUFFERS_LOCALE_INDEPENDENT=0",
     ]


### PR DESCRIPTION
Make all bazel builds treat compiler warnings as errors by default.

BUG=closes #2057