### PR TITLE
Generate BuiltinData for FullyConnected

### DIFF
--- a/codegen/BUILD
+++ b/codegen/BUILD
@@ -13,6 +13,7 @@ py_library(
     ],
     deps = [
         ":utils",
+        "//codegen/operators:factory",
         "//codegen/operators:operator",
         "//tensorflow/lite/python:schema_py",
         "//tensorflow/lite/tools:visualize",

--- a/codegen/examples/hello_world/hello_world_model.cc
+++ b/codegen/examples/hello_world/hello_world_model.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "hello_world_model.h"
 
+#include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/c_api_types.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/kernels/micro_ops.h"
@@ -42,6 +43,11 @@ struct Node0_0 {
     int data[1] = {7};
   } outputs;
   // No intermediates
+  TfLiteFullyConnectedParams builtin_data = {
+      .activation = kTfLiteActRelu,
+      .weights_format = kTfLiteFullyConnectedWeightsFormatDefault,
+      .keep_num_dims = false,
+      .asymmetric_quantize_inputs = false};
 } node_0_0;
 
 struct Node0_1 {
@@ -54,6 +60,11 @@ struct Node0_1 {
     int data[1] = {8};
   } outputs;
   // No intermediates
+  TfLiteFullyConnectedParams builtin_data = {
+      .activation = kTfLiteActRelu,
+      .weights_format = kTfLiteFullyConnectedWeightsFormatDefault,
+      .keep_num_dims = false,
+      .asymmetric_quantize_inputs = false};
 } node_0_1;
 
 struct Node0_2 {
@@ -66,6 +77,11 @@ struct Node0_2 {
     int data[1] = {9};
   } outputs;
   // No intermediates
+  TfLiteFullyConnectedParams builtin_data = {
+      .activation = kTfLiteActNone,
+      .weights_format = kTfLiteFullyConnectedWeightsFormatDefault,
+      .keep_num_dims = false,
+      .asymmetric_quantize_inputs = false};
 } node_0_2;
 
 }  // namespace
@@ -84,7 +100,7 @@ Model::Model() {
       .outputs = reinterpret_cast<TfLiteIntArray*>(&node_0_0.outputs),
       .intermediates = nullptr,
       .user_data = nullptr,
-      .builtin_data = nullptr,
+      .builtin_data = static_cast<void*>(&node_0_0.builtin_data),
       .custom_initial_data = nullptr,
       .custom_initial_data_size = 0};
   subgraph0_nodes_[1] = {
@@ -92,7 +108,7 @@ Model::Model() {
       .outputs = reinterpret_cast<TfLiteIntArray*>(&node_0_1.outputs),
       .intermediates = nullptr,
       .user_data = nullptr,
-      .builtin_data = nullptr,
+      .builtin_data = static_cast<void*>(&node_0_1.builtin_data),
       .custom_initial_data = nullptr,
       .custom_initial_data_size = 0};
   subgraph0_nodes_[2] = {
@@ -100,7 +116,7 @@ Model::Model() {
       .outputs = reinterpret_cast<TfLiteIntArray*>(&node_0_2.outputs),
       .intermediates = nullptr,
       .user_data = nullptr,
-      .builtin_data = nullptr,
+      .builtin_data = static_cast<void*>(&node_0_2.builtin_data),
       .custom_initial_data = nullptr,
       .custom_initial_data_size = 0};
 }

--- a/codegen/graph.py
+++ b/codegen/graph.py
@@ -19,6 +19,7 @@ from typing import List, Optional, Sequence
 import string
 import textwrap
 
+from tflite_micro.codegen.operators import factory
 from tflite_micro.codegen.operators import operator
 from tflite_micro.codegen import utils
 from tflite_micro.tensorflow.lite.python import schema_py_generated as schema_fb
@@ -55,12 +56,13 @@ class Subgraph(object):
                subgraph: schema_fb.SubGraphT):
     self._subgraph_idx: int = subgraph_idx
     self._subgraph: schema_fb.SubGraphT = subgraph
-    self._operators: List[operator.Operator] = [
-        operator.Operator(op) for op in subgraph.operators
-    ]
     self._op_codes: List[OpCode] = [
         OpCode(op_code) for op_code in model.operatorCodes
     ]
+    self._operators: List[operator.Operator] = []
+    for op in subgraph.operators:
+      op_code = model.operatorCodes[op.opcodeIndex]
+      self._operators.append(factory.create_operator(op_code, op))
 
   @property
   def index(self) -> int:

--- a/codegen/operators/BUILD
+++ b/codegen/operators/BUILD
@@ -6,6 +6,41 @@ package(
 )
 
 py_library(
+    name = "constants",
+    srcs = [
+        "constants.py",
+    ],
+    deps = [
+        "//tensorflow/lite/python:schema_py",
+    ],
+)
+
+py_library(
+    name = "factory",
+    srcs = [
+        "factory.py",
+    ],
+    deps = [
+        ":fully_connected",
+        ":operator",
+        "//tensorflow/lite/python:schema_py",
+    ],
+)
+
+py_library(
+    name = "fully_connected",
+    srcs = [
+        "fully_connected.py",
+    ],
+    deps = [
+        ":constants",
+        ":operator",
+        "//codegen:utils",
+        "//tensorflow/lite/python:schema_py",
+    ],
+)
+
+py_library(
     name = "operator",
     srcs = [
         "operator.py",

--- a/codegen/operators/constants.py
+++ b/codegen/operators/constants.py
@@ -1,0 +1,28 @@
+# Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+""" Operator Constants """
+
+from typing import Dict
+
+from tflite_micro.tensorflow.lite.python import schema_py_generated as schema_fb
+
+ACTIVATION_FUNCS: Dict[int, str] = {
+    schema_fb.ActivationFunctionType.NONE: "kTfLiteActNone",
+    schema_fb.ActivationFunctionType.RELU: "kTfLiteActRelu",
+    schema_fb.ActivationFunctionType.RELU_N1_TO_1: "kTfLiteActReluN1To1",
+    schema_fb.ActivationFunctionType.RELU6: "kTfLiteActRelu6",
+    schema_fb.ActivationFunctionType.TANH: "kTfLiteActTanh",
+    schema_fb.ActivationFunctionType.SIGN_BIT: "kTfLiteActSignBit",
+}

--- a/codegen/operators/factory.py
+++ b/codegen/operators/factory.py
@@ -1,0 +1,28 @@
+# Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+""" A factory function for creating operators """
+
+from tflite_micro.codegen.operators import fully_connected
+from tflite_micro.codegen.operators import operator
+from tflite_micro.tensorflow.lite.python import schema_py_generated as schema_fb
+
+_BUILTIN_OPERATORS: dict[int, operator.Operator.__class__] = {
+    schema_fb.BuiltinOperator.FULLY_CONNECTED: fully_connected.FullyConnected,
+}
+
+
+def create_operator(op_code: schema_fb.OperatorCodeT, op: schema_fb.Operator):
+  operator_class = _BUILTIN_OPERATORS[op_code.builtinCode]
+  return operator_class(op)

--- a/codegen/operators/fully_connected.py
+++ b/codegen/operators/fully_connected.py
@@ -1,0 +1,53 @@
+# Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+""" FullyConnected operator """
+
+from typing import Dict
+import string
+
+from tflite_micro.codegen.operators import constants
+from tflite_micro.codegen.operators import operator
+from tflite_micro.codegen import utils
+from tflite_micro.tensorflow.lite.python import schema_py_generated as schema_fb
+
+_WEIGHTS_FORMATS: Dict[int, str] = {
+    schema_fb.FullyConnectedOptionsWeightsFormat.DEFAULT:
+    "kTfLiteFullyConnectedWeightsFormatDefault",
+    schema_fb.FullyConnectedOptionsWeightsFormat.SHUFFLED4x16INT8:
+    "kTfLiteFullyConnectedWeightsFormatShuffled4x16Int8",
+}
+
+
+class FullyConnected(operator.Operator):
+
+  def __init__(self, op: schema_fb.OperatorT):
+    assert op.builtinOptionsType == schema_fb.BuiltinOptions.FullyConnectedOptions
+    super(FullyConnected, self).__init__(op)
+    self._builtin_options: schema_fb.FullyConnectedOptionsT = op.builtinOptions
+
+  def generate_c_builtin_data(self) -> str:
+    builtin_template = string.Template(
+        "TfLiteFullyConnectedParams builtin_data = {\n"
+        "    .activation = ${activation},\n"
+        "    .weights_format = ${weights_format},\n"
+        "    .keep_num_dims = ${keep_num_dims},\n"
+        "    .asymmetric_quantize_inputs = ${asymmetric_quantize_inputs}};")
+    return builtin_template.substitute(
+        activation=constants.ACTIVATION_FUNCS[
+            self._builtin_options.fusedActivationFunction],
+        weights_format=_WEIGHTS_FORMATS[self._builtin_options.weightsFormat],
+        keep_num_dims=utils.bool_to_c_str(self._builtin_options.keepNumDims),
+        asymmetric_quantize_inputs=utils.bool_to_c_str(
+            self._builtin_options.asymmetricQuantizeInputs))

--- a/codegen/templates/inference.cc.mako
+++ b/codegen/templates/inference.cc.mako
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "${header_file}"
 
+#include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/c_api_types.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/kernels/micro_ops.h"

--- a/codegen/utils.py
+++ b/codegen/utils.py
@@ -25,6 +25,11 @@ def to_pascal_case(s: str) -> str:
   return s.title().replace('_', '')
 
 
+def bool_to_c_str(b: bool) -> str:
+  """ Convert a python bool value to a C bool string. Ie, False -> 'false' """
+  return str(b).lower()
+
+
 class IntArray(object):
   """ A helper class for generating int arrays that can be used to provide the
       backing storage for a TfLiteIntArray. """


### PR DESCRIPTION
Each operator has its own set of BuiltinOptions, which will translate into an op-specific TfLite Params structure. This change turns Operator into a base class with common functionality, and adds a FullyConnected subclass that knows how to generate the TfLiteFullyConnectedParams struct.

BUG=b/295175961