### PR TITLE
Signal Library OPs python BUILD update

### DIFF
--- a/python/tflite_micro/signal/BUILD
+++ b/python/tflite_micro/signal/BUILD
@@ -27,6 +27,7 @@ py_library(
         "ops/__init__.py",
     ],
     srcs_version = "PY3",
+    visibility = ["//python/tflite_micro/signal/utils:__subpackages__"],
     deps = [
         ":fft_ops",
         ":window_op",

--- a/python/tflite_micro/signal/utils/BUILD
+++ b/python/tflite_micro/signal/utils/BUILD
@@ -13,6 +13,7 @@ py_library(
     srcs = ["util.py"],
     deps = [
         "//python/tflite_micro:runtime",
+        "//python/tflite_micro/signal:ops",
         requirement("tensorflow-cpu"),
     ],
 )


### PR DESCRIPTION
This is needed to properly build all the ops together. Since we are calling into a singular utils function to load the ops, if it checks for any other ops, it would break before this.

Now we make it build all ops everytime utils.py is built.

BUG=[288938993](http://b/288938993)