### PR TITLE
Remove extra Xtensa tools install

### DIFF
--- a/.github/workflows/xtensa_postmerge.yml
+++ b/.github/workflows/xtensa_postmerge.yml
@@ -31,7 +31,7 @@ jobs:
       - run: |
           rm -rf .git
           echo ${{ secrets.tflm-bot-token }} | docker login ghcr.io -u tflm-bot --password-stdin
-          docker run --env XTENSA_TOOLS_VERSION=RI-2020.4-linux --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa_xplorer_13:0.2 \
+          docker run --env XTENSA_TOOLS_VERSION=RI-2020.4-linux --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa_xplorer_13:0.3 \
           /bin/bash -c \
           "cd /opt && tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_fusion_f1.sh EXTERNAL tflite-micro/"
 
@@ -46,7 +46,7 @@ jobs:
       - run: |
           rm -rf .git
           echo ${{ secrets.tflm-bot-token }} | docker login ghcr.io -u tflm-bot --password-stdin
-          docker run --env XTENSA_TOOLS_VERSION=RI-2020.4-linux --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa_xplorer_13:0.2 \
+          docker run --env XTENSA_TOOLS_VERSION=RI-2020.4-linux --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa_xplorer_13:0.3 \
           /bin/bash -c \
           "cd /opt && tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_vision_p6.sh RUN_TESTS tflite-micro/"
 

--- a/.github/workflows/xtensa_presubmit.yml
+++ b/.github/workflows/xtensa_presubmit.yml
@@ -32,7 +32,7 @@ jobs:
       - run: |
           rm -rf .git
           echo ${{ secrets.tflm-bot-token }} | docker login ghcr.io -u tflm-bot --password-stdin
-          docker run --env XTENSA_TOOLS_VERSION=RI-2020.4-linux --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa_xplorer_13:0.2 \
+          docker run --env XTENSA_TOOLS_VERSION=RI-2020.4-linux --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa_xplorer_13:0.3 \
           /bin/bash -c \
           "cd /opt && tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_vision_p6.sh RUN_NO_TESTS tflite-micro/"
 
@@ -62,6 +62,6 @@ jobs:
       - run: |
           rm -rf .git
           echo ${{ secrets.tflm-bot-token }} | docker login ghcr.io -u tflm-bot --password-stdin
-          docker run --env XTENSA_TOOLS_VERSION=RI-2020.4-linux --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa_xplorer_13:0.2 \
+          docker run --env XTENSA_TOOLS_VERSION=RI-2020.4-linux --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa_xplorer_13:0.3 \
           /bin/bash -c \
           "cd /opt && tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi3z.sh EXTERNAL tflite-micro/"

--- a/ci/Dockerfile.xtensa_xplorer_13
+++ b/ci/Dockerfile.xtensa_xplorer_13
@@ -14,7 +14,6 @@ RUN \
 WORKDIR /opt/xtensa
 
 COPY ./Xplorer-8.0.13-linux-x64-installer.bin .
-COPY ./XtensaTools_RI_2022_9_linux.tgz .
 COPY ./F1_190305_swupgrade_linux.tgz .
 COPY ./P6_200528_linux.tgz .
 COPY ./HIFI_190304_swupgrade_linux.tgz .
@@ -41,7 +40,6 @@ RUN ./install_bazelisk.sh
 
 RUN \
   rm Xplorer-8.0.13-linux-x64-installer.bin && \
-  rm XtensaTools_RI_2022_9_linux.tgz && \
   rm F1_190305_swupgrade_linux.tgz && \
   rm P6_200528_linux.tgz && \
   rm HIFI_190304_swupgrade_linux.tgz && \

--- a/ci/install_cores_xplorer_13.sh
+++ b/ci/install_cores_xplorer_13.sh
@@ -2,10 +2,6 @@
 
 mkdir /opt/xtensa/licenses
 
-mkdir -p /opt/xtensa/XtDevTools/install/tools/
-tar xvzf XtensaTools_RI_2022_9_linux.tgz --dir /opt/xtensa/XtDevTools/install/tools/
-
-
 ##############
 #  Fusion F1
 ##############


### PR DESCRIPTION
Currently, only the RI-2020.4 xtensa tools are used for building F1, HiFi3z and VP6 cores. The docker image contained an additional xtensa tools installation that was not needed. This PR removes that installation to free up space in the image.

BUG=b/304795957