### PR TITLE
Move benchmarking model to static memory

### DIFF
--- a/tensorflow/lite/micro/tools/benchmarking/generic_model_benchmark.cc
+++ b/tensorflow/lite/micro/tools/benchmarking/generic_model_benchmark.cc
@@ -104,7 +104,7 @@ bool ReadFile(const char* file_name, void* buffer, size_t buffer_size) {
 int Benchmark(const char* model_file_name) {
   Profiler profiler;
   alignas(16) static uint8_t tensor_arena[kTensorArenaSize];
-  alignas(16) unsigned char model_file_content[kModelSize];
+  alignas(16) static uint8_t model_file_content[kModelSize];
 
   if (!ReadFile(model_file_name, model_file_content, kModelSize)) {
     return -1;


### PR DESCRIPTION
In the tflm_benchmark target, we read a file in from the command line into an internal buffer for the TFLite model. The buffer for this is 2e6 bytes. This PR moves this buffer from the stack to static storage.

BUG=cleanup