### PR TITLE
adding twine to pypi upload script

### DIFF
--- a/.github/workflows/pypi_build.yml
+++ b/.github/workflows/pypi_build.yml
@@ -41,6 +41,10 @@ jobs:
       - name: Check Directory Output
         run: |
           ls -l bazel-pypi-out
+      - name: Install Twine
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install twine
       - name: upload to pypi
         if: |
           github.event.inputs.upload-type == 'pypi' ||


### PR DESCRIPTION
This adds the twine module to .github/workflows/pypi_build.yml

BUG=request from RJ