### PR TITLE
Adding micro_log.h header to micro_interpreter_context.cc and batch_matmul.cc

### DIFF
--- a/tensorflow/lite/micro/kernels/batch_matmul.cc
+++ b/tensorflow/lite/micro/kernels/batch_matmul.cc
@@ -25,8 +25,8 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
-#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 namespace {

--- a/tensorflow/lite/micro/kernels/batch_matmul.cc
+++ b/tensorflow/lite/micro/kernels/batch_matmul.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/micro_interpreter_context.h
+++ b/tensorflow/lite/micro/micro_interpreter_context.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define TENSORFLOW_LITE_MICRO_MICRO_INTERPRETER_CONTEXT_H_
 
 #include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_allocator.h"
 #include "tensorflow/lite/micro/micro_context.h"
 #include "tensorflow/lite/micro/micro_interpreter_graph.h"

--- a/tensorflow/lite/micro/micro_interpreter_context.h
+++ b/tensorflow/lite/micro/micro_interpreter_context.h
@@ -17,10 +17,10 @@ limitations under the License.
 #define TENSORFLOW_LITE_MICRO_MICRO_INTERPRETER_CONTEXT_H_
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_allocator.h"
 #include "tensorflow/lite/micro/micro_context.h"
 #include "tensorflow/lite/micro/micro_interpreter_graph.h"
+#include "tensorflow/lite/micro/micro_log.h"
 
 namespace tflite {
 


### PR DESCRIPTION
micro_interpreter_context.cc and batch_matmul.cc are missing micro_log.h header needed to use MicroPrintf causing Copybara sync to break

[copybara google3 CL](https://critique.corp.google.com/cl/564553284) with same fix

BUG=N/A