### PR TITLE
 Remove unwanted ;(semicolon) in micro_profiler.h

### DIFF
--- a/tensorflow/lite/micro/micro_profiler.h
+++ b/tensorflow/lite/micro/micro_profiler.h
@@ -87,7 +87,7 @@ class MicroProfiler : public MicroProfilerInterface {
 
   int FindExistingOrNextPosition(const char* tag_name);
 
-  TF_LITE_REMOVE_VIRTUAL_DELETE;
+  TF_LITE_REMOVE_VIRTUAL_DELETE
 };
 
 #if defined(TF_LITE_STRIP_ERROR_STRINGS)


### PR DESCRIPTION
Remove unwanted **;(semicolon)** for `TF_LITE_REMOVE_VIRTUAL_DELETE` from **micro_profiler.h**

BUG=cleanup