### PR TITLE
Fix metrics deps

### DIFF
--- a/tensorflow/lite/micro/tools/benchmarking/BUILD
+++ b/tensorflow/lite/micro/tools/benchmarking/BUILD
@@ -10,9 +10,10 @@ cc_library(
     srcs = ["metrics.cc"],
     hdrs = ["metrics.h"],
     deps = [
+        "//tensorflow/lite/kernels/internal:compatibility",
+        "//tensorflow/lite/micro:micro_log",
         "//tensorflow/lite/micro:micro_profiler",
         "//tensorflow/lite/micro:recording_allocators",
-        "//tensorflow/lite/micro/arena_allocator:recording_simple_memory_allocator",
     ],
 )
 


### PR DESCRIPTION
There are a couple new dependencies in metrics.cc, and this PR updates the corresponding BUILD target to match.

BUG=b/316963245