### PR TITLE
Use branch_protection_injection_mode for mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,7 +1,7 @@
 queue_rules:
   - name: default
     checks_timeout: 2 h
-    require_branch_protection: true
+    branch_protection_injection_mode: queue
     conditions:
       - base=main
       - label=ci:ready_to_merge


### PR DESCRIPTION
The option require_branch_protection in queue_rules is also deprecated. This PR replaces it with the queue_rules option
branch_protection_injection_mode.

BUG=cleanup