### PR TITLE
codegen: Add Bazel macro for inference library

### DIFF
--- a/codegen/examples/hello_world/BUILD
+++ b/codegen/examples/hello_world/BUILD
@@ -1,0 +1,14 @@
+load("//codegen:build_def.bzl", "tflm_inference_library")
+
+package(default_visibility = ["//visibility:public"])
+
+tflm_inference_library(
+    name = "hello_world_model",
+    tflite_model = "//tensorflow/lite/micro/examples/hello_world/models:hello_world_int8.tflite",
+)
+
+cc_binary(
+    name = "hello_world",
+    srcs = ["hello_world.cc"],
+    deps = [":hello_world_model"],
+)

--- a/codegen/examples/hello_world/README.md
+++ b/codegen/examples/hello_world/README.md
@@ -7,7 +7,7 @@ is checked in for now so that it can be reviewed during the prototyping stage.
 Please note that this will execute Bazel from make as part of the process.
 
 ```
-make -f tensorflow/lite/micro/tools/make/Makefile codegen_hello_world
+bazel build //codegen/examples/hello_world:hello_world
 ```
 
 ## Running the example
@@ -16,7 +16,7 @@ TODO(rjascani): The command works, but it'll just crash as we don't have all of
 the data structures fully populated yet.
 
 ```
-make -f tensorflow/lite/micro/tools/make/Makefile run_codegen_hello_world
+bazel run //codegen/examples/hello_world:hello_world
 ```
 
 ## Updating the generated sources

--- a/codegen/examples/hello_world/hello_world.cc
+++ b/codegen/examples/hello_world/hello_world.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "hello_world_model.h"
+#include "codegen/examples/hello_world/hello_world_model.h"
 #include "tensorflow/lite/c/c_api_types.h"
 
 int main(int argc, char** argv) {

--- a/codegen/examples/hello_world/update_example_source.sh
+++ b/codegen/examples/hello_world/update_example_source.sh
@@ -24,6 +24,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR=${SCRIPT_DIR}/../../..
 cd "${ROOT_DIR}"
 
-make -j8 -f tensorflow/lite/micro/tools/make/Makefile codegen_hello_world
-cp ./gen/linux_x86_64_default/genfiles/hello_world_model.h ${SCRIPT_DIR}
-cp ./gen/linux_x86_64_default/genfiles/hello_world_model.cc ${SCRIPT_DIR}
+bazel build //codegen/examples/hello_world:hello_world_model
+cp ./bazel-bin/codegen/examples/hello_world/hello_world_model.h ${SCRIPT_DIR}
+cp ./bazel-bin/codegen/examples/hello_world/hello_world_model.cc ${SCRIPT_DIR}
+clang-format --style=google -i \
+  ${SCRIPT_DIR}/hello_world_model.h \
+  ${SCRIPT_DIR}/hello_world_model.cc

--- a/codegen/runtime/BUILD
+++ b/codegen/runtime/BUILD
@@ -1,0 +1,18 @@
+load("//tensorflow/lite/micro:build_def.bzl", "micro_copts")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "micro_codegen_context",
+    srcs = ["micro_codegen_context.cc"],
+    hdrs = ["micro_codegen_context.h"],
+    copts = micro_copts(),
+    deps = [
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/kernels:op_macros",
+        "//tensorflow/lite/kernels/internal:compatibility",
+        "//tensorflow/lite/micro:micro_context",
+        "//tensorflow/lite/micro:micro_graph",
+        "//tensorflow/lite/micro:micro_log",
+    ],
+)

--- a/tensorflow/lite/micro/examples/hello_world/models/BUILD
+++ b/tensorflow/lite/micro/examples/hello_world/models/BUILD
@@ -9,7 +9,10 @@ exports_files(
         "hello_world_float.tflite",
         "hello_world_int8.tflite",
     ],
-    visibility = ["//tensorflow/lite/micro/examples/hello_world:__subpackages__"],
+    visibility = [
+        "//codegen/examples/hello_world:__subpackages__",
+        "//tensorflow/lite/micro/examples/hello_world:__subpackages__",
+    ],
 )
 
 generate_cc_arrays(


### PR DESCRIPTION
The TFLM code_generator takes a TFLite model and generates C/C++ source code that can then be compiled into a binary. This change adds a Bazel macro for invoking the code generator and creating a cc_library with the resulting sources. It also updates the checked-in hello_world example with an appropriate BUILD file and updates the script to use Bazel instead of make.

BUG=b/294230402