### PR TITLE
build(ci): word-wrap GitHub PR descriptions when committed

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -18,7 +18,7 @@ pull_request_rules:
         method: squash
         commit_message_template: |
           {{ title }} (#{{ number }})
-          {{ body_raw  }}
+          {{ body_raw | wordwrap(width=79, break_long_words=False) }}
 
   - name: remove ci:ready_to_merge label
     conditions:


### PR DESCRIPTION
Word-wrap GitHub PR descriptions when Mergify squash-merges and commits them to git.

Unless the PR author goes out of their way to add line breaks to a description, a GitHub PR description is one long line per paragraph. This is true even if the description is automatically populated by GitHub from a commit message with proper line breaks. When Mergify merges a PR, the description becomes the commit message. One long line per paragraph may be fine in GitHub's web UI, but it breaks conventional git usage and is hard to read in the git command line client. Have Mergify break these lines at a conventional width.

As a test, this PR description was submitted with a long paragraph as a single line.

BUG=see description