### PR TITLE
Add MicroSnPrintf

### DIFF
--- a/tensorflow/lite/micro/BUILD
+++ b/tensorflow/lite/micro/BUILD
@@ -420,6 +420,7 @@ cc_test(
     deps = [
         ":micro_log",
         ":system_setup",
+        "//tensorflow/lite/micro/testing:micro_test",
     ],
 )
 

--- a/tensorflow/lite/micro/arc_emsdp/debug_log.cc
+++ b/tensorflow/lite/micro/arc_emsdp/debug_log.cc
@@ -126,7 +126,7 @@ extern "C" void DebugLog(const char* format, va_list args) {
 
 #ifndef TF_LITE_STRIP_ERROR_STRINGS
 // Only called from MicroVsnprintf (micro_log.h)
-extern "C" int DebugLogVsnprintf(char* buffer, size_t buf_size,
+extern "C" int DebugVsnprintf(char* buffer, size_t buf_size,
                                  const char* format, va_list vlist) {
   return vsnprintf_(buffer, buf_size, format, vlist);
 }

--- a/tensorflow/lite/micro/arc_emsdp/debug_log.cc
+++ b/tensorflow/lite/micro/arc_emsdp/debug_log.cc
@@ -126,8 +126,8 @@ extern "C" void DebugLog(const char* format, va_list args) {
 
 #ifndef TF_LITE_STRIP_ERROR_STRINGS
 // Only called from MicroVsnprintf (micro_log.h)
-extern "C" int DebugVsnprintf(char* buffer, size_t buf_size,
-                                 const char* format, va_list vlist) {
+extern "C" int DebugVsnprintf(char* buffer, size_t buf_size, const char* format,
+                              va_list vlist) {
   return vsnprintf_(buffer, buf_size, format, vlist);
 }
 #endif

--- a/tensorflow/lite/micro/arc_emsdp/debug_log.cc
+++ b/tensorflow/lite/micro/arc_emsdp/debug_log.cc
@@ -123,3 +123,11 @@ extern "C" void DebugLog(const char* format, va_list args) {
   LogDebugString(log_buffer);
 #endif
 }
+
+#ifndef TF_LITE_STRIP_ERROR_STRINGS
+// Only called from MicroVsnprintf (micro_log.h)
+extern "C" int DebugLogVsnprintf(char* buffer, size_t buf_size,
+                                 const char* format, va_list vlist) {
+  return vsnprintf_(buffer, buf_size, format, vlist);
+}
+#endif

--- a/tensorflow/lite/micro/bluepill/debug_log.cc
+++ b/tensorflow/lite/micro/bluepill/debug_log.cc
@@ -48,7 +48,7 @@ extern "C" void DebugLog(const char* format, va_list args) {
 
 #ifndef TF_LITE_STRIP_ERROR_STRINGS
 // Only called from MicroVsnprintf (micro_log.h)
-extern "C" int DebugLogVsnprintf(char* buffer, size_t buf_size,
+extern "C" int DebugVsnprintf(char* buffer, size_t buf_size,
                                  const char* format, va_list vlist) {
   return vsnprintf_(buffer, buf_size, format, vlist);
 }

--- a/tensorflow/lite/micro/bluepill/debug_log.cc
+++ b/tensorflow/lite/micro/bluepill/debug_log.cc
@@ -45,3 +45,11 @@ extern "C" void DebugLog(const char* format, va_list args) {
   SysWriteDebugConsole(log_buffer);
 #endif  // TF_LITE_STRIP_ERROR_STRINGS
 }
+
+#ifndef TF_LITE_STRIP_ERROR_STRINGS
+// Only called from MicroVsnprintf (micro_log.h)
+extern "C" int DebugLogVsnprintf(char* buffer, size_t buf_size,
+                                 const char* format, va_list vlist) {
+  return vsnprintf_(buffer, buf_size, format, vlist);
+}
+#endif

--- a/tensorflow/lite/micro/bluepill/debug_log.cc
+++ b/tensorflow/lite/micro/bluepill/debug_log.cc
@@ -48,8 +48,8 @@ extern "C" void DebugLog(const char* format, va_list args) {
 
 #ifndef TF_LITE_STRIP_ERROR_STRINGS
 // Only called from MicroVsnprintf (micro_log.h)
-extern "C" int DebugVsnprintf(char* buffer, size_t buf_size,
-                                 const char* format, va_list vlist) {
+extern "C" int DebugVsnprintf(char* buffer, size_t buf_size, const char* format,
+                              va_list vlist) {
   return vsnprintf_(buffer, buf_size, format, vlist);
 }
 #endif

--- a/tensorflow/lite/micro/chre/debug_log.cc
+++ b/tensorflow/lite/micro/chre/debug_log.cc
@@ -33,8 +33,8 @@ extern "C" void DebugLog(const char* format, va_list args) {
 
 #ifndef TF_LITE_STRIP_ERROR_STRINGS
 // Only called from MicroVsnprintf (micro_log.h)
-extern "C" int DebugVsnprintf(char* buffer, size_t buf_size,
-                                 const char* format, va_list vlist) {
+extern "C" int DebugVsnprintf(char* buffer, size_t buf_size, const char* format,
+                              va_list vlist) {
   return vsnprintf_(buffer, buf_size, format, vlist);
 }
 #endif

--- a/tensorflow/lite/micro/chre/debug_log.cc
+++ b/tensorflow/lite/micro/chre/debug_log.cc
@@ -30,3 +30,11 @@ extern "C" void DebugLog(const char* format, va_list args) {
   chreLog(CHRE_LOG_DEBUG, "[TFL_MICRO] %s", log_buffer);
 #endif
 }
+
+#ifndef TF_LITE_STRIP_ERROR_STRINGS
+// Only called from MicroVsnprintf (micro_log.h)
+extern "C" int DebugLogVsnprintf(char* buffer, size_t buf_size,
+                                 const char* format, va_list vlist) {
+  return vsnprintf_(buffer, buf_size, format, vlist);
+}
+#endif

--- a/tensorflow/lite/micro/chre/debug_log.cc
+++ b/tensorflow/lite/micro/chre/debug_log.cc
@@ -33,7 +33,7 @@ extern "C" void DebugLog(const char* format, va_list args) {
 
 #ifndef TF_LITE_STRIP_ERROR_STRINGS
 // Only called from MicroVsnprintf (micro_log.h)
-extern "C" int DebugLogVsnprintf(char* buffer, size_t buf_size,
+extern "C" int DebugVsnprintf(char* buffer, size_t buf_size,
                                  const char* format, va_list vlist) {
   return vsnprintf_(buffer, buf_size, format, vlist);
 }

--- a/tensorflow/lite/micro/cortex_m_generic/debug_log.cc
+++ b/tensorflow/lite/micro/cortex_m_generic/debug_log.cc
@@ -54,6 +54,14 @@ void DebugLog(const char* format, va_list args) {
 #endif
 }
 
+#ifndef TF_LITE_STRIP_ERROR_STRINGS
+// Only called from MicroVsnprintf (micro_log.h)
+int DebugLogVsnprintf(char* buffer, size_t buf_size, const char* format,
+                      va_list vlist) {
+  return vsnprintf(buffer, buf_size, format, vlist);
+}
+#endif
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/tensorflow/lite/micro/cortex_m_generic/debug_log.cc
+++ b/tensorflow/lite/micro/cortex_m_generic/debug_log.cc
@@ -56,7 +56,7 @@ void DebugLog(const char* format, va_list args) {
 
 #ifndef TF_LITE_STRIP_ERROR_STRINGS
 // Only called from MicroVsnprintf (micro_log.h)
-int DebugLogVsnprintf(char* buffer, size_t buf_size, const char* format,
+int DebugVsnprintf(char* buffer, size_t buf_size, const char* format,
                       va_list vlist) {
   return vsnprintf(buffer, buf_size, format, vlist);
 }

--- a/tensorflow/lite/micro/cortex_m_generic/debug_log.cc
+++ b/tensorflow/lite/micro/cortex_m_generic/debug_log.cc
@@ -57,7 +57,7 @@ void DebugLog(const char* format, va_list args) {
 #ifndef TF_LITE_STRIP_ERROR_STRINGS
 // Only called from MicroVsnprintf (micro_log.h)
 int DebugVsnprintf(char* buffer, size_t buf_size, const char* format,
-                      va_list vlist) {
+                   va_list vlist) {
   return vsnprintf(buffer, buf_size, format, vlist);
 }
 #endif

--- a/tensorflow/lite/micro/debug_log.cc
+++ b/tensorflow/lite/micro/debug_log.cc
@@ -44,3 +44,11 @@ extern "C" void DebugLog(const char* format, va_list args) {
   vfprintf(stderr, format, args);
 #endif
 }
+
+#ifndef TF_LITE_STRIP_ERROR_STRINGS
+// Only called from MicroVsnprintf (micro_log.h)
+extern "C" int DebugLogVsnprintf(char* buffer, size_t buf_size,
+                                 const char* format, va_list vlist) {
+  return vsnprintf(buffer, buf_size, format, vlist);
+}
+#endif

--- a/tensorflow/lite/micro/debug_log.cc
+++ b/tensorflow/lite/micro/debug_log.cc
@@ -47,8 +47,8 @@ extern "C" void DebugLog(const char* format, va_list args) {
 
 #ifndef TF_LITE_STRIP_ERROR_STRINGS
 // Only called from MicroVsnprintf (micro_log.h)
-extern "C" int DebugLogVsnprintf(char* buffer, size_t buf_size,
-                                 const char* format, va_list vlist) {
+extern "C" int DebugVsnprintf(char* buffer, size_t buf_size, const char* format,
+                              va_list vlist) {
   return vsnprintf(buffer, buf_size, format, vlist);
 }
 #endif

--- a/tensorflow/lite/micro/debug_log.h
+++ b/tensorflow/lite/micro/debug_log.h
@@ -32,8 +32,8 @@ extern "C" {
 // the tensorflow/lite/micro/debug_log.cc file.  These functions should support
 // standard C/C++ stdio style formatting operations.
 void DebugLog(const char* format, va_list args);
-int DebugLogVsnprintf(char* buffer, size_t buf_size, const char* format,
-                      va_list vlist);
+int DebugVsnprintf(char* buffer, size_t buf_size, const char* format,
+                   va_list vlist);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tensorflow/lite/micro/debug_log.h
+++ b/tensorflow/lite/micro/debug_log.h
@@ -17,19 +17,23 @@ limitations under the License.
 
 #ifdef __cplusplus
 #include <cstdarg>
+#include <cstddef>
 #else
 #include <stdarg.h>
+#include <stddef.h>
 #endif  // __cplusplus
 
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
 
-// This function should be implemented by each target platform, and provide a
+// These functions should be implemented by each target platform, and provide a
 // way for strings to be output to some text stream. For more information, see
-// the tensorflow/lite/micro/debug_log.cc file.  This function should support
+// the tensorflow/lite/micro/debug_log.cc file.  These functions should support
 // standard C/C++ stdio style formatting operations.
 void DebugLog(const char* format, va_list args);
+int DebugLogVsnprintf(char* buffer, size_t buf_size, const char* format,
+                      va_list vlist);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tensorflow/lite/micro/micro_log.cc
+++ b/tensorflow/lite/micro/micro_log.cc
@@ -47,16 +47,16 @@ void MicroPrintf(const char* format, ...) {
   va_end(args);
 }
 
-int MicroSnPrintf(char* buffer, size_t buf_size, const char* format, ...) {
+int MicroSnprintf(char* buffer, size_t buf_size, const char* format, ...) {
   va_list args;
   va_start(args, format);
-  int result = VMicroSnPrintf(buffer, buf_size, format, args);
+  int result = MicroVsnprintf(buffer, buf_size, format, args);
   va_end(args);
   return result;
 }
 
-int VMicroSnPrintf(char* buffer, size_t buf_size, const char* format,
+int MicroVsnprintf(char* buffer, size_t buf_size, const char* format,
                    va_list vlist) {
-  return DebugLogVsnprintf(buffer, buf_size, format, vlist);
+  return DebugVsnprintf(buffer, buf_size, format, vlist);
 }
 #endif  // !defined(TF_LITE_STRIP_ERROR_STRINGS)

--- a/tensorflow/lite/micro/micro_log.cc
+++ b/tensorflow/lite/micro/micro_log.cc
@@ -46,4 +46,17 @@ void MicroPrintf(const char* format, ...) {
   VMicroPrintf(format, args);
   va_end(args);
 }
+
+int MicroSnPrintf(char* buffer, size_t buf_size, const char* format, ...) {
+  va_list args;
+  va_start(args, format);
+  int result = VMicroSnPrintf(buffer, buf_size, format, args);
+  va_end(args);
+  return result;
+}
+
+int VMicroSnPrintf(char* buffer, size_t buf_size, const char* format,
+                   va_list vlist) {
+  return DebugLogVsnprintf(buffer, buf_size, format, vlist);
+}
 #endif  // !defined(TF_LITE_STRIP_ERROR_STRINGS)

--- a/tensorflow/lite/micro/micro_log.h
+++ b/tensorflow/lite/micro/micro_log.h
@@ -17,15 +17,21 @@ limitations under the License.
 
 #if !defined(TF_LITE_STRIP_ERROR_STRINGS)
 #include <cstdarg>
+#include <cstddef>
 // These functions can be used independent of the MicroErrorReporter to get
 // printf-like functionalitys and are common to all target platforms.
 void MicroPrintf(const char* format, ...);
 void VMicroPrintf(const char* format, va_list args);
+int MicroSnPrintf(char* buffer, size_t buf_size, const char* format, ...);
+int VMicroSnPrintf(char* buffer, size_t buf_size, const char* format,
+                   va_list vlist);
 #else
 // We use a #define to ensure that the strings are completely stripped, to
 // prevent an unnecessary increase in the binary size.
 #define MicroPrintf(...) tflite::Unused(__VA_ARGS__)
 #define VMicroPrintf(...) tflite::Unused(__VA_ARGS__)
+#define MicroSnPrintf(...) tflite::Unused(__VA_ARGS__)
+#define VMicroSnPrintf(...) tflite::Unused(__VA_ARGS__)
 #endif
 
 namespace tflite {

--- a/tensorflow/lite/micro/micro_log.h
+++ b/tensorflow/lite/micro/micro_log.h
@@ -22,16 +22,16 @@ limitations under the License.
 // printf-like functionalitys and are common to all target platforms.
 void MicroPrintf(const char* format, ...);
 void VMicroPrintf(const char* format, va_list args);
-int MicroSnPrintf(char* buffer, size_t buf_size, const char* format, ...);
-int VMicroSnPrintf(char* buffer, size_t buf_size, const char* format,
+int MicroSnprintf(char* buffer, size_t buf_size, const char* format, ...);
+int MicroVsnprintf(char* buffer, size_t buf_size, const char* format,
                    va_list vlist);
 #else
 // We use a #define to ensure that the strings are completely stripped, to
 // prevent an unnecessary increase in the binary size.
 #define MicroPrintf(...) tflite::Unused(__VA_ARGS__)
 #define VMicroPrintf(...) tflite::Unused(__VA_ARGS__)
-#define MicroSnPrintf(...) tflite::Unused(__VA_ARGS__)
-#define VMicroSnPrintf(...) tflite::Unused(__VA_ARGS__)
+#define MicroSnprintf(...) tflite::Unused<int>(__VA_ARGS__)
+#define MicroVsnprintf(...) tflite::Unused<int>(__VA_ARGS__)
 #endif
 
 namespace tflite {
@@ -41,6 +41,12 @@ namespace tflite {
 template <typename... Args>
 void Unused(Args&&... args) {
   (void)(sizeof...(args));
+}
+
+template <typename T, typename... Args>
+T Unused(Args&&... args) {
+  (void)(sizeof...(args));
+  return static_cast<T>(0);
 }
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/micro_log_test.cc
+++ b/tensorflow/lite/micro/micro_log_test.cc
@@ -21,9 +21,13 @@ limitations under the License.
 #include "tensorflow/lite/micro/testing/micro_test.h"
 
 namespace {
+
+#if !defined(TF_LITE_STRIP_ERROR_STRINGS)
 constexpr int kMaxBufferSize = 128;
 const char* kFormat = "%2d%6.2f%#5x%5s";
 const char* kExpect = "42 42.42 0x42 \"42\"";
+#endif  // !defined(TF_LITE_STRIP_ERROR_STRINGS)
+
 }  // namespace
 
 TF_LITE_MICRO_TESTS_BEGIN

--- a/tensorflow/lite/micro/micro_log_test.cc
+++ b/tensorflow/lite/micro/micro_log_test.cc
@@ -1,4 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,18 +15,38 @@ limitations under the License.
 
 #include "tensorflow/lite/micro/micro_log.h"
 
-#include "tensorflow/lite/micro/system_setup.h"
+#include <cstddef>
+#include <cstring>
 
-namespace tflite {
-inline void InitializeTest() { InitializeTarget(); }
-}  // namespace tflite
+#include "tensorflow/lite/micro/testing/micro_test.h"
 
-int main(int argc, char** argv) {
-  tflite::InitializeTest();
-#ifndef TF_LITE_STRIP_ERROR_STRINGS
-  MicroPrintf("Number: %d", 42);
+namespace {
+constexpr int kMaxBufferSize = 128;
+const char* kFormat = "%2d%6.2f%#5x%5s";
+const char* kExpect = "42 42.42 0x42 \"42\"";
+}  // namespace
+
+TF_LITE_MICRO_TESTS_BEGIN
+
+#if !defined(TF_LITE_STRIP_ERROR_STRINGS)
+
+TF_LITE_MICRO_TEST(MicroPrintfTest) {
+  MicroPrintf("Integer 42: %d", 42);
+  MicroPrintf("Float 42.42: %2.2f", 42.42);
+  MicroPrintf("String \"Hello World!\": %s", "\"Hello World!\"");
   MicroPrintf("Badly-formed format string %");
-  MicroPrintf("Another % badly-formed %% format string");
-  MicroPrintf("~~~%s~~~", "ALL TESTS PASSED");
-#endif  // !defined(TF_LITE_STRIP_ERROR_STRINGS)
+  MicroPrintf("Another %# badly-formed %% format string");
 }
+
+TF_LITE_MICRO_TEST(MicroSnPrintf) {
+  char buffer[kMaxBufferSize];
+  buffer[0] = '\0';
+  size_t result =
+      MicroSnPrintf(buffer, kMaxBufferSize, kFormat, 42, 42.42, 0x42, "\"42\"");
+  TF_LITE_MICRO_EXPECT_EQ(result, strlen(buffer));
+  TF_LITE_MICRO_EXPECT_STRING_EQ(buffer, kExpect);
+}
+
+#endif  // !defined(TF_LITE_STRIP_ERROR_STRINGS)
+
+TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/micro_log_test.cc
+++ b/tensorflow/lite/micro/micro_log_test.cc
@@ -48,7 +48,7 @@ TF_LITE_MICRO_TEST(MicroSnPrintf) {
   size_t result =
       MicroSnPrintf(buffer, kMaxBufferSize, kFormat, 42, 42.42, 0x42, "\"42\"");
   TF_LITE_MICRO_EXPECT_EQ(result, strlen(buffer));
-  TF_LITE_MICRO_EXPECT_STRING_EQ(buffer, kExpect);
+  TF_LITE_MICRO_EXPECT_STRING_EQ(kExpect, buffer);
 }
 
 #endif  // !defined(TF_LITE_STRIP_ERROR_STRINGS)

--- a/tensorflow/lite/micro/micro_log_test.cc
+++ b/tensorflow/lite/micro/micro_log_test.cc
@@ -42,11 +42,11 @@ TF_LITE_MICRO_TEST(MicroPrintfTest) {
   MicroPrintf("Another %# badly-formed %% format string");
 }
 
-TF_LITE_MICRO_TEST(MicroSnPrintf) {
+TF_LITE_MICRO_TEST(MicroSnprintf) {
   char buffer[kMaxBufferSize];
   buffer[0] = '\0';
   size_t result =
-      MicroSnPrintf(buffer, kMaxBufferSize, kFormat, 42, 42.42, 0x42, "\"42\"");
+      MicroSnprintf(buffer, kMaxBufferSize, kFormat, 42, 42.42, 0x42, "\"42\"");
   TF_LITE_MICRO_EXPECT_EQ(result, strlen(buffer));
   TF_LITE_MICRO_EXPECT_STRING_EQ(kExpect, buffer);
 }

--- a/tensorflow/lite/micro/riscv32_generic/debug_log.cc
+++ b/tensorflow/lite/micro/riscv32_generic/debug_log.cc
@@ -33,8 +33,8 @@ extern "C" void DebugLog(const char* format, va_list args) {
 
 #ifndef TF_LITE_STRIP_ERROR_STRINGS
 // Only called from MicroVsnprintf (micro_log.h)
-extern "C" int DebugLogVsnprintf(char* buffer, size_t buf_size,
-                                 const char* format, va_list vlist) {
+extern "C" int DebugVsnprintf(char* buffer, size_t buf_size, const char* format,
+                              va_list vlist) {
   return vsnprintf_(buffer, buf_size, format, vlist);
 }
 #endif

--- a/tensorflow/lite/micro/riscv32_generic/debug_log.cc
+++ b/tensorflow/lite/micro/riscv32_generic/debug_log.cc
@@ -1,0 +1,40 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/micro/debug_log.h"
+
+#include <cstdio>
+
+#ifndef TF_LITE_STRIP_ERROR_STRINGS
+#include "eyalroz_printf/src/printf/printf.h"
+#endif
+
+extern "C" void DebugLog(const char* format, va_list args) {
+#ifndef TF_LITE_STRIP_ERROR_STRINGS
+  constexpr int kMaxLogLen = 256;
+  char log_buffer[kMaxLogLen];
+
+  vsnprintf_(log_buffer, kMaxLogLen, format, args);
+  std::fputs(log_buffer, stdout);
+#endif
+}
+
+#ifndef TF_LITE_STRIP_ERROR_STRINGS
+// Only called from MicroVsnprintf (micro_log.h)
+extern "C" int DebugLogVsnprintf(char* buffer, size_t buf_size,
+                                 const char* format, va_list vlist) {
+  return vsnprintf_(buffer, buf_size, format, vlist);
+}
+#endif

--- a/tensorflow/lite/micro/tools/make/targets/riscv32_generic_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/riscv32_generic_makefile.inc
@@ -47,3 +47,4 @@ TEST_SCRIPT := $(TENSORFLOW_ROOT)tensorflow/lite/micro/testing/test_with_qemu.sh
 SIZE_SCRIPT := ${TENSORFLOW_ROOT}tensorflow/lite/micro/testing/size_riscv32_binary.sh
 RUN_COMMAND := qemu-riscv32 -cpu rv32
 
+include $(MAKEFILE_DIR)/ext_libs/eyalroz_printf.inc


### PR DESCRIPTION
@tensorflow/micro

Preparatory work for [b/297590035](https://issuetracker.google.com/297590035)
Add MicroSnprintf
Add MicroVsnprintf
Update debug_log.cc for all required targets
Add debug_log.cc for riscv32_generic target using third-party eyalroz printf code (riscv32_generic stdio formatting does not support %f) 

bug=fixes #2342
