### PR TITLE
Fix a linker error: undefined kMaxSmallSize

### DIFF
--- a/tensorflow/lite/kernels/internal/common.cc
+++ b/tensorflow/lite/kernels/internal/common.cc
@@ -17,7 +17,6 @@ limitations under the License.
 
 namespace tflite {
 
-
 // Single-rounding MultiplyByQuantizedMultiplier
 #if TFLITE_SINGLE_ROUNDING
 int32_t MultiplyByQuantizedMultiplier(int32_t x, int32_t quantized_multiplier,

--- a/tensorflow/lite/kernels/internal/common.cc
+++ b/tensorflow/lite/kernels/internal/common.cc
@@ -17,6 +17,10 @@ limitations under the License.
 
 namespace tflite {
 
+
+// Defining a constexpr static class member is necessary in C++11
+constexpr int tflite::RuntimeShape::kMaxSmallSize;
+
 // Single-rounding MultiplyByQuantizedMultiplier
 #if TFLITE_SINGLE_ROUNDING
 int32_t MultiplyByQuantizedMultiplier(int32_t x, int32_t quantized_multiplier,

--- a/tensorflow/lite/kernels/internal/common.cc
+++ b/tensorflow/lite/kernels/internal/common.cc
@@ -18,9 +18,6 @@ limitations under the License.
 namespace tflite {
 
 
-// Defining a constexpr static class member is necessary in C++11
-constexpr int tflite::RuntimeShape::kMaxSmallSize;
-
 // Single-rounding MultiplyByQuantizedMultiplier
 #if TFLITE_SINGLE_ROUNDING
 int32_t MultiplyByQuantizedMultiplier(int32_t x, int32_t quantized_multiplier,

--- a/tensorflow/lite/kernels/internal/runtime_shape.cc
+++ b/tensorflow/lite/kernels/internal/runtime_shape.cc
@@ -1,0 +1,21 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+namespace tflite {
+
+// Defining a constexpr static class member is necessary in C++11
+constexpr int tflite::RuntimeShape::kMaxSmallSize;
+
+}

--- a/tensorflow/lite/kernels/internal/runtime_shape.cc
+++ b/tensorflow/lite/kernels/internal/runtime_shape.cc
@@ -20,4 +20,4 @@ namespace tflite {
 // Defining a constexpr static class member is necessary in C++11
 constexpr int tflite::RuntimeShape::kMaxSmallSize;
 
-} // namespace tflite
+}  // namespace tflite

--- a/tensorflow/lite/kernels/internal/runtime_shape.cc
+++ b/tensorflow/lite/kernels/internal/runtime_shape.cc
@@ -1,4 +1,4 @@
-/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,9 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "tensorflow/lite/kernels/internal/runtime_shape.h"
+
 namespace tflite {
 
 // Defining a constexpr static class member is necessary in C++11
 constexpr int tflite::RuntimeShape::kMaxSmallSize;
 
-}
+} // namespace tflite


### PR DESCRIPTION
When building with a recent version of xt-clang and -std=c++11, the linker errs on missing definition of a static constexpr class member. In C++11, static class members still had to be defined in a C++11 file and TFLM code is expected to be compatible with C++11.

BUG=323856831