### PR TITLE
Increase Rfft float test tolerance

### DIFF
--- a/signal/micro/kernels/fft_test.cc
+++ b/signal/micro/kernels/fft_test.cc
@@ -220,18 +220,12 @@ TF_LITE_MICRO_TEST(RfftTestSize512Float) {
   float output[kOutputLen * 2];
   const TFLMRegistration* registration =
       tflite::tflm_signal::Register_RFFT_FLOAT();
-// See (b/287518815) for why this is needed.
-#if defined(ARMCM55)
-  float tolerance = 1e-5;
-#else   // defined(ARMCM55)
-  float tolerance = 1e-7;
-#endif  // defined(ARMCM55)
   TF_LITE_MICRO_EXPECT_EQ(
       kTfLiteOk, tflite::testing::TestFFT<float>(
                      input_shape, tflite::kRfftFloatLength512Input,
                      output_shape, tflite::kRfftFloatLength512Golden,
                      *registration, g_gen_data_fft_length_512_float,
-                     g_gen_data_size_fft_length_512_float, output, tolerance));
+                     g_gen_data_size_fft_length_512_float, output, 1e-5));
 }
 
 TF_LITE_MICRO_TEST(RfftTestSize512Int16) {

--- a/signal/micro/kernels/fft_test.cc
+++ b/signal/micro/kernels/fft_test.cc
@@ -220,12 +220,18 @@ TF_LITE_MICRO_TEST(RfftTestSize512Float) {
   float output[kOutputLen * 2];
   const TFLMRegistration* registration =
       tflite::tflm_signal::Register_RFFT_FLOAT();
+// See (b/287518815) for why this is needed.
+#if defined(ARMCM55)
+  float tolerance = 1e-5;
+#else   // defined(ARMCM55)
+  float tolerance = 1e-7;
+#endif  // defined(ARMCM55)
   TF_LITE_MICRO_EXPECT_EQ(
       kTfLiteOk, tflite::testing::TestFFT<float>(
                      input_shape, tflite::kRfftFloatLength512Input,
                      output_shape, tflite::kRfftFloatLength512Golden,
                      *registration, g_gen_data_fft_length_512_float,
-                     g_gen_data_size_fft_length_512_float, output, 1e-7));
+                     g_gen_data_size_fft_length_512_float, output, tolerance));
 }
 
 TF_LITE_MICRO_TEST(RfftTestSize512Int16) {

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -333,6 +333,7 @@ tflm_kernel_cc_library(
         ":activation_utils",
         ":kernel_util",
         ":micro_tensor_utils",
+        "//signal/micro/kernels:register_signal_ops",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/kernels:kernel_util",
         "//tensorflow/lite/kernels:op_macros",
@@ -351,7 +352,6 @@ tflm_kernel_cc_library(
         "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:micro_utils",
         "//tensorflow/lite/schema:schema_fbs",
-        "//signal/micro/kernels:register_signal_ops",
         "@flatbuffers//:runtime_cc",
     ] + select({
         xtensa_fusion_f1_config(): ["//third_party/xtensa/nnlib_hifi4:nnlib_hifi4_lib"],


### PR DESCRIPTION
Our Cortex-M55 test is failing due to strict tolerance in the Rfft float test.
Increasing tolerance for this target.

BUG=[287518815](http://b/287518815)