### PR TITLE
Flatten kernel namespace: RESHAPE

### DIFF
--- a/tensorflow/lite/micro/kernels/micro_ops.h
+++ b/tensorflow/lite/micro/kernels/micro_ops.h
@@ -100,6 +100,7 @@ TFLMRegistration Register_READ_VARIABLE();
 TFLMRegistration Register_REDUCE_MAX();
 TFLMRegistration Register_RELU();
 TFLMRegistration Register_RELU6();
+TFLMRegistration Register_RESHAPE();
 TFLMRegistration Register_RESIZE_BILINEAR();
 TFLMRegistration Register_RESIZE_NEAREST_NEIGHBOR();
 TFLMRegistration Register_RSQRT();
@@ -137,7 +138,6 @@ TFLMRegistration* Register_WINDOW();
 
 namespace ops {
 namespace micro {
-TFLMRegistration Register_RESHAPE();
 TFLMRegistration Register_ROUND();
 }  // namespace micro
 }  // namespace ops

--- a/tensorflow/lite/micro/kernels/reshape.cc
+++ b/tensorflow/lite/micro/kernels/reshape.cc
@@ -27,9 +27,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {
-namespace ops {
-namespace micro {
-namespace reshape {
+namespace {
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   const TfLiteEvalTensor* input =
@@ -51,13 +49,10 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 }
 
-}  // namespace reshape
+}  // namespace
 
 TFLMRegistration Register_RESHAPE() {
-  return tflite::micro::RegisterOp(nullptr, reshape::PrepareReshapeReference,
-                                   reshape::Eval);
+  return tflite::micro::RegisterOp(nullptr, PrepareReshapeReference, Eval);
 }
 
-}  // namespace micro
-}  // namespace ops
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/reshape.h
+++ b/tensorflow/lite/micro/kernels/reshape.h
@@ -17,16 +17,10 @@ limitations under the License.
 #include "tensorflow/lite/c/common.h"
 
 namespace tflite {
-namespace ops {
-namespace micro {
-namespace reshape {
 
 constexpr int kReshapeInputTensor = 0;
 constexpr int kReshapeOutputTensor = 0;
 
 TfLiteStatus PrepareReshapeReference(TfLiteContext* context, TfLiteNode* node);
 
-}  // namespace reshape
-}  // namespace micro
-}  // namespace ops
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/reshape_common.cc
+++ b/tensorflow/lite/micro/kernels/reshape_common.cc
@@ -26,9 +26,6 @@ limitations under the License.
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {
-namespace ops {
-namespace micro {
-namespace reshape {
 
 namespace {
 
@@ -94,7 +91,4 @@ TfLiteStatus PrepareReshapeReference(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 }
 
-}  // namespace reshape
-}  // namespace micro
-}  // namespace ops
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/reshape_test.cc
+++ b/tensorflow/lite/micro/kernels/reshape_test.cc
@@ -38,7 +38,7 @@ void ValidateReshapeGoldens(TfLiteTensor* tensors, int tensors_size,
                             const size_t expected_output_len,
                             int* expected_dims, const size_t expected_dims_len,
                             bool expect_failure) {
-  const TFLMRegistration registration = tflite::ops::micro::Register_RESHAPE();
+  const TFLMRegistration registration = tflite::Register_RESHAPE();
   micro::KernelRunner runner(registration, tensors, tensors_size, inputs_array,
                              outputs_array,
                              /*builtin_data=*/nullptr);

--- a/tensorflow/lite/micro/kernels/xtensa/reshape.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/reshape.cc
@@ -29,9 +29,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {
-namespace ops {
-namespace micro {
-namespace reshape {
+namespace {
 
 #if defined(VISION_P6)
 void* Init(TfLiteContext* context, const char* buffer, size_t length) {
@@ -91,17 +89,14 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 }
 
-}  // namespace reshape
+}  // namespace
 
 TFLMRegistration Register_RESHAPE() {
 #if defined(VISION_P6)
-  return tflite::micro::RegisterOp(reshape::Init, reshape::Prepare,
-                                   reshape::Eval);
+  return tflite::micro::RegisterOp(Init, Prepare, Eval);
 #else
-  return tflite::micro::RegisterOp(nullptr, reshape::Prepare, reshape::Eval);
+  return tflite::micro::RegisterOp(nullptr, Prepare, Eval);
 #endif
 }
 
-}  // namespace micro
-}  // namespace ops
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/reshape_vision.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/reshape_vision.cc
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/reshape.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa_reshape.h"
 

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_reshape.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_reshape.h
@@ -22,9 +22,6 @@ limitations under the License.
 
 namespace tflite {
 
-constexpr int kReshapeInputTensor = 0;
-constexpr int kReshapeOutputTensor = 0;
-
 #if defined(VISION_P6)
 
 struct XtensaReshapeData {

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -429,8 +429,8 @@ class MicroMutableOpResolver : public MicroOpResolver {
   }
 
   TfLiteStatus AddReshape() {
-    return AddBuiltin(BuiltinOperator_RESHAPE,
-                      tflite::ops::micro::Register_RESHAPE(), ParseReshape);
+    return AddBuiltin(BuiltinOperator_RESHAPE, Register_RESHAPE(),
+                      ParseReshape);
   }
 
   TfLiteStatus AddResizeBilinear() {


### PR DESCRIPTION
@tensorflow/micro

Flatten namespace for kernel operator RESHAPE

Update unit tests namespace usage

Update MicroOpResolver namespace usage

bug=fixes #2105