### PR TITLE
Use absl::Status instead of tsl::Status

### DIFF
--- a/signal/tensorflow_core/ops/delay_op.cc
+++ b/signal/tensorflow_core/ops/delay_op.cc
@@ -22,11 +22,11 @@ using tensorflow::shape_inference::ShapeHandle;
 namespace tensorflow {
 namespace signal {
 
-Status DelayShape(InferenceContext* c) {
+absl::Status DelayShape(InferenceContext* c) {
   ShapeHandle out;
   TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(0), 1, &out));
   c->set_output(0, out);
-  return OkStatus();
+  return absl::OkStatus();
 }
 
 // TODO(b/286250473): change back name after name clash resolved

--- a/signal/tensorflow_core/ops/energy_op.cc
+++ b/signal/tensorflow_core/ops/energy_op.cc
@@ -22,7 +22,7 @@ using tensorflow::shape_inference::ShapeHandle;
 namespace tensorflow {
 namespace signal {
 
-Status EnergyShape(InferenceContext* c) {
+absl::Status EnergyShape(InferenceContext* c) {
   ShapeHandle out;
 
   TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 1, &out));
@@ -30,7 +30,7 @@ Status EnergyShape(InferenceContext* c) {
 
   TF_RETURN_IF_ERROR(c->ReplaceDim(out, 0, c->MakeDim(length), &out));
   c->set_output(0, out);
-  return OkStatus();
+  return absl::OkStatus();
 }
 
 // TODO(b/286250473): change back name after name clash resolved

--- a/signal/tensorflow_core/ops/fft_ops.cc
+++ b/signal/tensorflow_core/ops/fft_ops.cc
@@ -22,7 +22,7 @@ using tensorflow::shape_inference::ShapeHandle;
 namespace tensorflow {
 namespace signal {
 
-Status RfftShape(InferenceContext* c) {
+absl::Status RfftShape(InferenceContext* c) {
   ShapeHandle out;
   int fft_length;
   TF_RETURN_IF_ERROR(c->GetAttr<int>("fft_length", &fft_length));
@@ -30,17 +30,17 @@ Status RfftShape(InferenceContext* c) {
   auto dim = ((fft_length / 2) + 1) * 2;  // * 2 for complex
   TF_RETURN_IF_ERROR(c->ReplaceDim(out, -1, c->MakeDim(dim), &out));
   c->set_output(0, out);
-  return OkStatus();
+  return absl::OkStatus();
 }
 
-Status IrfftShape(InferenceContext* c) {
+absl::Status IrfftShape(InferenceContext* c) {
   ShapeHandle out;
   int fft_length;
   TF_RETURN_IF_ERROR(c->GetAttr<int>("fft_length", &fft_length));
   TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(0), 1, &out));
   TF_RETURN_IF_ERROR(c->ReplaceDim(out, -1, c->MakeDim(fft_length), &out));
   c->set_output(0, out);
-  return OkStatus();
+  return absl::OkStatus();
 }
 
 // TODO(b/286250473): change back name after name clash resolved
@@ -107,7 +107,7 @@ REGISTER_OP("SignalFftAutoScale")
       TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 1, &out));
       c->set_output(0, out);
       c->set_output(1, c->Scalar());
-      return OkStatus();
+      return absl::OkStatus();
     })
     .Doc(R"doc(
 Shifts the input left until the amplitude is maximized without clipping. Returns

--- a/signal/tensorflow_core/ops/filter_bank_ops.cc
+++ b/signal/tensorflow_core/ops/filter_bank_ops.cc
@@ -22,7 +22,7 @@ using tensorflow::shape_inference::ShapeHandle;
 namespace tensorflow {
 namespace signal {
 
-Status FilterBankShape(InferenceContext* c) {
+absl::Status FilterBankShape(InferenceContext* c) {
   ShapeHandle out;
   shape_inference::DimensionHandle unused;
   int num_channels;
@@ -49,7 +49,7 @@ Status FilterBankShape(InferenceContext* c) {
       c->WithValue(c->Dim(c->input(5), 0), num_channels + 1, &unused));
   TF_RETURN_IF_ERROR(c->ReplaceDim(out, 0, c->MakeDim(num_channels), &out));
   c->set_output(0, out);
-  return OkStatus();
+  return absl::OkStatus();
 }
 
 // TODO(b/286250473): change back name after name clash resolved
@@ -92,7 +92,7 @@ REGISTER_OP("SignalFilterBankSquareRoot")
       ShapeHandle out;
       TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 1, &out));
       c->set_output(0, out);
-      return OkStatus();
+      return absl::OkStatus();
     })
     .Doc(R"doc(
 Applies a square root to each element in the input then shift right by
@@ -122,7 +122,7 @@ REGISTER_OP("SignalFilterBankSpectralSubtraction")
       TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 1, &out));
       c->set_output(0, out);
       c->set_output(1, out);
-      return OkStatus();
+      return absl::OkStatus();
     })
     .Doc(R"doc(
 Applies spectral subtraction to a filter bank output of size num_channels
@@ -152,7 +152,7 @@ REGISTER_OP("SignalFilterBankLog")
       ShapeHandle out;
       TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 1, &out));
       c->set_output(0, out);
-      return OkStatus();
+      return absl::OkStatus();
     })
     .Doc(R"doc(
 Applies natural log to each element in input with pre-shift and post scaling.

--- a/signal/tensorflow_core/ops/framer_op.cc
+++ b/signal/tensorflow_core/ops/framer_op.cc
@@ -22,7 +22,7 @@ using tensorflow::shape_inference::ShapeHandle;
 namespace tensorflow {
 namespace signal {
 
-Status FramerShape(InferenceContext* c) {
+absl::Status FramerShape(InferenceContext* c) {
   ShapeHandle unused;
   ShapeHandle in;
   int frame_step, frame_size;
@@ -41,7 +41,7 @@ Status FramerShape(InferenceContext* c) {
   TF_RETURN_IF_ERROR(c->ReplaceDim(out, -1, c->MakeDim(frame_size), &out));
   c->set_output(0, out);
   c->set_output(1, c->Scalar());
-  return OkStatus();
+  return absl::OkStatus();
 }
 
 // TODO(b/286250473): change back name after name clash resolved

--- a/signal/tensorflow_core/ops/overlap_add_op.cc
+++ b/signal/tensorflow_core/ops/overlap_add_op.cc
@@ -22,7 +22,7 @@ using tensorflow::shape_inference::ShapeHandle;
 namespace tensorflow {
 namespace signal {
 
-Status OverlapAddShape(InferenceContext* c) {
+absl::Status OverlapAddShape(InferenceContext* c) {
   shape_inference::DimensionHandle unused;
   ShapeHandle in;
   ShapeHandle out;
@@ -39,7 +39,7 @@ Status OverlapAddShape(InferenceContext* c) {
         c->ReplaceDim(out, -1, c->MakeDim(n_frames * frame_step), &out));
   }
   c->set_output(0, out);
-  return OkStatus();
+  return absl::OkStatus();
 }
 
 // TODO(b/286250473): change back name after name clash resolved

--- a/signal/tensorflow_core/ops/pcan_op.cc
+++ b/signal/tensorflow_core/ops/pcan_op.cc
@@ -24,14 +24,14 @@ namespace signal {
 
 namespace {
 
-Status PcanShape(InferenceContext* c) {
+absl::Status PcanShape(InferenceContext* c) {
   ShapeHandle out, lut;
   TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 1, &out));
   TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 1, &out));
   TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 1, &lut));
 
   c->set_output(0, out);
-  return OkStatus();
+  return absl::OkStatus();
 }
 
 }  // namespace

--- a/signal/tensorflow_core/ops/stacker_op.cc
+++ b/signal/tensorflow_core/ops/stacker_op.cc
@@ -22,7 +22,7 @@ using tensorflow::shape_inference::ShapeHandle;
 namespace tensorflow {
 namespace signal {
 
-Status StackerShape(InferenceContext* c) {
+absl::Status StackerShape(InferenceContext* c) {
   int num_channels, stacker_left_context, stacker_right_context;
   TF_RETURN_IF_ERROR(c->GetAttr<int>("num_channels", &num_channels));
   TF_RETURN_IF_ERROR(
@@ -41,7 +41,7 @@ Status StackerShape(InferenceContext* c) {
       c->ReplaceDim(out, 0, c->MakeDim(num_channels * output_frames), &out));
   c->set_output(0, out);
   c->set_output(1, c->Scalar());
-  return OkStatus();
+  return absl::OkStatus();
 }
 
 // TODO(b/286250473): change back name after name clash resolved

--- a/signal/tensorflow_core/ops/window_op.cc
+++ b/signal/tensorflow_core/ops/window_op.cc
@@ -22,7 +22,7 @@ using tensorflow::shape_inference::ShapeHandle;
 namespace tensorflow {
 namespace signal {
 
-Status WindowShape(InferenceContext* c) {
+absl::Status WindowShape(InferenceContext* c) {
   ShapeHandle out;
   TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 1, &out));
   TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(0), 1, &out));
@@ -33,7 +33,7 @@ Status WindowShape(InferenceContext* c) {
   TF_RETURN_IF_ERROR(c->WithValue(c->Dim(c->input(1), 0),
                                   InferenceContext::Value(dim_in), &dim_in));
   c->set_output(0, out);
-  return OkStatus();
+  return absl::OkStatus();
 }
 
 // TODO(b/286250473): change back name to "Window" after name clash resolved


### PR DESCRIPTION
tsl::Status has been deprecated and is just an alias for absl::Status. This PR updates the usage to just use absl::Status directly.

BUG=cl/609910156