### PR TITLE
Fix cortex_m_generic C++ linkage errors

### DIFF
--- a/tensorflow/lite/micro/cortex_m_generic/debug_log.cc
+++ b/tensorflow/lite/micro/cortex_m_generic/debug_log.cc
@@ -16,11 +16,11 @@ limitations under the License.
 // Implementation for the DebugLog() function that prints to the debug logger on
 // an generic Cortex-M device.
 
+#include "tensorflow/lite/micro/debug_log.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
-
-#include "tensorflow/lite/micro/debug_log.h"
 
 #include "tensorflow/lite/micro/cortex_m_generic/debug_log_callback.h"
 


### PR DESCRIPTION
Removes debug_log.h include from extern "C"-block to avoid errors when including <cstddef>.

bug=fixes cortex_m_generic build errors