### PR TITLE
Fix array out-of-bounds access in WideDynamicFuncLut

### DIFF
--- a/python/tflite_micro/signal/utils/wide_dynamic_func_lut_wrapper.cc
+++ b/python/tflite_micro/signal/utils/wide_dynamic_func_lut_wrapper.cc
@@ -42,7 +42,8 @@ int16_t PcanGainLookupFunction(const float strength, const float offset,
 
 py::list WideDynamicFuncLut(float strength, float offset, int input_bits,
                             int gain_bits) {
-  int16_t gain_lut_storage[kWideDynamicFunctionLUTSize];
+  // Avoid accessing outside of the buffer below gain_lut[4 * interval + 3].
+  int16_t gain_lut_storage[kWideDynamicFunctionLUTSize + 1];
   int16_t* gain_lut = gain_lut_storage;
 
   gain_lut[0] =


### PR DESCRIPTION
### Problem description:

In the original code, pointer arithmetic of gain_lut and the assignment of gain_lut[4 * interval + 3] could potentially lead to out-of-bounds array access.
On certain architectures (e.g., macOS ARM64), this out-of-bounds access causes the program to crash.
BUG=#2464

### Solution:

Increase the size of the gain_lut_storage array by 1 to provide an extra buffer and prevent overflow during the calculation within the loop.

### Risks and considerations:

Increasing the array size will slightly increase memory usage.
In extremely resource-constrained systems, alternative algorithm implementations may need to be considered.