### PR TITLE
Fix formatting in lstm_eval_hifi.cc

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/lstm_eval_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/lstm_eval_hifi.cc
@@ -114,7 +114,7 @@ void calc_cell_state_without_cifg(int16_t* cell_state,
 // residue iterations
 #pragma concurrent
 #pragma loop_count max = 7
-    for (i = 0; i < ((num_elms)&7); i++) {
+    for (i = 0; i < ((num_elms) & 7); i++) {
       d_cs_r_0 = p16_cs_r[i];
       d_fg_0 = p16_fg_r[i];
       d_cg_0 = p16_cg_r[i];
@@ -179,7 +179,7 @@ void calc_cell_state_without_cifg(int16_t* cell_state,
 // residue iterations
 #pragma concurrent
 #pragma loop_count max = 7
-    for (i = 0; i < ((num_elms)&7); i++) {
+    for (i = 0; i < ((num_elms) & 7); i++) {
       d_cs_r_0 = p16_cs_r[i];
       d_fg_0 = p16_fg_r[i];
       d_cg_0 = p16_cg_r[i];
@@ -288,7 +288,7 @@ void calc_cell_state_with_cifg(int16_t* cell_state, const int16_t* forget_gate,
 // residue iterations
 #pragma concurrent
 #pragma loop_count max = 7
-    for (i = 0; i < ((num_elms)&7); i++) {
+    for (i = 0; i < ((num_elms) & 7); i++) {
       d_cs_r_0 = p16_cs_r[i];
       d_fg_0 = p16_fg_r[i];
       d_cg_0 = p16_cg_r[i];
@@ -353,7 +353,7 @@ void calc_cell_state_with_cifg(int16_t* cell_state, const int16_t* forget_gate,
 // residue iterations
 #pragma concurrent
 #pragma loop_count max = 7
-    for (i = 0; i < ((num_elms)&7); i++) {
+    for (i = 0; i < ((num_elms) & 7); i++) {
       d_cs_r_0 = p16_cs_r[i];
       d_fg_0 = p16_fg_r[i];
       d_cg_0 = p16_cg_r[i];
@@ -440,7 +440,7 @@ void xa_nn_elm_mul_16x16_asym8s(int8_t* output, const int16_t* input_1,
 // residue iterations
 #pragma concurrent
 #pragma loop_count max = 7
-  for (int j = 0; j < ((num_elms)&7); j++) {
+  for (int j = 0; j < ((num_elms) & 7); j++) {
     AE_L16_IP(data_a_0, (ae_int16*)tmp_input_1, 2);
     AE_L16_IP(data_b_0, (ae_int16*)tmp_input_2, 2);
 


### PR DESCRIPTION
The lack of whitespace around bitwise & operations started failing clang-format checks. The code didn't change, so presumably this was on account of clang-format updates.

BUG=formatcleanup