### PR TITLE
Enable tflm_benchmark on HiFi5

### DIFF
--- a/tensorflow/lite/micro/tools/benchmarking/Makefile.inc
+++ b/tensorflow/lite/micro/tools/benchmarking/Makefile.inc
@@ -9,7 +9,7 @@ $(MICROLITE_BENCHMARK_ROOT_DIR)/op_resolver.h \
 $(MICROLITE_BENCHMARK_ROOT_DIR)/metrics.h
 
 ifneq ($(TARGET),bluepill)
-ifneq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi5 hifimini))
+ifneq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifimini))
     $(eval $(call microlite_test,tflm_benchmark,\
     $(GENERIC_BENCHMARK_SRCS),$(GENERIC_BENCHMARK_HDRS),))
 endif


### PR DESCRIPTION
The tflm_benchmark utility runs fine on HiFi5. It is unclear why it was disabled.

BUG=none