### PR TITLE
Fix layer_by_layer build

### DIFF
--- a/tensorflow/lite/micro/tools/layer_by_layer.cc
+++ b/tensorflow/lite/micro/tools/layer_by_layer.cc
@@ -47,7 +47,7 @@ namespace tflite {
 
 namespace {
 
-using TflmOpResolver = MicroMutableOpResolver<96>;
+using TflmOpResolver = MicroMutableOpResolver<128>;
 
 // Seed used for the random input. Input data shouldn't affect invocation timing
 // so randomness isn't really needed.


### PR DESCRIPTION
The layer_by_layer tool re-uses the OpResolver from the benchmarking utility, so the size of the MicroMutableOpResolver needs to be increased in sync with each other.