### PR TITLE
RISC-V target makefile: make the arch, abi and mcmodel configurable.

### DIFF
--- a/tensorflow/lite/micro/tools/make/targets/riscv32_generic_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/riscv32_generic_makefile.inc
@@ -18,16 +18,16 @@ endif
 export PATH := $(TARGET_TOOLCHAIN_ROOT):$(PATH)
 
 PLATFORM_FLAGS = \
-   -march=$(RISCV_ARCH) \
-   -mabi=$(RISCV_ABI) \
-   -mcmodel=$(RISCV_CODE_MODEL) \
-   -mexplicit-relocs \
-   -fno-builtin-printf \
-   -DTF_LITE_MCU_DEBUG_LOG \
-   -DTF_LITE_USE_GLOBAL_CMATH_FUNCTIONS \
-   -funsigned-char \
-   -fno-delete-null-pointer-checks \
-   -fomit-frame-pointer
+  -march=$(RISCV_ARCH) \
+  -mabi=$(RISCV_ABI) \
+  -mcmodel=$(RISCV_CODE_MODEL) \
+  -mexplicit-relocs \
+  -fno-builtin-printf \
+  -DTF_LITE_MCU_DEBUG_LOG \
+  -DTF_LITE_USE_GLOBAL_CMATH_FUNCTIONS \
+  -funsigned-char \
+  -fno-delete-null-pointer-checks \
+  -fomit-frame-pointer
 
 CXXFLAGS += $(PLATFORM_FLAGS) \
   -fpermissive \

--- a/tensorflow/lite/micro/tools/make/targets/riscv32_generic_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/riscv32_generic_makefile.inc
@@ -2,6 +2,13 @@
 TARGET_ARCH := riscv32
 TARGET_TOOLCHAIN_PREFIX := riscv64-unknown-elf-
 
+RISCV_ARCH := rv32imc
+RISCV_ABI := ilp32
+RISCV_CODE_MODEL := medany
+
+# Allow additional flags on the command line for debugging.
+RISCV_EXTRA_CFLAGS :=
+
 TARGET_DEFAULT_TOOLCHAIN_ROOT := $(DOWNLOADS_DIR)/riscv_toolchain/bin/
 TARGET_TOOLCHAIN_ROOT := $(TARGET_DEFAULT_TOOLCHAIN_ROOT)
 ifeq ($(TARGET_TOOLCHAIN_ROOT), $(TARGET_DEFAULT_TOOLCHAIN_ROOT))
@@ -11,16 +18,16 @@ endif
 export PATH := $(TARGET_TOOLCHAIN_ROOT):$(PATH)
 
 PLATFORM_FLAGS = \
-  -march=rv32imac \
-  -mabi=ilp32 \
-  -mcmodel=medany \
-  -mexplicit-relocs \
-  -fno-builtin-printf \
-  -DTF_LITE_MCU_DEBUG_LOG \
-  -DTF_LITE_USE_GLOBAL_CMATH_FUNCTIONS \
-  -funsigned-char \
-  -fno-delete-null-pointer-checks \
-  -fomit-frame-pointer
+   -march=$(RISCV_ARCH) \
+   -mabi=$(RISCV_ABI) \
+   -mcmodel=$(RISCV_CODE_MODEL) \
+   -mexplicit-relocs \
+   -fno-builtin-printf \
+   -DTF_LITE_MCU_DEBUG_LOG \
+   -DTF_LITE_USE_GLOBAL_CMATH_FUNCTIONS \
+   -funsigned-char \
+   -fno-delete-null-pointer-checks \
+   -fomit-frame-pointer
 
 CXXFLAGS += $(PLATFORM_FLAGS) \
   -fpermissive \
@@ -39,6 +46,9 @@ EXCLUDED_TESTS := \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/memory_arena_threshold_test.cc
 
 MICROLITE_TEST_SRCS := $(filter-out $(EXCLUDED_TESTS), $(MICROLITE_TEST_SRCS))
+
+CCFLAGS += $(RISCV_EXTRA_CFLAGS)
+CXXFLAGS += $(RISCV_EXTRA_CFLAGS)
 
 # This disables the "linker relaxation" optimization, which produced incorrect code.
 # TODO(b/279805615): Check whether this is fixed in newer versions of the toolchain.


### PR DESCRIPTION
These are the options that change between different riscv configurations.

BUG=321746747