### PR TITLE
Implement MicroContext/Graph for codegen

### DIFF
--- a/codegen/examples/hello_world/Makefile.inc
+++ b/codegen/examples/hello_world/Makefile.inc
@@ -1,9 +1,13 @@
+# TODO(rjascani): The codegen runtime files (ie, in runtime subdir) should be a
+# separate library.
 CODEGEN_HELLO_WORLD_SRCS := \
 $(TENSORFLOW_ROOT)codegen/examples/hello_world/hello_world.cc \
-$(TENSORFLOW_ROOT)codegen/examples/hello_world/hello_world_model.cc
+$(TENSORFLOW_ROOT)codegen/examples/hello_world/hello_world_model.cc \
+$(TENSORFLOW_ROOT)codegen/runtime/micro_codegen_context.cc
 
 CODEGEN_HELLO_WORLD_HDRS := \
-$(TENSORFLOW_ROOT)codegen/examples/hello_world/hello_world_model.h
+$(TENSORFLOW_ROOT)codegen/examples/hello_world/hello_world_model.h \
+$(TENSORFLOW_ROOT)codegen/runtime/micro_codegen_context.h
 
 # Builds a standalone binary.
 $(eval $(call microlite_test,codegen_hello_world,\

--- a/codegen/examples/hello_world/hello_world_model.h
+++ b/codegen/examples/hello_world/hello_world_model.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #pragma once
 
+#include "codegen/runtime/micro_codegen_context.h"
 #include "tensorflow/lite/c/c_api_types.h"
 #include "tensorflow/lite/c/common.h"
 
@@ -29,9 +30,9 @@ class Model {
   TfLiteStatus Invoke();
 
  private:
-  TfLiteStatus InvokeSubgraph0();
-
   TfLiteContext context_ = {};
+  tflite::Subgraph subgraphs_[1];
+  tflite::MicroCodegenContext micro_context_;
   TfLiteNode subgraph0_nodes_[3] = {};
   TfLiteEvalTensor subgraph0_tensors_[10] = {};
 };

--- a/codegen/runtime/micro_codegen_context.cc
+++ b/codegen/runtime/micro_codegen_context.cc
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include "codegen/runtime/micro_codegen_context.h"
 
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/compatibility.h"
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/micro_log.h"
 
@@ -30,6 +32,8 @@ void* MicroCodegenContext::GetScratchBuffer(int buffer_idx) {
 }
 
 TfLiteEvalTensor* MicroCodegenContext::GetEvalTensor(int tensor_idx) {
+  TFLITE_DCHECK(static_cast<size_t>(tensor_idx) <
+                subgraphs_[current_subgraph_idx_].tensors.size());
   return &subgraphs_[current_subgraph_idx_].tensors[tensor_idx];
 }
 
@@ -88,6 +92,8 @@ void MicroCodegenContext::DeallocateTempBuffer(uint8_t*) {
 }
 
 TfLiteStatus MicroCodegenContext::InvokeSubgraph(int subgraph_idx) {
+  TF_LITE_ENSURE(context_,
+                 static_cast<size_t>(subgraph_idx) < subgraphs_.size());
   size_t previous_subgraph_idx = current_subgraph_idx_;
   TfLiteStatus status =
       subgraphs_[subgraph_idx].invoke(context_, subgraphs_[subgraph_idx].nodes);
@@ -96,21 +102,29 @@ TfLiteStatus MicroCodegenContext::InvokeSubgraph(int subgraph_idx) {
 }
 
 size_t MicroCodegenContext::NumSubgraphInputs(int subgraph_idx) {
+  TFLITE_DCHECK(static_cast<size_t>(subgraph_idx) < subgraphs_.size());
   return subgraphs_[subgraph_idx].inputs.size();
 }
 
 TfLiteEvalTensor* MicroCodegenContext::GetSubgraphInput(int subgraph_idx,
                                                         int input_idx) {
+  TFLITE_DCHECK(static_cast<size_t>(subgraph_idx) < subgraphs_.size());
+  TFLITE_DCHECK(static_cast<size_t>(input_idx) <
+                subgraphs_[subgraph_idx].inputs.size());
   const size_t tensor_idx = subgraphs_[subgraph_idx].inputs[input_idx];
   return &subgraphs_[subgraph_idx].tensors[tensor_idx];
 }
 
 size_t MicroCodegenContext::NumSubgraphOutputs(int subgraph_idx) {
+  TFLITE_DCHECK(static_cast<size_t>(subgraph_idx) < subgraphs_.size());
   return subgraphs_[subgraph_idx].outputs.size();
 }
 
 TfLiteEvalTensor* MicroCodegenContext::GetSubgraphOutput(int subgraph_idx,
                                                          int output_idx) {
+  TFLITE_DCHECK(static_cast<size_t>(subgraph_idx) < subgraphs_.size());
+  TFLITE_DCHECK(static_cast<size_t>(output_idx) <
+                subgraphs_[subgraph_idx].outputs.size());
   const size_t tensor_idx = subgraphs_[subgraph_idx].outputs[output_idx];
   return &subgraphs_[subgraph_idx].tensors[tensor_idx];
 }

--- a/codegen/runtime/micro_codegen_context.cc
+++ b/codegen/runtime/micro_codegen_context.cc
@@ -1,0 +1,124 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "codegen/runtime/micro_codegen_context.h"
+
+#include "tensorflow/lite/kernels/op_macros.h"
+#include "tensorflow/lite/micro/micro_log.h"
+
+namespace tflite {
+
+MicroCodegenContext::MicroCodegenContext(TfLiteContext* context,
+                                         Span<Subgraph> subgraphs)
+    : context_(context), subgraphs_(subgraphs) {}
+
+void* MicroCodegenContext::GetScratchBuffer(int buffer_idx) {
+  // TODO(rjascani): Implement scratch buffers
+  return nullptr;
+}
+
+TfLiteEvalTensor* MicroCodegenContext::GetEvalTensor(int tensor_idx) {
+  return &subgraphs_[current_subgraph_idx_].tensors[tensor_idx];
+}
+
+TfLiteStatus MicroCodegenContext::set_external_context(
+    void* external_context_payload) {
+  if (external_context_payload == nullptr ||
+      external_context_payload_ != nullptr) {
+    MicroPrintf(
+        "Attempting to set external context to %x but it was %x already",
+        external_context_payload, external_context_payload_);
+    return kTfLiteError;
+  }
+
+  external_context_payload_ = external_context_payload;
+  return kTfLiteOk;
+}
+
+void* MicroCodegenContext::external_context() {
+  return external_context_payload_;
+}
+
+MicroGraph& MicroCodegenContext::graph() { return *this; }
+
+void* MicroCodegenContext::AllocatePersistentBuffer(size_t) {
+  // Not allowed at Eval
+  TFLITE_ABORT;
+  return nullptr;
+}
+
+TfLiteStatus MicroCodegenContext::RequestScratchBufferInArena(size_t, int*) {
+  // Not allowed at Eval
+  TFLITE_ABORT;
+  return kTfLiteError;
+}
+
+TfLiteTensor* MicroCodegenContext::AllocateTempTfLiteTensor(int) {
+  // Not allowed at Eval
+  TFLITE_ABORT;
+  return nullptr;
+}
+
+void MicroCodegenContext::DeallocateTempTfLiteTensor(TfLiteTensor*) {
+  // Not allowed at Eval
+  TFLITE_ABORT;
+}
+
+uint8_t* MicroCodegenContext::AllocateTempBuffer(size_t, size_t) {
+  // Not allowed at Eval
+  TFLITE_ABORT;
+  return nullptr;
+}
+
+void MicroCodegenContext::DeallocateTempBuffer(uint8_t*) {
+  // Not allowed at Eval
+  TFLITE_ABORT;
+}
+
+TfLiteStatus MicroCodegenContext::InvokeSubgraph(int subgraph_idx) {
+  size_t previous_subgraph_idx = current_subgraph_idx_;
+  TfLiteStatus status =
+      subgraphs_[subgraph_idx].invoke(context_, subgraphs_[subgraph_idx].nodes);
+  current_subgraph_idx_ = previous_subgraph_idx;
+  return status;
+}
+
+size_t MicroCodegenContext::NumSubgraphInputs(int subgraph_idx) {
+  return subgraphs_[subgraph_idx].inputs.size();
+}
+
+TfLiteEvalTensor* MicroCodegenContext::GetSubgraphInput(int subgraph_idx,
+                                                        int input_idx) {
+  const size_t tensor_idx = subgraphs_[subgraph_idx].inputs[input_idx];
+  return &subgraphs_[subgraph_idx].tensors[tensor_idx];
+}
+
+size_t MicroCodegenContext::NumSubgraphOutputs(int subgraph_idx) {
+  return subgraphs_[subgraph_idx].outputs.size();
+}
+
+TfLiteEvalTensor* MicroCodegenContext::GetSubgraphOutput(int subgraph_idx,
+                                                         int output_idx) {
+  const size_t tensor_idx = subgraphs_[subgraph_idx].outputs[output_idx];
+  return &subgraphs_[subgraph_idx].tensors[tensor_idx];
+}
+
+int MicroCodegenContext::NumSubgraphs() { return subgraphs_.size(); }
+
+MicroResourceVariables* MicroCodegenContext::GetResourceVariables() {
+  return nullptr;
+}
+
+}  // namespace tflite

--- a/codegen/runtime/micro_codegen_context.cc
+++ b/codegen/runtime/micro_codegen_context.cc
@@ -95,6 +95,7 @@ TfLiteStatus MicroCodegenContext::InvokeSubgraph(int subgraph_idx) {
   TF_LITE_ENSURE(context_,
                  static_cast<size_t>(subgraph_idx) < subgraphs_.size());
   size_t previous_subgraph_idx = current_subgraph_idx_;
+  current_subgraph_idx_ = subgraph_idx;
   TfLiteStatus status =
       subgraphs_[subgraph_idx].invoke(context_, subgraphs_[subgraph_idx].nodes);
   current_subgraph_idx_ = previous_subgraph_idx;

--- a/codegen/runtime/micro_codegen_context.h
+++ b/codegen/runtime/micro_codegen_context.h
@@ -1,0 +1,90 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef CODEGEN_RUNTIME_MICRO_CODEGEN_CONTEXT_H_
+#define CODEGEN_RUNTIME_MICRO_CODEGEN_CONTEXT_H_
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/micro/micro_context.h"
+#include "tensorflow/lite/micro/micro_graph.h"
+
+namespace tflite {
+
+// A poor man's std::span, we should consider using the Pigweed span instead.
+template <typename T>
+class Span {
+ public:
+  constexpr Span(T* data, size_t size) noexcept : data_(data), size_(size) {}
+
+  constexpr T& operator[](size_t idx) const noexcept { return *(data_ + idx); }
+
+  constexpr T* data() const noexcept { return data_; }
+  constexpr size_t size() const noexcept { return size_; }
+
+ private:
+  T* data_;
+  size_t size_;
+};
+
+struct Subgraph {
+  Span<const size_t> inputs;
+  Span<const size_t> outputs;
+  Span<TfLiteNode> nodes;
+  Span<TfLiteEvalTensor> tensors;
+  TfLiteStatus (*invoke)(TfLiteContext*, Span<TfLiteNode>);
+};
+
+class MicroCodegenContext : public MicroContext, MicroGraph {
+ public:
+  MicroCodegenContext(TfLiteContext* context, Span<Subgraph> subgraphs);
+
+  ~MicroCodegenContext() = default;
+
+  // MicroContext API
+  void* AllocatePersistentBuffer(size_t bytes) override;
+  TfLiteStatus RequestScratchBufferInArena(size_t bytes,
+                                           int* buffer_idx) override;
+  void* GetScratchBuffer(int buffer_idx) override;
+  TfLiteTensor* AllocateTempTfLiteTensor(int tensor_idx) override;
+  void DeallocateTempTfLiteTensor(TfLiteTensor* tensor) override;
+  uint8_t* AllocateTempBuffer(size_t size, size_t alignment) override;
+  void DeallocateTempBuffer(uint8_t* buffer) override;
+  TfLiteEvalTensor* GetEvalTensor(int tensor_idx) override;
+  TfLiteStatus set_external_context(void* external_context_payload) override;
+  void* external_context() override;
+  MicroGraph& graph() override;
+
+  // MicroGraph API
+  TfLiteStatus InvokeSubgraph(int subgraph_idx) override;
+  size_t NumSubgraphInputs(int subgraph_idx) override;
+  TfLiteEvalTensor* GetSubgraphInput(int subgraph_idx, int input_idx) override;
+  size_t NumSubgraphOutputs(int subgraph_idx) override;
+  TfLiteEvalTensor* GetSubgraphOutput(int subgraph_idx,
+                                      int output_idx) override;
+  int NumSubgraphs() override;
+  MicroResourceVariables* GetResourceVariables() override;
+
+ private:
+  TfLiteContext* context_;
+  Span<Subgraph> subgraphs_;
+  size_t current_subgraph_idx_ = 0;
+  void* external_context_payload_ = nullptr;
+
+  TF_LITE_REMOVE_VIRTUAL_DELETE
+};
+
+}  // namespace tflite
+
+#endif  // CODEGEN_RUNTIME_MICRO_CODEGEN_CONTEXT_H_

--- a/codegen/templates/inference.h.mako
+++ b/codegen/templates/inference.h.mako
@@ -17,6 +17,7 @@ limitations under the License.
 
 #pragma once
 
+#include "codegen/runtime/micro_codegen_context.h"
 #include "tensorflow/lite/c/c_api_types.h"
 #include "tensorflow/lite/c/common.h"
 
@@ -29,11 +30,9 @@ class Model {
   TfLiteStatus Invoke();
 
  private:
-% for subgraph_idx in range(len(graph.subgraphs)):
-  TfLiteStatus InvokeSubgraph${subgraph_idx}();
-% endfor
-
   TfLiteContext context_ = {};
+  tflite::Subgraph subgraphs_[${len(graph.subgraphs)}];
+  tflite::MicroCodegenContext micro_context_;
 % for subgraph in graph.subgraphs:
   TfLiteNode ${subgraph.nodes_array}[${len(subgraph.operators)}] = {};
 % endfor


### PR DESCRIPTION
The TFLM kernels use the MicroContext and MicroGraph interfaces to fetch
eval tensors and access other parts of the graph. Since codegen does not
have the MicroInterpreter and related objects to serve those, this PR
introduces a new MicroCodegenContext class that serves as both the
MicroContext and MicroGraph.

The MicroCodegenContext is configured with a span of Subgraphs, each of
which includes the inputs, outputs, nodes, tensors and an invocation
function. The code generator will create the data and functions needed
for each Subgraph and initialize the MicroCodegenContext with it. By
having the re-usable MicroCodegenContext, the code generator won't have
to generate nearly as much code.

BUG=b/295174086