### PR TITLE
Fix zero-point calculation rounding error

### DIFF
--- a/tensorflow/lite/micro/test_helpers.h
+++ b/tensorflow/lite/micro/test_helpers.h
@@ -1,4 +1,4 @@
-/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ limitations under the License.
 #define TENSORFLOW_LITE_MICRO_TEST_HELPERS_H_
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <limits>
 #include <type_traits>
@@ -325,7 +326,7 @@ inline float SymmetricScaleFromMinMax(const float min, const float max) {
 template <typename T>
 inline int ZeroPointFromMinMax(const float min, const float max) {
   return static_cast<int>(std::numeric_limits<T>::min()) +
-         static_cast<int>(-min / ScaleFromMinMax<T>(min, max) + 0.5f);
+         static_cast<int>(roundf(-min / ScaleFromMinMax<T>(min, max)));
 }
 
 }  // namespace testing


### PR DESCRIPTION
@tensorflow/micro 

Use roundf to correctly round negative values.

bug=fixes #2327