### PR TITLE
PyPI whl build and upload to PyPI test server nightly job

### DIFF
--- a/.github/workflows/pypi_build.yml
+++ b/.github/workflows/pypi_build.yml
@@ -43,7 +43,7 @@ jobs:
           ls -l bazel-pypi-out
       - name: upload to pypi
         if: |
-          github.event.inputs.upload-type == 'test-pypi' ||
+          github.event.inputs.upload-type == 'pypi' ||
           github.event_name == 'schedule'
         run: |
           python/tflite_micro/pypi_upload.sh \

--- a/.github/workflows/pypi_build.yml
+++ b/.github/workflows/pypi_build.yml
@@ -26,7 +26,7 @@ env:
   TWINE_PASSWORD: ${{ secrets.PYPI_API_KEY }}
 
 jobs:
-  test-pypi-build:
+  pypi-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pypi_build.yml
+++ b/.github/workflows/pypi_build.yml
@@ -1,0 +1,56 @@
+# YAML schema for GitHub Actions:
+# https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
+#
+# Helpful YAML parser to clarify YAML syntax:
+# https://yaml-online-parser.appspot.com/
+#
+
+name: PyPI Build
+
+on:
+  schedule:
+    # 1pm UTC is 6am or 7am PT depending on daylight savings.
+    - cron: '0 13 * * *'
+
+  workflow_dispatch:
+    inputs:
+      upload-type:
+        description: 'Upload type'
+        required: true
+        default: 'test-pypi'
+        type: choice
+        options:
+          - 'test-pypi'
+          - 'release'
+          - 'no upload'
+env:
+  TWINE_PASSWORD: ${{ secrets.PYPI_API_KEY }}
+
+jobs:
+  test-pypi-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.TFLM_BOT_REPO_TOKEN }}
+      - name: Build Wheel 3.10
+        run: |
+          python/tflite_micro/pypi_build.sh cp310
+      - name: Build Wheel 3.11
+        run: |
+          python/tflite_micro/pypi_build.sh cp311
+      - name: Check Directory Output
+        run: |
+          ls -l bazel-pypi-out
+      - name: upload to test pypi
+        if: |
+          github.event.inputs.upload-type == 'test-pypi' ||
+          github.event_name == 'schedule'
+        run: |
+          python/tflite_micro/pypi_upload.sh \
+          --test-pypi bazel-pypi-out/tflite_micro-*.whl
+      - name: upload to pypi release
+        if: github.event.inputs.upload-type == 'release'
+        run: |
+          python/tflite_micro/pypi_upload.sh \ 
+          bazel-pypi-out/tflite_micro-*.whl 

--- a/.github/workflows/pypi_build.yml
+++ b/.github/workflows/pypi_build.yml
@@ -21,7 +21,6 @@ on:
         type: choice
         options:
           - 'test-pypi'
-          - 'release'
           - 'no upload'
 env:
   TWINE_PASSWORD: ${{ secrets.PYPI_API_KEY }}
@@ -49,8 +48,3 @@ jobs:
         run: |
           python/tflite_micro/pypi_upload.sh \
           --test-pypi bazel-pypi-out/tflite_micro-*.whl
-      - name: upload to pypi release
-        if: github.event.inputs.upload-type == 'release'
-        run: |
-          python/tflite_micro/pypi_upload.sh \ 
-          bazel-pypi-out/tflite_micro-*.whl 

--- a/.github/workflows/pypi_build.yml
+++ b/.github/workflows/pypi_build.yml
@@ -17,10 +17,10 @@ on:
       upload-type:
         description: 'Upload type'
         required: true
-        default: 'test-pypi'
+        default: 'pypi'
         type: choice
         options:
-          - 'test-pypi'
+          - 'pypi'
           - 'no upload'
 env:
   TWINE_PASSWORD: ${{ secrets.PYPI_API_KEY }}
@@ -41,10 +41,10 @@ jobs:
       - name: Check Directory Output
         run: |
           ls -l bazel-pypi-out
-      - name: upload to test pypi
+      - name: upload to pypi
         if: |
           github.event.inputs.upload-type == 'test-pypi' ||
           github.event_name == 'schedule'
         run: |
           python/tflite_micro/pypi_upload.sh \
-          --test-pypi bazel-pypi-out/tflite_micro-*.whl
+          bazel-pypi-out/tflite_micro-*.whl


### PR DESCRIPTION
This script builds the python 3.10 and 3.11 wheels using python/tflite_micro/pypi_build.sh and then uploads to the test PyPI server with python/tflite_micro/pypi_upload.sh. It is scheduled to run at 1300 UTC each day (0600 or 0700 PST). The runs require approximately 11 minutes.

This job can also be run manually by going to Actions > PyPI Build. There is an option to run only the whl build without upload for troubleshooting.

It also should be relatively obvious how to add a release build option if the live server key was added to repo secrets and the script env block and another optional run block added with the -p <live server key> switch added to a copy of the upload script line.

I have tested the build block, but can't test the upload section since I don't have access to the PYPI_API_KEY secret. 

BUG=request from rj