### PR TITLE
build(bazel): add missing dep on python package `pillow`

### DIFF
--- a/tensorflow/lite/micro/examples/mnist_lstm/BUILD
+++ b/tensorflow/lite/micro/examples/mnist_lstm/BUILD
@@ -18,6 +18,7 @@ py_binary(
     deps = [
         "//python/tflite_micro:runtime",
         "@absl_py//absl:app",
+        requirement("pillow"),
     ],
 )
 


### PR DESCRIPTION
Add an undeclared dependency on the Python package `pillow` to the example
mnist_lstm. The missing dependency causes run and test failures on a system
where pillow isn't installed system-wide.

BUG=see description