### PR TITLE
Update python version in Xtensa images

### DIFF
--- a/ci/Dockerfile.xtensa_xplorer_11
+++ b/ci/Dockerfile.xtensa_xplorer_11
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM python:3.10-bullseye
 ENV DEBIAN_FRONTEND noninterative
 
 RUN \
@@ -9,10 +9,7 @@ RUN \
     curl \
     git \
     unzip \
-    wget \
-    python3 \
-    python \
-    python3-pip
+    wget
 
 WORKDIR /opt/xtensa
 
@@ -21,9 +18,6 @@ COPY ./mini1m1m_RI_2019_2_linux_w_keys.tgz .
 COPY ./XtensaTools_RI_2022_9_linux.tgz .
 COPY ci/install_cores_xplorer_11.sh .
 COPY ci/install_bazelisk.sh .
-
-RUN \
-  python3 -m pip install -U --force-reinstall pip
 
 RUN \
   pip3 install Pillow

--- a/ci/Dockerfile.xtensa_xplorer_13
+++ b/ci/Dockerfile.xtensa_xplorer_13
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM python:3.10-bullseye
 ENV DEBIAN_FRONTEND noninterative
 
 RUN \
@@ -9,10 +9,7 @@ RUN \
     curl \
     git \
     unzip \
-    wget \
-    python3 \
-    python \
-    python3-pip
+    wget
 
 WORKDIR /opt/xtensa
 
@@ -23,9 +20,6 @@ COPY ./P6_200528_linux.tgz .
 COPY ./HIFI_190304_swupgrade_linux.tgz .
 COPY ci/install_cores_xplorer_13.sh .
 COPY ci/install_bazelisk.sh .
-
-RUN \
-  python3 -m pip install -U --force-reinstall pip
 
 RUN \
   pip3 install Pillow

--- a/ci/Dockerfile.xtensa_xplorer_solo
+++ b/ci/Dockerfile.xtensa_xplorer_solo
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM python:3.10-bullseye
 ENV DEBIAN_FRONTEND noninterative
 
 RUN \
@@ -9,10 +9,7 @@ RUN \
     curl \
     git \
     unzip \
-    wget \
-    python3 \
-    python \
-    python3-pip
+    wget
 
 WORKDIR /opt/xtensa
 
@@ -21,9 +18,6 @@ COPY ./PRD_H5_RDO_07_01_2022_linux.tgz .
 COPY ./XtensaTools_RI_2022_9_linux.tgz .
 COPY ci/install_cores_xplorer_solo.sh .
 COPY ci/install_bazelisk.sh .
-
-RUN \
-  python3 -m pip install -U --force-reinstall pip
 
 RUN \
   pip3 install Pillow


### PR DESCRIPTION
The Xtensa docker images were using python 3.6, which is incompatible with some of our python packages. This has not been a problem before because the Xtensa images only perform make builds with very minimal python script usage. With the new codegen tools, Bazel is used to invoke the code generator, and this brings in the incompatible python dependencies.

This PR changes the base image for the three Xtensa docker containers to pull to python instead of ubuntu. This is similar to our base TFLM docker image, which also uses the same python:3.10-bullseye base image.

BUG=b/300655634