### PR TITLE
Fix Hifi5 docker image name

### DIFF
--- a/.github/workflows/xtensa_presubmit.yml
+++ b/.github/workflows/xtensa_presubmit.yml
@@ -47,7 +47,7 @@ jobs:
       - run: |
           rm -rf .git
           echo ${{ secrets.tflm-bot-token }} | docker login ghcr.io -u tflm-bot --password-stdin
-          docker run --env XTENSA_TOOLS_VERSION=RI-2022.9-linux --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa_hifi5:0.2 \
+          docker run --env XTENSA_TOOLS_VERSION=RI-2022.9-linux --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa_xplorer_hifi5:0.2 \
           /bin/bash -c \
           "cd /opt && tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi5.sh tflite-micro/"
 


### PR DESCRIPTION
In uploading the latest docker container images, the xtensa_hifi5 image was renamed to xtensa_xplorer_hifi5. This commit updates the presubmit job to use the correct image name.

BUG=2225