### PR TITLE
refactor(runtime.py): count resource variables in native code

### DIFF
--- a/python/tflite_micro/BUILD
+++ b/python/tflite_micro/BUILD
@@ -75,7 +75,6 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         requirement("numpy"),
-        "//tensorflow/lite/tools:flatbuffer_utils",
     ],
 )
 

--- a/python/tflite_micro/_runtime.cc
+++ b/python/tflite_micro/_runtime.cc
@@ -28,10 +28,9 @@ PYBIND11_MODULE(_runtime, m) {
   py::class_<InterpreterWrapper>(m, "InterpreterWrapper")
       .def(py::init([](const py::bytes& data,
                        const std::vector<std::string>& registerers_by_name,
-                       size_t arena_size, int num_resource_variables) {
-        return std::unique_ptr<InterpreterWrapper>(
-            new InterpreterWrapper(data.ptr(), registerers_by_name, arena_size,
-                                   num_resource_variables));
+                       size_t arena_size) {
+        return std::unique_ptr<InterpreterWrapper>(new InterpreterWrapper(
+            data.ptr(), registerers_by_name, arena_size));
       }))
       .def("PrintAllocations", &InterpreterWrapper::PrintAllocations)
       .def("Invoke", &InterpreterWrapper::Invoke)

--- a/python/tflite_micro/interpreter_wrapper.h
+++ b/python/tflite_micro/interpreter_wrapper.h
@@ -27,7 +27,7 @@ class InterpreterWrapper {
  public:
   InterpreterWrapper(PyObject* model_data,
                      const std::vector<std::string>& registerers_by_name,
-                     size_t arena_size, int num_resource_variables);
+                     size_t arena_size);
   ~InterpreterWrapper();
 
   void PrintAllocations();

--- a/python/tflite_micro/runtime.py
+++ b/python/tflite_micro/runtime.py
@@ -17,7 +17,6 @@
 import os
 
 from tflite_micro.python.tflite_micro import _runtime
-from tflite_micro.tensorflow.lite.tools import flatbuffer_utils
 
 
 class Interpreter(object):
@@ -34,16 +33,9 @@ class Interpreter(object):
     if arena_size is None:
       arena_size = len(model_data) * 10
 
-    # Some models make use of resource variables ops, get the count here
-    num_resource_variables = flatbuffer_utils.count_resource_variables(
-        model_data)
-    print("Number of resource variables the model uses = ",
-          num_resource_variables)
-
     self._interpreter = _runtime.InterpreterWrapper(model_data,
                                                     custom_op_registerers,
-                                                    arena_size,
-                                                    num_resource_variables)
+                                                    arena_size)
 
   @classmethod
   def from_file(self, model_path, custom_op_registerers=[], arena_size=None):


### PR DESCRIPTION
Move the counting of resource variables from the Python code to the native code
of the soon-to-be-public Python module tflm_micro.runtime. This avoids what
would be a large, complex dependency in the public module on the third-party
packages tensorflow, tflite-runtime, and flatbuffers (or vendored parts
thereof).

This code is covered by the existing tests.

BUG=part of #1484 