### PR TITLE
build(bazel): upgrade @rules_python to 0.24.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,6 +15,9 @@
 
 workspace(name = "tflite_micro")
 
+load("//tensorflow:workspace.bzl", "workspace")
+workspace()
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # compile_commands.json generator
@@ -29,22 +32,22 @@ hedron_compile_commands_setup()
 
 http_archive(
     name = "rules_python",
-    sha256 = "497ca47374f48c8b067d786b512ac10a276211810f4a580178ee9b9ad139323a",
-    strip_prefix = "rules_python-0.16.1",
-    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.16.1.tar.gz",
+    sha256 = "0a8003b044294d7840ac7d9d73eef05d6ceb682d7516781a4ec62eeb34702578",
+    strip_prefix = "rules_python-0.24.0",
+    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.24.0.tar.gz",
 )
 
+# Read the Python package dependencies of the build environment. To modify
+# them, see //third_party:python_requirements.in.
 load("@rules_python//python:pip.bzl", "pip_parse")
 pip_parse(
     name = "tflm_pip_deps",
     requirements_lock = "//third_party:python_requirements.txt",
 )
 
+# Create repositories for each Python package dependency.
 load("@tflm_pip_deps//:requirements.bzl", "install_deps", "requirement")
 install_deps()
-
-load("//tensorflow:workspace.bzl", "workspace")
-workspace()
 
 http_archive(
   name = "pybind11_bazel",


### PR DESCRIPTION
Upgrade @rules_python in preparation for adding build stamp information to the
tflite_micro Python distribution package. This new version contains necessary
fixes.

Move the call to workspace(), which defines several external repositories,
ahead of the repository definitions in WORKSPACE itself. workspace() defines
@bazel_skylib, which is needed by the new version of @rules_python, and
therefore must be defined first.

Add a few comments about the use of @rules_python.

BUG=part of #1484