### PR TITLE
Streaming convolution first-cut code for 16x8 precision

### DIFF
--- a/tensorflow/lite/micro/kernels/conv.cc
+++ b/tensorflow/lite/micro/kernels/conv.cc
@@ -141,6 +141,201 @@ TfLiteStatus ConvEval(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 }
 
+void updateStreamingConvBuffer(int16_t *pbuf, const int16_t *pinp, int ih, int ic, int kw){
+/* This will update the persistent mem. Input data is coming in as ihx1xic, buffer is ihxkwxic */
+  int i, j;
+
+/* step 1 : Move the older columns in persistent buffer */
+  int striplength = (kw-1)*ic;
+  int16_t *pbuf_dst = pbuf;
+  int16_t *pbuf_src = pbuf + ic;
+
+  for(i = 0; i < ih; i++){
+    memmove(pbuf_dst, pbuf_src, striplength*sizeof(int16_t));
+    pbuf_dst += kw*ic;
+    pbuf_src += kw*ic;
+  } 
+
+/* step 2: Copy new input column to buffer */
+  int16_t *pbuf_base = pbuf+(ic*(kw-1));
+  const int16_t *pinp_base = pinp;
+
+  for(i = 0; i < ih; i++){
+    for(j = 0; j < ic; j++){
+      pbuf_base[j] = pinp_base[j];
+    }
+    pbuf_base += (kw*ic);
+    pinp_base += ic;
+  }
+}
+
+template <typename AccumScalar>
+inline void StreamingConvPerChannel(
+    const ConvParams& params, const int32_t* output_multiplier,
+    const int32_t* output_shift, const RuntimeShape& input_shape,
+    const int16_t* input_data, const RuntimeShape& filter_shape,
+    const int8_t* filter_data, const RuntimeShape& bias_shape,
+    const AccumScalar* bias_data, const RuntimeShape& output_shape,
+    int16_t* output_data, int16_t *input_state) {
+  // Get parameters.
+  const int stride_width = params.stride_width;
+  const int stride_height = params.stride_height;
+  const int dilation_width_factor = params.dilation_width_factor;
+  const int dilation_height_factor = params.dilation_height_factor;
+  const int pad_width = params.padding_values.width;
+  const int pad_height = params.padding_values.height;
+
+  // Set min and max value of the output.
+  const int32_t output_activation_min = params.quantized_activation_min;
+  const int32_t output_activation_max = params.quantized_activation_max;
+
+  // Consistency check.
+  TFLITE_DCHECK_LE(output_activation_min, output_activation_max);
+  TFLITE_DCHECK_EQ(input_shape.DimensionsCount(), 4);
+  TFLITE_DCHECK_EQ(filter_shape.DimensionsCount(), 4);
+  TFLITE_DCHECK_EQ(output_shape.DimensionsCount(), 4);
+  const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+  const int input_depth = input_shape.Dims(3);
+  const int output_depth = MatchingDim(filter_shape, 0, output_shape, 3);
+  if (bias_data) {
+    TFLITE_DCHECK_EQ(bias_shape.FlatSize(), output_depth);
+  }
+
+  // Check dimensions of the tensors.
+  const int input_height = input_shape.Dims(1);
+  int input_width = input_shape.Dims(2);
+  const int filter_height = filter_shape.Dims(1);
+  const int filter_width = filter_shape.Dims(2);
+  const int filter_input_depth = filter_shape.Dims(3);
+
+  /* Update streaming conv buffer with input data */
+  input_width = filter_width;
+  const int dims_shape[4] = {1, input_height, filter_width, input_depth};
+  RuntimeShape input_state_shape(4,dims_shape) ;
+
+  const int groups = input_depth / filter_input_depth;
+  TFLITE_DCHECK_EQ(input_depth % filter_input_depth, 0);
+  const int filters_per_group = output_depth / groups;
+  const int output_height = output_shape.Dims(1);
+  const int output_width = output_shape.Dims(2);
+  for (int batch = 0; batch < batches; ++batch) {
+    updateStreamingConvBuffer(input_state, &input_data[Offset(input_shape, batch, 0, 0, 0)], input_height, input_depth, filter_width);
+    for (int out_y = 0; out_y < output_height; ++out_y) {
+      const int in_y_origin = (out_y * stride_height) - pad_height;
+      for (int out_x = 0; out_x < output_width; ++out_x) {
+        const int in_x_origin = (out_x * stride_width) - pad_width;
+        for (int out_channel = 0; out_channel < output_depth; ++out_channel) {
+          auto group = out_channel / filters_per_group;
+          AccumScalar acc = 0;
+          for (int filter_y = 0; filter_y < filter_height; ++filter_y) {
+            const int in_y = in_y_origin + dilation_height_factor * filter_y;
+            for (int filter_x = 0; filter_x < filter_width; ++filter_x) {
+              const int in_x = in_x_origin + dilation_width_factor * filter_x;
+
+              // Zero padding by omitting the areas outside the image.
+              const bool is_point_inside_image =
+                  (in_x >= 0) && (in_x < input_width) && (in_y >= 0) &&
+                  (in_y < input_height);
+
+              if (!is_point_inside_image) {
+                continue;
+              }
+
+              for (int in_channel = 0; in_channel < filter_input_depth;
+                   ++in_channel) {
+                int32_t input_val =
+                    input_state[Offset(input_state_shape, 0, in_y, in_x,
+                                      in_channel + group * filter_input_depth)];
+                int32_t filter_val = filter_data[Offset(
+                    filter_shape, out_channel, filter_y, filter_x, in_channel)];
+                // Accumulate with 64 bits accumulator.
+                // int64_t += int8_t * int16_t so the highest value we can
+                // get from each accumulation is [-127, 127] * ([-32768,
+                // 32767] -
+                // [-32768, 32767]), which is [-8322945, 8322945].
+                // log2(8322945) = 22.99.
+                acc += filter_val * input_val;
+              }
+            }
+          }
+          if (bias_data) {
+            acc += bias_data[out_channel];
+          }
+          int32_t scaled_acc = MultiplyByQuantizedMultiplier(
+              acc, output_multiplier[out_channel], output_shift[out_channel]);
+          scaled_acc = std::max(scaled_acc, output_activation_min);
+          scaled_acc = std::min(scaled_acc, output_activation_max);
+          output_data[Offset(output_shape, batch, out_y, out_x, out_channel)] =
+              static_cast<int16_t>(scaled_acc);
+        }
+      }
+    }
+  }
+}
+
+TfLiteStatus StreamingConvEval(TfLiteContext* context, TfLiteNode* node) {
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kConvInputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kConvWeightsTensor);
+  const TfLiteEvalTensor* bias =
+      (NumInputs(node) == 3)
+          ? tflite::micro::GetEvalInput(context, node, kConvBiasTensor)
+          : nullptr;
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kConvOutputTensor);
+
+  TFLITE_DCHECK(node->builtin_data != nullptr);
+  const auto& params =
+      *(reinterpret_cast<TfLiteConvParams*>(node->builtin_data));
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const auto& sdata = *(static_cast<const OpDataStreamingConv*>(node->user_data));
+  const auto& data = sdata.op_data;
+
+  switch (input->type) {  // Already know in/out types are same.
+    case kTfLiteInt16: {
+      if (bias == nullptr || bias->type == kTfLiteInt32) {
+        StreamingConvPerChannel(
+            ConvParamsQuantized(params, data),
+            data.per_channel_output_multiplier, data.per_channel_output_shift,
+            tflite::micro::GetTensorShape(input),
+            tflite::micro::GetTensorData<int16_t>(input),
+            tflite::micro::GetTensorShape(filter),
+            tflite::micro::GetTensorData<int8_t>(filter),
+            tflite::micro::GetTensorShape(bias),
+            tflite::micro::GetOptionalTensorData<std::int32_t>(bias),
+            tflite::micro::GetTensorShape(output),
+            tflite::micro::GetTensorData<int16_t>(output),
+            (int16_t *)sdata.input_state);
+      } else if (bias->type == kTfLiteInt64) {
+        StreamingConvPerChannel(
+            ConvParamsQuantized(params, data),
+            data.per_channel_output_multiplier, data.per_channel_output_shift,
+            tflite::micro::GetTensorShape(input),
+            tflite::micro::GetTensorData<int16_t>(input),
+            tflite::micro::GetTensorShape(filter),
+            tflite::micro::GetTensorData<int8_t>(filter),
+            tflite::micro::GetTensorShape(bias),
+            tflite::micro::GetOptionalTensorData<std::int64_t>(bias),
+            tflite::micro::GetTensorShape(output),
+            tflite::micro::GetTensorData<int16_t>(output),
+            (int16_t *)sdata.input_state);
+      } else {
+        MicroPrintf("Bias type %s (%d) not supported.",
+                    TfLiteTypeGetName(bias->type), bias->type);
+        return kTfLiteError;
+      }
+      break;
+    }
+    default:
+      MicroPrintf("Type %s (%d) not supported.", TfLiteTypeGetName(input->type),
+                  input->type);
+      return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+
 }  // namespace
 
 TFLMRegistration Register_CONV_2D() {
@@ -149,7 +344,7 @@ TFLMRegistration Register_CONV_2D() {
 
 TFLMRegistration Register_STREAMING_CONV_2D() {
   // TODO(rjascani): These should be replaced with Streaming wrapper functions.
-  return tflite::micro::RegisterOp(ConvInit, ConvPrepare, ConvEval);
+  return tflite::micro::RegisterOp(StreamingConvInit, StreamingConvPrepare, StreamingConvEval);
 }
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/conv.h
+++ b/tensorflow/lite/micro/kernels/conv.h
@@ -51,6 +51,11 @@ struct OpDataConv {
   int filter_buffer_index;
 };
 
+struct OpDataStreamingConv {
+  struct OpDataConv op_data;
+  void *input_state;
+};
+
 extern const int kConvInputTensor;
 extern const int kConvWeightsTensor;
 extern const int kConvBiasTensor;
@@ -85,8 +90,10 @@ TfLiteStatus ConvReshapeOutputTensor(TfLiteContext* context, TfLiteNode* node,
                                      int width);
 
 void* ConvInit(TfLiteContext* context, const char* buffer, size_t length);
-
 TfLiteStatus ConvPrepare(TfLiteContext* context, TfLiteNode* node);
+
+void* StreamingConvInit(TfLiteContext* context, const char* buffer, size_t length);
+TfLiteStatus StreamingConvPrepare(TfLiteContext* context, TfLiteNode* node);
 
 // This is the most generic TFLMRegistration. The actual supported types
 // may still be target dependent. The only requirement is that every


### PR DESCRIPTION
Added streaming convolution first-cut code for 16x8 precision with one unit test.