### PR TITLE
Remove LICENSE export for non-existent file

### DIFF
--- a/third_party/ruy/BUILD
+++ b/third_party/ruy/BUILD
@@ -4,5 +4,3 @@ package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],
 )
-
-exports_files(["LICENSE"])


### PR DESCRIPTION
There is no LICENSE file in the //third_party/ruy folder.

Context: http://cl/557522005
BUG=cleanup