### PR TITLE
Add py load statement for codegen

### DIFF
--- a/codegen/BUILD
+++ b/codegen/BUILD
@@ -1,3 +1,4 @@
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("@tflm_pip_deps//:requirements.bzl", "requirement")
 
 package(


### PR DESCRIPTION
The new codegen python build rules were added without properly loading the rules.

BUG=b/295216390