### PR TITLE
Update Ethos-U download links

### DIFF
--- a/tensorflow/lite/micro/tools/make/download_and_extract.sh
+++ b/tensorflow/lite/micro/tools/make/download_and_extract.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2024 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -123,9 +123,9 @@ download_and_extract() {
     sleep 2
   done
 
-  # Check that the file was downloaded correctly using a checksum.
+  # Check that the file was downloaded correctly using a checksum. Put expected_md5 as "SKIP_MD5_CHECK" to skip this check.
   DOWNLOADED_MD5=$(openssl dgst -md5 ${tempfile} | sed 's/.* //g')
-  if [ ${expected_md5} != ${DOWNLOADED_MD5} ]; then
+  if [ ${expected_md5} != ${DOWNLOADED_MD5} ] && [ ${expected_md5} != "SKIP_MD5_CHECK" ]; then
     echo "Checksum error for '${url}'. Expected ${expected_md5} but found ${DOWNLOADED_MD5}"
     exit 1
   fi
@@ -134,28 +134,30 @@ download_and_extract() {
   url=$(echo "${url}" | sed "s/\?.*//")
 
   if [[ "${url}" == *gz ]]; then
-    tar -C "${dir}" --strip-components=1 -xzf ${tempfile}
+    tar -C "${tempdir2}" -xzf ${tempfile}
   elif [[ "${url}" == *tar.xz ]]; then
-    tar -C "${dir}" --strip-components=1 -xf ${tempfile}
+    tar -C "${tempdir2}" -xf ${tempfile}
   elif [[ "${url}" == *bz2 ]]; then
     curl -Ls "${url}" > ${tempdir}/tarred.bz2
-    tar -C "${dir}" --strip-components=1 -xjf ${tempfile}
+    tar -C "${tempdir2}" -xjf ${tempfile}
   elif [[ "${url}" == *zip ]]; then
     unzip ${tempfile} -d ${tempdir2} 2>&1 1>/dev/null
-    # If the zip file contains nested directories, extract the files from the
-    # inner directory.
-    if [ $(find $tempdir2/* -maxdepth 0 | wc -l) = 1 ] && [ -d $tempdir2/* ]; then
-      # unzip has no strip components, so unzip to a temp dir, and move the
-      # files we want from the tempdir to destination.
-      cp -R ${tempdir2}/*/* ${dir}/
-    else
-      cp -R ${tempdir2}/* ${dir}/
-    fi
   else
     echo "Error unsupported archive type. Failed to extract tool after download."
     exit 1
   fi
-  rm -rf ${tempdir2} ${tempdir}
+
+  # If the zip file contains nested directories, extract the files from the
+  # inner directory.
+  if [ $(find $tempdir2/* -maxdepth 0 | wc -l) = 1 ] && [ -d $tempdir2/* ]; then
+    # Unzip to a temp dir, and move the files we want from the tempdir to destination.
+    # We want this to be dependent on the folder structure of the zipped file, so --strip-components cannot be used.
+    cp -R ${tempdir2}/*/* ${dir}/
+  else
+    cp -R ${tempdir2}/* ${dir}/
+  fi
+
+  rm -rf ${tempdir} ${tempdir2}
 
   # Delete any potential BUILD files, which would interfere with Bazel builds.
   find "${dir}" -type f -name '*BUILD' -delete

--- a/tensorflow/lite/micro/tools/make/ethos_u_core_platform_download.sh
+++ b/tensorflow/lite/micro/tools/make/ethos_u_core_platform_download.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2024 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ else
     exit 1
   fi
 
-  git clone https://git.mlplatform.org/ml/ethos-u/ethos-u-core-platform.git ${DOWNLOADED_ETHOS_U_CORE_PLATFORM_PATH} >&2
+  git clone "https://review.mlplatform.org/ml/ethos-u/ethos-u-core-platform" ${DOWNLOADED_ETHOS_U_CORE_PLATFORM_PATH} >&2
   pushd ${DOWNLOADED_ETHOS_U_CORE_PLATFORM_PATH} > /dev/null
   git checkout e25a89dec1cf990f3168dbd6c565e3b0d51cb151 >&2
   rm -rf .git

--- a/tensorflow/lite/micro/tools/make/third_party_downloads.inc
+++ b/tensorflow/lite/micro/tools/make/third_party_downloads.inc
@@ -39,5 +39,6 @@ endif
 EMBARC_MLI_PRE_COMPILED_URL := "https://github.com/foss-for-synopsys-dwc-arc-processors/embarc_mli/releases/download/Release_1.1/embARC_MLI_package.zip"
 EMBARC_MLI_PRE_COMPILED_MD5 := "173990c2dde4efef6a2c95b92d1f0244"
 
-ETHOSU_URL := "https://git.mlplatform.org/ml/ethos-u/ethos-u-core-driver.git/snapshot/ethos-u-core-driver-24455eedb9e8939f8a28ca0101a6f2d171e1b2f9.tar.gz"
-ETHOSU_MD5 := "14b5712525d4af612d35217f0bc53fcc"
+# Skip md5sum-check since ethos-u-core-driver download link is non-deterministic, see  https://github.com/google/gitiles/issues/84
+ETHOSU_URL := "https://review.mlplatform.org/plugins/gitiles/ml/ethos-u/ethos-u-core-driver/+archive/24455eedb9e8939f8a28ca0101a6f2d171e1b2f9.tar.gz"
+ETHOSU_MD5 := "SKIP_MD5_CHECK"


### PR DESCRIPTION
- Updates links for ethos-u-core-platform and ethous-u-core-driver
- Updates download_and_extract.sh to handle changes caused by the new links:
   - Adds possibility to skip md5sum-check
   - Removes first folder-level only if the downloaded folder is nested.

BUG=`git.` changed in favor of `review.`
Change-Id: I7597cda2ef45ceb16bd8dbb810e4e9c0b5d63dee