### PR TITLE
Add hello world codegen example

### DIFF
--- a/codegen/examples/hello_world/Makefile.inc
+++ b/codegen/examples/hello_world/Makefile.inc
@@ -1,0 +1,10 @@
+CODEGEN_HELLO_WORLD_SRCS := \
+$(TENSORFLOW_ROOT)codegen/examples/hello_world/hello_world.cc \
+$(TENSORFLOW_ROOT)codegen/examples/hello_world/hello_world_model.cc
+
+CODEGEN_HELLO_WORLD_HDRS := \
+$(TENSORFLOW_ROOT)codegen/examples/hello_world/hello_world_model.h
+
+# Builds a standalone binary.
+$(eval $(call microlite_test,codegen_hello_world,\
+$(CODEGEN_HELLO_WORLD_SRCS),,))

--- a/codegen/examples/hello_world/README.md
+++ b/codegen/examples/hello_world/README.md
@@ -1,0 +1,18 @@
+# Codegen Hello World Example
+
+This is a code-generated example of the hello world model.
+
+To generate the inference code at `codegen/example/hello_world_model.h/.cc`:
+
+```
+bazel run codegen:code_generator -- \
+  --model $(pwd)/tensorflow/lite/micro/examples/hello_world/models/hello_world_int8.tflite \
+  --output_dir $(pwd)/codegen/examples/hello_world \
+  --output_name hello_world_model
+```
+
+To compile the generated source, you can use the Makefile:
+
+```
+make -f tensorflow/lite/micro/tools/make/Makefile codegen_hello_world
+```

--- a/codegen/examples/hello_world/hello_world.cc
+++ b/codegen/examples/hello_world/hello_world.cc
@@ -13,12 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-/* AUTOMATICALLY GENERATED DO NOT MODIFY */
+#include "hello_world_model.h"
 
-#pragma once
+int main(int argc, char** argv) {
+  hello_world_model::Invoke();
 
-namespace ${model_name} {
-
-void Invoke();
-
-}  // namespace ${model_name}
+  return 0;
+}

--- a/codegen/examples/hello_world/hello_world_model.cc
+++ b/codegen/examples/hello_world/hello_world_model.cc
@@ -15,10 +15,10 @@ limitations under the License.
 
 /* AUTOMATICALLY GENERATED DO NOT MODIFY */
 
-#pragma once
+#include "hello_world_model.h"
 
-namespace ${model_name} {
+namespace hello_world_model {
 
-void Invoke();
+void Invoke() {}
 
-}  // namespace ${model_name}
+}  // namespace hello_world_model

--- a/codegen/examples/hello_world/hello_world_model.h
+++ b/codegen/examples/hello_world/hello_world_model.h
@@ -17,8 +17,8 @@ limitations under the License.
 
 #pragma once
 
-namespace ${model_name} {
+namespace hello_world_model {
 
 void Invoke();
 
-}  // namespace ${model_name}
+}  // namespace hello_world_model

--- a/codegen/templates/inference.cc.mako
+++ b/codegen/templates/inference.cc.mako
@@ -21,4 +21,4 @@ namespace ${model_name} {
 
 void Invoke() {}
 
-} // ${model_name}
+}  // namespace ${model_name}

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -287,6 +287,8 @@ MICRO_LITE_BENCHMARKS := $(wildcard $(TENSORFLOW_ROOT)tensorflow/lite/micro/tool
 MICROLITE_BENCHMARK_SRCS := \
 $(wildcard $(TENSORFLOW_ROOT)tensorflow/lite/micro/tools/benchmarking/*benchmark.cc)
 
+MICRO_LITE_CODEGEN_EXAMPLES := $(shell find $(TENSORFLOW_ROOT)codegen/examples/ -name Makefile.inc)
+
 MICROLITE_TEST_SRCS := \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/fake_micro_context_test.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/flatbuffer_utils_test.cc \
@@ -675,6 +677,9 @@ INCLUDES += -I$(GENERATED_SRCS_DIR)$(TENSORFLOW_ROOT)
 
 # Load the examples.
 include $(MICRO_LITE_EXAMPLE_TESTS)
+
+# Load codegen examples.
+include $(MICRO_LITE_CODEGEN_EXAMPLES)
 
 # Load the integration tests.
 include $(MICRO_LITE_INTEGRATION_TESTS)


### PR DESCRIPTION
This PR adds a codegen inference example for the hello world model to demonstrate how to invoke the code generator and build the generated source. For now, we're just checking the generated source into the repo to skip over building out the make rules and also ensuring the generated source complies with formatting rules.

This also fixes a minor formatting issue in the source templates, as clang-format now properly complained about it.

BUG=b/295390000