### PR TITLE
Fix a linker error: undefined kMaxBufferCount

### DIFF
--- a/tensorflow/lite/micro/memory_planner/linear_memory_planner.cc
+++ b/tensorflow/lite/micro/memory_planner/linear_memory_planner.cc
@@ -19,6 +19,9 @@ limitations under the License.
 
 namespace tflite {
 
+// C++11 requires defining a constexpr static class member in a .cc file
+constexpr int tflite::LinearMemoryPlanner::kMaxBufferCount;
+
 LinearMemoryPlanner::LinearMemoryPlanner()
     : current_buffer_count_(0), next_free_offset_(0) {}
 LinearMemoryPlanner::~LinearMemoryPlanner() {}


### PR DESCRIPTION
When building with a recent version of xt-clang and -std=c++, the linker errs on missing definition of a static constexpr class member. In C++11, static class members still had to be defined in a C++11 file and TFLM code is expected to be compatible with C++11.

BUG=323856831