### PR TITLE
removing usage of `tflm_runtime` and replacing usage with new runtime target target in g3 TFLM repo

### DIFF
--- a/tensorflow/lite/micro/examples/recipes/BUILD
+++ b/tensorflow/lite/micro/examples/recipes/BUILD
@@ -38,8 +38,6 @@ py_test(
     ],
     deps = [
         ":resource_variables_lib",
-        # TODO(b/286456378): update tflm_runtime to runtime when we are ready to
-        # remove the alias.
-        "//tensorflow/lite/micro/python/interpreter/src:tflm_runtime",
+        "//python/tflite_micro:runtime",
     ],
 )

--- a/tensorflow/lite/micro/examples/recipes/resource_variables_test.py
+++ b/tensorflow/lite/micro/examples/recipes/resource_variables_test.py
@@ -18,9 +18,7 @@ from tensorflow.python.framework import test_util
 from tensorflow.python.platform import test
 from tflite_micro.tensorflow.lite.micro.examples.recipes import resource_variables_lib
 
-# TODO(b/286456378): change tflm_runtime to runtime when we all other usage has
-# been updated.
-from tflite_micro.tensorflow.lite.micro.python.interpreter.src import tflm_runtime
+from tflite_micro.python.tflite_micro import runtime as tflm_runtime
 
 
 class ResourceVariablesTest(test_util.TensorFlowTestCase):

--- a/tensorflow/lite/micro/python/interpreter/src/BUILD
+++ b/tensorflow/lite/micro/python/interpreter/src/BUILD
@@ -18,24 +18,6 @@ package_group(
     packages = tflm_python_op_resolver_friends(),
 )
 
-# tflm_runtime is deprecated, please use //python/tflite_micro:runtime instead.
-# TODO(b/286456378): remove once all usage is changed to the runtime target.
-py_library(
-    name = "tflm_runtime",
-    srcs = ["tflm_runtime.py"],
-    visibility = ["//visibility:public"],
-    deps = ["//python/tflite_micro:runtime"],
-)
-
-# runtime is deprecated, please use //python/tflite_micro:runtime instead.
-# TODO(b/286456378): remove once all usage is changed to the runtime target.
-py_library(
-    name = "runtime",
-    srcs = ["runtime.py"],
-    visibility = ["//visibility:public"],
-    deps = ["//python/tflite_micro:runtime"],
-)
-
 # TODO(b/286456378): remove once all internal usage is fixed.
 cc_library(
     name = "python_ops_resolver",

--- a/tensorflow/lite/micro/tools/BUILD
+++ b/tensorflow/lite/micro/tools/BUILD
@@ -136,7 +136,7 @@ py_library(
         "@absl_py//absl/logging",
         requirement("numpy"),
         requirement("tensorflow-cpu"),
-        "//tensorflow/lite/micro/python/interpreter/src:runtime",
+        "//python/tflite_micro:runtime",
         "//tensorflow/lite/tools:flatbuffer_utils",
     ],
 )
@@ -208,7 +208,7 @@ py_binary(
         "@absl_py//absl:app",
         "@absl_py//absl/flags",
         requirement("tensorflow-cpu"),
-        "//tensorflow/lite/micro/python/interpreter/src:runtime",
+        "//python/tflite_micro:runtime",
         "//tensorflow/lite/tools:flatbuffer_utils",
     ],
 )

--- a/tensorflow/lite/micro/tools/layer_by_layer_debugger.py
+++ b/tensorflow/lite/micro/tools/layer_by_layer_debugger.py
@@ -25,7 +25,7 @@ import tensorflow as tf
 
 from tflite_micro.tensorflow.lite.tools import flatbuffer_utils
 from tensorflow.python.platform import gfile
-from tflite_micro.tensorflow.lite.micro.python.interpreter.src import runtime
+from tflite_micro.python.tflite_micro import runtime
 from tflite_micro.tensorflow.lite.micro.tools import layer_by_layer_schema_py_generated as layer_schema_fb
 from tflite_micro.tensorflow.lite.micro.tools import model_transforms_utils
 

--- a/tensorflow/lite/micro/tools/tflm_model_transforms_lib.py
+++ b/tensorflow/lite/micro/tools/tflm_model_transforms_lib.py
@@ -29,7 +29,7 @@ from tensorflow.python.platform import gfile
 
 from tflite_micro.tensorflow.lite.tools import flatbuffer_utils
 from tflite_micro.tensorflow.lite.micro.tools import model_transforms_utils
-from tflite_micro.tensorflow.lite.micro.python.interpreter.src import runtime
+from tflite_micro.python.tflite_micro import runtime
 
 
 def _save_and_align_flatbuffer(model, model_path):


### PR DESCRIPTION
removing usage of `tflm_runtime` and replacing usage with new runtime target target in g3 TFLM repo

[g3 cl](https://critique.corp.google.com/cl/595884672)

BUG=[b/286456378](https://b.corp.google.com/issues/286456378)