### PR TITLE
Remove initialized but unused variables.

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/lstm_eval_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/lstm_eval_hifi.cc
@@ -435,7 +435,6 @@ void xa_nn_elm_mul_16x16_asym8s(int8_t* output, const int16_t* input_1,
   ae_int16x4 data_a_0, data_a_1;
   ae_int16x4 data_b_0, data_b_1;
   ae_int32x2 data_ab_0, data_ab_1, data_ab_2, data_ab_3;
-  ae_int32x2 d_multiplier, d_left_shift;
   ae_int16x4 d_zp;
   ae_int16x4 data_c_0, data_c_1;
   ae_int8x8 data_c;
@@ -449,7 +448,6 @@ void xa_nn_elm_mul_16x16_asym8s(int8_t* output, const int16_t* input_1,
   align_src_input_2 = AE_LA128_PP((ae_int16x8*)tmp_input_2);
   align_dst_output = AE_ZALIGN64();  // zero alignment reg
 
-  d_multiplier = AE_MOVDA32(multiplier);
   d_zp = AE_MOVDA16(zero_point);
 
 #if TFLITE_SINGLE_ROUNDING
@@ -459,8 +457,6 @@ void xa_nn_elm_mul_16x16_asym8s(int8_t* output, const int16_t* input_1,
   left_shift = shift < 0 ? 0 : shift;
   right_shift = shift > 0 ? 0 : -shift;
 #endif /* #if TFLITE_SINGLE_ROUNDING */
-
-  d_left_shift = AE_MOVDA32(1 << left_shift);
 #pragma concurrent
   for (i = 0; i < (num_elms >> 3); i++) {
     AE_LA16X4X2_IP(data_a_0, data_a_1, align_src_input_1, tmp_input_1);

--- a/tensorflow/lite/micro/kernels/xtensa/sub.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/sub.cc
@@ -105,17 +105,12 @@ TfLiteStatus EvalSubQuantized(TfLiteContext* context, TfLiteNode* node,
       // TODO(b/259724572): Refactor the following block of code.
       int b;
       int inp1_off = 0;
-      int inp2_off = 0;
       int out_off;
       out_off =
           output_dims[1] * output_dims[2] * output_dims[3] * output_dims[4];
       if (input1_dims[0] > 1) {
         inp1_off =
             input1_dims[1] * input1_dims[2] * input1_dims[3] * input1_dims[4];
-      }
-      if (input2_dims[0] > 1) {
-        inp2_off =
-            input2_dims[1] * input2_dims[2] * input2_dims[3] * input2_dims[4];
       }
 
       for (b = 0; b < output_dims[0]; b++) {
@@ -168,17 +163,12 @@ TfLiteStatus EvalSubQuantized(TfLiteContext* context, TfLiteNode* node,
       const int* output_dims = extended_output_shape.DimsData();
       int b;
       int inp1_off = 0;
-      int inp2_off = 0;
       int out_off;
       out_off =
           output_dims[1] * output_dims[2] * output_dims[3] * output_dims[4];
       if (input1_dims[0] > 1) {
         inp1_off =
             input1_dims[1] * input1_dims[2] * input1_dims[3] * input1_dims[4];
-      }
-      if (input2_dims[0] > 1) {
-        inp2_off =
-            input2_dims[1] * input2_dims[2] * input2_dims[3] * input2_dims[4];
       }
 
       for (b = 0; b < output_dims[0]; b++) {


### PR DESCRIPTION
We're seeing these warnings/errors only with newer version of the Xtensa toolchains.
The warnings/errors can be silenced, but that might mask other occurances.

BUG=323856831