### PR TITLE
Exclude xa_nn_activations_asym8_asym8.c from NNLib build for Hifi4

### DIFF
--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -130,7 +130,8 @@ else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi3 hifi4))
   EXCLUDED_NNLIB_SRCS = \
     $(NNLIB_PATH)/algo/layers/cnn/src/xa_nn_cnn_api.c \
     $(NNLIB_PATH)/algo/layers/gru/src/xa_nn_gru_api.c \
-    $(NNLIB_PATH)/algo/layers/lstm/src/xa_nn_lstm_api.c
+    $(NNLIB_PATH)/algo/layers/lstm/src/xa_nn_lstm_api.c \
+    $(NNLIB_PATH)/algo/kernels/activations/hifi4/xa_nn_activations_asym8_asym8.c
 
   ifeq ($(TARGET_ARCH), hifi3)
     EXCLUDED_NNLIB_SRCS += \

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -130,8 +130,7 @@ else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi3 hifi4))
   EXCLUDED_NNLIB_SRCS = \
     $(NNLIB_PATH)/algo/layers/cnn/src/xa_nn_cnn_api.c \
     $(NNLIB_PATH)/algo/layers/gru/src/xa_nn_gru_api.c \
-    $(NNLIB_PATH)/algo/layers/lstm/src/xa_nn_lstm_api.c \
-    $(NNLIB_PATH)/algo/kernels/activations/hifi4/xa_nn_activations_asym8_asym8.c
+    $(NNLIB_PATH)/algo/layers/lstm/src/xa_nn_lstm_api.c
 
   ifeq ($(TARGET_ARCH), hifi3)
     EXCLUDED_NNLIB_SRCS += \
@@ -139,6 +138,11 @@ else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi3 hifi4))
       $(NNLIB_PATH)/algo/ndsp/hifi4/src/scl_tanhf_hifi4.c \
       $(NNLIB_PATH)/algo/ndsp/hifi4/src/vec_tanhf_hifi4.c \
       $(NNLIB_PATH)/algo/ndsp/hifi4/src/tanhf_tbl.c
+  endif
+  
+  ifeq ($(TARGET_ARCH), hifi4)
+    EXCLUDED_NNLIB_SRCS += \
+      $(NNLIB_PATH)/algo/kernels/activations/hifi4/xa_nn_activations_asym8_asym8.c
   endif
 
   THIRD_PARTY_KERNEL_CC_SRCS := $(filter-out $(EXCLUDED_NNLIB_SRCS), $(THIRD_PARTY_KERNEL_CC_SRCS))


### PR DESCRIPTION
Due to an assembler error:
/tmp/xa_nn_activations_asym8_asym8-037a85.s: Assembler messages: /tmp/xa_nn_activations_asym8_asym8-037a85.s:470: Error: operand 3 of 'slli' has invalid value '0' clang-3.9: error: Xtensa-as command failed with exit code 1 (use -v to see invocation)
BUG=319139235