### PR TITLE
Update Signal RFFT to have namespace and reformat Makefile targets

### DIFF
--- a/signal/micro/kernels/rfft.cc
+++ b/signal/micro/kernels/rfft.cc
@@ -142,16 +142,16 @@ void* InitAll(TfLiteContext* context, const char* buffer, size_t length) {
 
   switch (tensor_type) {
     case TensorType_INT16: {
-      return Init<int16_t, RfftInt16GetNeededMemory, RfftInt16Init>(
-          context, buffer, length);
+      return Init<int16_t, ::tflm_signal::RfftInt16GetNeededMemory,
+                  ::tflm_signal::RfftInt16Init>(context, buffer, length);
     }
     case TensorType_INT32: {
-      return Init<int32_t, RfftInt32GetNeededMemory, RfftInt32Init>(
-          context, buffer, length);
+      return Init<int32_t, ::tflm_signal::RfftInt32GetNeededMemory,
+                  ::tflm_signal::RfftInt32Init>(context, buffer, length);
     }
     case TensorType_FLOAT32: {
-      return Init<float, RfftFloatGetNeededMemory, RfftFloatInit>(
-          context, buffer, length);
+      return Init<float, ::tflm_signal::RfftFloatGetNeededMemory,
+                  ::tflm_signal::RfftFloatInit>(context, buffer, length);
     }
     default:
       return nullptr;
@@ -183,13 +183,13 @@ TfLiteStatus EvalAll(TfLiteContext* context, TfLiteNode* node) {
 
   switch (params->fft_type) {
     case kTfLiteInt16: {
-      return Eval<int16_t, RfftInt16Apply>(context, node);
+      return Eval<int16_t, ::tflm_signal::RfftInt16Apply>(context, node);
     }
     case kTfLiteInt32: {
-      return Eval<int32_t, RfftInt32Apply>(context, node);
+      return Eval<int32_t, ::tflm_signal::RfftInt32Apply>(context, node);
     }
     case kTfLiteFloat32: {
-      return Eval<float, RfftFloatApply>(context, node);
+      return Eval<float, ::tflm_signal::RfftFloatApply>(context, node);
     }
     default:
       return kTfLiteError;
@@ -208,22 +208,28 @@ TFLMRegistration* Register_RFFT() {
 
 TFLMRegistration* Register_RFFT_FLOAT() {
   static TFLMRegistration r = tflite::micro::RegisterOp(
-      Init<float, RfftFloatGetNeededMemory, RfftFloatInit>,
-      Prepare<float, kTfLiteFloat32>, Eval<float, RfftFloatApply>);
+      Init<float, ::tflm_signal::RfftFloatGetNeededMemory,
+           ::tflm_signal::RfftFloatInit>,
+      Prepare<float, kTfLiteFloat32>,
+      Eval<float, ::tflm_signal::RfftFloatApply>);
   return &r;
 }
 
 TFLMRegistration* Register_RFFT_INT16() {
   static TFLMRegistration r = tflite::micro::RegisterOp(
-      Init<int16_t, RfftInt16GetNeededMemory, RfftInt16Init>,
-      Prepare<int16_t, kTfLiteInt16>, Eval<int16_t, RfftInt16Apply>);
+      Init<int16_t, ::tflm_signal::RfftInt16GetNeededMemory,
+           ::tflm_signal::RfftInt16Init>,
+      Prepare<int16_t, kTfLiteInt16>,
+      Eval<int16_t, ::tflm_signal::RfftInt16Apply>);
   return &r;
 }
 
 TFLMRegistration* Register_RFFT_INT32() {
   static TFLMRegistration r = tflite::micro::RegisterOp(
-      Init<int32_t, RfftInt32GetNeededMemory, RfftInt32Init>,
-      Prepare<int32_t, kTfLiteInt32>, Eval<int32_t, RfftInt32Apply>);
+      Init<int32_t, ::tflm_signal::RfftInt32GetNeededMemory,
+           ::tflm_signal::RfftInt32Init>,
+      Prepare<int32_t, kTfLiteInt32>,
+      Eval<int32_t, ::tflm_signal::RfftInt32Apply>);
   return &r;
 }
 

--- a/signal/src/rfft.h
+++ b/signal/src/rfft.h
@@ -21,6 +21,9 @@ limitations under the License.
 
 #include "signal/src/complex.h"
 
+// TODO(b/286250473): remove namespace once de-duped libraries
+namespace tflm_signal {
+
 // RFFT (Real Fast Fourier Transform)
 // FFT for real valued time domain inputs.
 
@@ -76,5 +79,7 @@ void* RfftFloatInit(int32_t fft_length, void* state, size_t state_size);
 // * `input` must be of size `fft_length` elements (see RfftInit)
 // * `output` must be of size (`fft_length` * 2) + 1 elements
 void RfftFloatApply(void* state, const float* input, Complex<float>* output);
+
+}  // namespace tflm_signal
 
 #endif  // SIGNAL_SRC_RFFT_H_

--- a/signal/src/rfft_float.cc
+++ b/signal/src/rfft_float.cc
@@ -20,6 +20,9 @@ limitations under the License.
 #include "signal/src/kiss_fft_wrappers/kiss_fft_float.h"
 #include "signal/src/rfft.h"
 
+// TODO(b/286250473): remove namespace once de-duped libraries
+namespace tflm_signal {
+
 size_t RfftFloatGetNeededMemory(int32_t fft_length) {
   size_t state_size = 0;
   kiss_fft_float::kiss_fftr_alloc(fft_length, 0, nullptr, &state_size);
@@ -36,3 +39,5 @@ void RfftFloatApply(void* state, const float* input, Complex<float>* output) {
       reinterpret_cast<const kiss_fft_scalar*>(input),
       reinterpret_cast<kiss_fft_float::kiss_fft_cpx*>(output));
 }
+
+}  // namespace tflm_signal

--- a/signal/src/rfft_int16.cc
+++ b/signal/src/rfft_int16.cc
@@ -20,6 +20,9 @@ limitations under the License.
 #include "signal/src/kiss_fft_wrappers/kiss_fft_int16.h"
 #include "signal/src/rfft.h"
 
+// TODO(b/286250473): remove namespace once de-duped libraries
+namespace tflm_signal {
+
 size_t RfftInt16GetNeededMemory(int32_t fft_length) {
   size_t state_size = 0;
   kiss_fft_fixed16::kiss_fftr_alloc(fft_length, 0, nullptr, &state_size);
@@ -37,3 +40,5 @@ void RfftInt16Apply(void* state, const int16_t* input,
       reinterpret_cast<const kiss_fft_scalar*>(input),
       reinterpret_cast<kiss_fft_fixed16::kiss_fft_cpx*>(output));
 }
+
+}  // namespace tflm_signal

--- a/signal/src/rfft_int32.cc
+++ b/signal/src/rfft_int32.cc
@@ -20,6 +20,9 @@ limitations under the License.
 #include "signal/src/kiss_fft_wrappers/kiss_fft_int32.h"
 #include "signal/src/rfft.h"
 
+// TODO(b/286250473): remove namespace once de-duped libraries
+namespace tflm_signal {
+
 size_t RfftInt32GetNeededMemory(int32_t fft_length) {
   size_t state_size = 0;
   kiss_fft_fixed32::kiss_fftr_alloc(fft_length, 0, nullptr, &state_size);
@@ -37,3 +40,5 @@ void RfftInt32Apply(void* state, const int32_t* input,
       reinterpret_cast<const kiss_fft_scalar*>(input),
       reinterpret_cast<kiss_fft_fixed32::kiss_fft_cpx*>(output));
 }
+
+}  // namespace tflm_signal

--- a/signal/tensorflow_core/kernels/fft_kernels.cc
+++ b/signal/tensorflow_core/kernels/fft_kernels.cc
@@ -82,21 +82,24 @@ class RfftOp : public tensorflow::OpKernel {
 };
 
 // TODO(b/286250473): change back name after name clash resolved
-REGISTER_KERNEL_BUILDER(Name("SignalRfft")
-                            .Device(tensorflow::DEVICE_CPU)
-                            .TypeConstraint<float>("T"),
-                        RfftOp<float, DT_FLOAT, RfftFloatGetNeededMemory,
-                               RfftFloatInit, RfftFloatApply>);
-REGISTER_KERNEL_BUILDER(Name("SignalRfft")
-                            .Device(tensorflow::DEVICE_CPU)
-                            .TypeConstraint<int16>("T"),
-                        RfftOp<int16_t, DT_INT16, RfftInt16GetNeededMemory,
-                               RfftInt16Init, RfftInt16Apply>);
-REGISTER_KERNEL_BUILDER(Name("SignalRfft")
-                            .Device(tensorflow::DEVICE_CPU)
-                            .TypeConstraint<int32>("T"),
-                        RfftOp<int32_t, DT_INT32, RfftInt32GetNeededMemory,
-                               RfftInt32Init, RfftInt32Apply>);
+REGISTER_KERNEL_BUILDER(
+    Name("SignalRfft")
+        .Device(tensorflow::DEVICE_CPU)
+        .TypeConstraint<float>("T"),
+    RfftOp<float, DT_FLOAT, ::tflm_signal::RfftFloatGetNeededMemory,
+           ::tflm_signal::RfftFloatInit, ::tflm_signal::RfftFloatApply>);
+REGISTER_KERNEL_BUILDER(
+    Name("SignalRfft")
+        .Device(tensorflow::DEVICE_CPU)
+        .TypeConstraint<int16>("T"),
+    RfftOp<int16_t, DT_INT16, ::tflm_signal::RfftInt16GetNeededMemory,
+           ::tflm_signal::RfftInt16Init, ::tflm_signal::RfftInt16Apply>);
+REGISTER_KERNEL_BUILDER(
+    Name("SignalRfft")
+        .Device(tensorflow::DEVICE_CPU)
+        .TypeConstraint<int32>("T"),
+    RfftOp<int32_t, DT_INT32, ::tflm_signal::RfftInt32GetNeededMemory,
+           ::tflm_signal::RfftInt32Init, ::tflm_signal::RfftInt32Apply>);
 
 }  // namespace signal
 }  // namespace tensorflow

--- a/tensorflow/lite/micro/kernels/Makefile.inc
+++ b/tensorflow/lite/micro/kernels/Makefile.inc
@@ -48,13 +48,13 @@ $(eval $(call microlite_test,unidirectional_sequence_lstm_test,\
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/testdata/lstm_test_data.cc,\
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/testdata/lstm_test_data.h))
 
-$(eval $(call microlite_test,kernel_fft_test,\
+$(eval $(call microlite_test,kernel_signal_fft_test,\
   $(TENSORFLOW_ROOT)signal/micro/kernels/fft_test.cc \
   $(TENSORFLOW_ROOT)signal/micro/kernels/fft_flexbuffers_generated_data.cc \
   $(TENSORFLOW_ROOT)signal/testdata/fft_test_data.cc, \
   $(TENSORFLOW_ROOT)signal/micro/kernels/fft_flexbuffers_generated_data.h))
 
-$(eval $(call microlite_test,kernel_window_test,\
+$(eval $(call microlite_test,kernel_signal_window_test,\
   $(TENSORFLOW_ROOT)signal/micro/kernels/window_test.cc \
   $(TENSORFLOW_ROOT)signal/micro/kernels/window_flexbuffers_generated_data.cc, \
   $(TENSORFLOW_ROOT)signal/micro/kernels/window_flexbuffers_generated_data.h))

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -314,9 +314,6 @@ $(TENSORFLOW_ROOT)tensorflow/lite/micro/memory_planner/non_persistent_buffer_pla
 MICROLITE_CC_KERNEL_SRCS := \
 $(TENSORFLOW_ROOT)signal/micro/kernels/rfft.cc \
 $(TENSORFLOW_ROOT)signal/micro/kernels/window.cc \
-$(TENSORFLOW_ROOT)signal/src/kiss_fft_wrappers/kiss_fft_float.cc \
-$(TENSORFLOW_ROOT)signal/src/kiss_fft_wrappers/kiss_fft_int16.cc \
-$(TENSORFLOW_ROOT)signal/src/kiss_fft_wrappers/kiss_fft_int32.cc \
 $(TENSORFLOW_ROOT)signal/src/rfft_float.cc \
 $(TENSORFLOW_ROOT)signal/src/rfft_int16.cc \
 $(TENSORFLOW_ROOT)signal/src/rfft_int32.cc \
@@ -456,7 +453,6 @@ $(TFL_CC_SRCS)
 MICROLITE_CC_HDRS := \
 $(wildcard $(TENSORFLOW_ROOT)signal/micro/kernels/*.h) \
 $(wildcard $(TENSORFLOW_ROOT)signal/src/*.h) \
-$(wildcard $(TENSORFLOW_ROOT)signal/src/kiss_fft_wrappers/*.h) \
 $(wildcard $(TENSORFLOW_ROOT)tensorflow/lite/micro/*.h) \
 $(wildcard $(TENSORFLOW_ROOT)tensorflow/lite/micro/benchmarks/*model_data.h) \
 $(wildcard $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/*.h) \

--- a/tensorflow/lite/micro/tools/make/additional_kernels.inc
+++ b/tensorflow/lite/micro/tools/make/additional_kernels.inc
@@ -1,0 +1,8 @@
+# TODO(b/288938993): de-dupe internal wrapper directory and remove this
+MICROLITE_CC_KERNEL_SRCS += \
+$(TENSORFLOW_ROOT)signal/src/kiss_fft_wrappers/kiss_fft_float.cc \
+$(TENSORFLOW_ROOT)signal/src/kiss_fft_wrappers/kiss_fft_int16.cc \
+$(TENSORFLOW_ROOT)signal/src/kiss_fft_wrappers/kiss_fft_int32.cc
+
+MICROLITE_CC_HDRS += \
+$(wildcard $(TENSORFLOW_ROOT)signal/src/kiss_fft_wrappers/*.h) \


### PR DESCRIPTION
This is needed to avoid name clashes and properly build all targets.

The make command names to run the signal tests have changed to use `signal_` before the op.
So:
`test_kernel_fft_test` is now `test_kernel_signal_fft_test`, etc.

BUG=[288938993](http://b/288938993)