### PR TITLE
build: Add -Wno-unused-parameter to bazel build

### DIFF
--- a/tensorflow/lite/build_def.bzl
+++ b/tensorflow/lite/build_def.bzl
@@ -3,6 +3,7 @@ def tflite_copts():
     copts = [
         "-DFARMHASH_NO_CXX_STRING",
         "-Wno-sign-compare",
+        "-Wno-unused-parameter",
         "-fno-exceptions",  # Exceptions are unused in TFLite.
     ]
     return copts

--- a/tensorflow/lite/micro/BUILD
+++ b/tensorflow/lite/micro/BUILD
@@ -124,6 +124,7 @@ cc_library(
 cc_library(
     name = "micro_graph",
     hdrs = ["micro_graph.h"],
+    copts = micro_copts(),
     deps = [
         ":micro_common",
         ":micro_resource_variable",
@@ -135,6 +136,7 @@ cc_library(
     name = "micro_interpreter_graph",
     srcs = ["micro_interpreter_graph.cc"],
     hdrs = ["micro_interpreter_graph.h"],
+    copts = micro_copts(),
     deps = [
         ":memory_helpers",
         ":micro_allocator",
@@ -154,6 +156,7 @@ cc_library(
     name = "mock_micro_graph",
     srcs = ["mock_micro_graph.cc"],
     hdrs = ["mock_micro_graph.h"],
+    copts = micro_copts(),
     deps = [
         ":micro_allocator",
         ":micro_graph",
@@ -210,6 +213,7 @@ cc_library(
     name = "flatbuffer_utils",
     srcs = ["flatbuffer_utils.cc"],
     hdrs = ["flatbuffer_utils.h"],
+    copts = micro_copts(),
     deps = [
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/schema:schema_fbs",
@@ -221,6 +225,7 @@ cc_library(
     name = "memory_helpers",
     srcs = ["memory_helpers.cc"],
     hdrs = ["memory_helpers.h"],
+    copts = micro_copts(),
     deps = [
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/kernels/internal:reference",

--- a/tensorflow/lite/micro/build_def.bzl
+++ b/tensorflow/lite/micro/build_def.bzl
@@ -1,6 +1,7 @@
 def micro_copts():
     return [
         "-Wall",
+        "-Wno-unused-parameter",
         "-Wnon-virtual-dtor",
         "-DFLATBUFFERS_LOCALE_INDEPENDENT=0",
     ]

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -38,6 +38,7 @@ package_group(
 cc_library(
     name = "activation_utils",
     hdrs = ["activation_utils.h"],
+    copts = micro_copts(),
     deps = [
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/kernels/internal:cppmath",
@@ -52,6 +53,7 @@ cc_library(
     hdrs = [
         "circular_buffer_flexbuffers_generated_data.h",
     ],
+    copts = micro_copts(),
 )
 
 cc_library(
@@ -62,6 +64,7 @@ cc_library(
     hdrs = [
         "conv_test.h",
     ],
+    copts = micro_copts(),
     deps = [
         ":kernel_runner",
         ":micro_ops",
@@ -79,6 +82,7 @@ cc_library(
     hdrs = [
         "detection_postprocess_flexbuffers_generated_data.h",
     ],
+    copts = micro_copts(),
 )
 
 cc_library(
@@ -87,6 +91,7 @@ cc_library(
         "kernel_runner.cc",
     ],
     hdrs = ["kernel_runner.h"],
+    copts = micro_copts(),
     visibility = [
         "//visibility:public",
     ],
@@ -107,6 +112,7 @@ cc_library(
         "kernel_util.cc",
     ],
     hdrs = ["kernel_util.h"],
+    copts = micro_copts(),
     visibility = [
         ":kernel_friends",
         ":tflite_micro",
@@ -126,6 +132,7 @@ cc_library(
     hdrs = [
         "lstm_shared.h",
     ],
+    copts = micro_copts(),
     visibility = ["//tensorflow/lite/micro/kernels/testdata:__pkg__"],
 )
 
@@ -134,6 +141,7 @@ cc_library(
     hdrs = [
         "lstm_eval_test.h",
     ],
+    copts = micro_copts(),
     deps = [
         ":kernel_util",
         ":micro_ops",
@@ -149,6 +157,7 @@ cc_library(
         "micro_tensor_utils.cc",
     ],
     hdrs = ["micro_tensor_utils.h"],
+    copts = micro_copts(),
     deps = [
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/core:macros",


### PR DESCRIPTION
This matches makefile build

Also adds some missing micro_copts() to targets.

BUG=cleanup