### PR TITLE
Fix Bazel dependencies for targets under signal/

### DIFF
--- a/python/tflite_micro/signal/BUILD
+++ b/python/tflite_micro/signal/BUILD
@@ -54,6 +54,9 @@ py_tflm_signal_library(
     cc_op_kernels = [
         "//signal/tensorflow_core/kernels:delay_kernel",
     ],
+    deps = [
+        "//python/tflite_micro/signal/utils:util",
+    ],
 )
 
 py_test(
@@ -66,7 +69,6 @@ py_test(
         ":delay_op",
         requirement("numpy"),
         requirement("tensorflow-cpu"),
-        "//python/tflite_micro/signal/utils:util",
     ],
 )
 
@@ -76,6 +78,9 @@ py_tflm_signal_library(
     cc_op_defs = ["//signal/tensorflow_core/ops:energy_op"],
     cc_op_kernels = [
         "//signal/tensorflow_core/kernels:energy_kernel",
+    ],
+    deps = [
+        "//python/tflite_micro/signal/utils:util",
     ],
 )
 
@@ -92,7 +97,6 @@ py_test(
         ":energy_op",
         requirement("numpy"),
         requirement("tensorflow-cpu"),
-        "//python/tflite_micro/signal/utils:util",
     ],
 )
 
@@ -102,6 +106,9 @@ py_tflm_signal_library(
     cc_op_defs = ["//signal/tensorflow_core/ops:fft_ops"],
     cc_op_kernels = [
         "//signal/tensorflow_core/kernels:fft_kernel",
+    ],
+    deps = [
+        "//python/tflite_micro/signal/utils:util",
     ],
 )
 
@@ -118,7 +125,6 @@ py_test(
         ":fft_ops",
         requirement("numpy"),
         requirement("tensorflow-cpu"),
-        "//python/tflite_micro/signal/utils:util",
     ],
 )
 
@@ -131,6 +137,7 @@ py_tflm_signal_library(
     ],
     deps = [
         "//python/tflite_micro/signal/utils:freq_to_mel",
+        "//python/tflite_micro/signal/utils:util",
     ],
 )
 
@@ -152,7 +159,6 @@ py_test(
         ":filter_bank_ops",
         requirement("numpy"),
         requirement("tensorflow-cpu"),
-        "//python/tflite_micro/signal/utils:util",
     ],
 )
 
@@ -162,6 +168,9 @@ py_tflm_signal_library(
     cc_op_defs = ["//signal/tensorflow_core/ops:framer_op"],
     cc_op_kernels = [
         "//signal/tensorflow_core/kernels:framer_kernel",
+    ],
+    deps = [
+        "//python/tflite_micro/signal/utils:util",
     ],
 )
 
@@ -178,7 +187,6 @@ py_test(
         ":framer_op",
         requirement("numpy"),
         requirement("tensorflow-cpu"),
-        "//python/tflite_micro/signal/utils:util",
     ],
 )
 
@@ -188,6 +196,9 @@ py_tflm_signal_library(
     cc_op_defs = ["//signal/tensorflow_core/ops:overlap_add_op"],
     cc_op_kernels = [
         "//signal/tensorflow_core/kernels:overlap_add_kernel",
+    ],
+    deps = [
+        "//python/tflite_micro/signal/utils:util",
     ],
 )
 
@@ -202,7 +213,6 @@ py_test(
         "@absl_py//absl/testing:parameterized",
         requirement("numpy"),
         requirement("tensorflow-cpu"),
-        "//python/tflite_micro/signal/utils:util",
     ],
 )
 
@@ -214,6 +224,7 @@ py_tflm_signal_library(
         "//signal/tensorflow_core/kernels:pcan_kernel",
     ],
     deps = [
+        "//python/tflite_micro/signal/utils:util",
         "//python/tflite_micro/signal/utils:wide_dynamic_func_lut",
     ],
 )
@@ -235,7 +246,6 @@ py_test(
         ":pcan_op",
         requirement("numpy"),
         requirement("tensorflow-cpu"),
-        "//python/tflite_micro/signal/utils:util",
     ],
 )
 
@@ -245,6 +255,9 @@ py_tflm_signal_library(
     cc_op_defs = ["//signal/tensorflow_core/ops:stacker_op"],
     cc_op_kernels = [
         "//signal/tensorflow_core/kernels:stacker_kernel",
+    ],
+    deps = [
+        "//python/tflite_micro/signal/utils:util",
     ],
 )
 
@@ -261,7 +274,6 @@ py_test(
         ":stacker_op",
         requirement("numpy"),
         requirement("tensorflow-cpu"),
-        "//python/tflite_micro/signal/utils:util",
     ],
 )
 
@@ -271,6 +283,9 @@ py_tflm_signal_library(
     cc_op_defs = ["//signal/tensorflow_core/ops:window_op"],
     cc_op_kernels = [
         "//signal/tensorflow_core/kernels:window_kernel",
+    ],
+    deps = [
+        "//python/tflite_micro/signal/utils:util",
     ],
 )
 
@@ -286,6 +301,5 @@ py_test(
         ":window_op",
         requirement("numpy"),
         requirement("tensorflow-cpu"),
-        "//python/tflite_micro/signal/utils:util",
     ],
 )

--- a/python/tflite_micro/signal/utils/BUILD
+++ b/python/tflite_micro/signal/utils/BUILD
@@ -41,7 +41,6 @@ py_library(
     deps = [
         requirement("tensorflow-cpu"),
         "//python/tflite_micro:runtime",
-        "//python/tflite_micro/signal:ops",
     ],
 )
 


### PR DESCRIPTION
The targets for building the ops should depend on
"//third_party/tflite_micro/python/tflite_micro/signal/utils:util Instead of just their unit tests.

BUG=315941833