### PR TITLE
update hifi3z test script to use correct make target

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi3z.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi3z.sh
@@ -58,7 +58,7 @@ if [[ ${1} == "INTERNAL" ]]; then
     XTENSA_CORE=HIFI_190304_swupgrade \
     TENSORFLOW_ROOT=${TENSORFLOW_ROOT} \
     EXTERNAL_DIR=${EXTERNAL_DIR} \
-    test_integration_tests_seanet_conv -j$(nproc)
+    test_integration_tests_seanet_conv_test -j$(nproc)
 
   readable_run make -f ${TENSORFLOW_ROOT}tensorflow/lite/micro/tools/make/Makefile \
     TARGET=xtensa \


### PR DESCRIPTION
Currently hifi3z is the only way Integration test are used via our ci in google3 but for conv it's calling a slightly different target then the one that's generated. 

Updated it from ` test_integration_tests_seanet_conv` to what is generated when a conv test is made ` test_integration_tests_seanet_conv_test`

was changed in following [google3 cl](https://critique.corp.google.com/cl/540727482)  as well

BUG=[209675411](https://b.corp.google.com/issues/209675411)