### PR TITLE
Enable subpackage visibility for signal

### DIFF
--- a/python/tflite_micro/signal/BUILD
+++ b/python/tflite_micro/signal/BUILD
@@ -3,7 +3,10 @@ load("//python/tflite_micro/signal:tflm_signal.bzl", "py_tflm_signal_library")
 load("//tensorflow:extra_rules.bzl", "tflm_signal_friends")
 load("@tflm_pip_deps//:requirements.bzl", "requirement")
 
-package(licenses = ["notice"])
+package(
+    default_visibility = [":__subpackages__"],
+    licenses = ["notice"],
+)
 
 package_group(
     name = "signal_friends",


### PR DESCRIPTION
The py_tflm_signal_library macro generates multiple targets, some of which are referenced by an internal subdirectory target. This PR adds a default visibility for the package for all targets to be visibile within the subpackage.

BUG=b/316963245