### PR TITLE
Prevent runtime_shape.cc removal during sync

### DIFF
--- a/ci/sync_from_upstream_tf.sh
+++ b/ci/sync_from_upstream_tf.sh
@@ -47,6 +47,7 @@ done
 git checkout tensorflow/lite/kernels/internal/optimized/neon_check.h
 # http://b/149862813
 git checkout tensorflow/lite/kernels/internal/runtime_shape.h
+git checkout tensorflow/lite/kernels/internal/runtime_shape.cc
 # http://b/187728891
 git checkout tensorflow/lite/kernels/op_macros.h
 # http://b/242077843


### PR DESCRIPTION
Despite existing in TFLite, the runtime_shape.h has long differed between TFLite and TFLM. The file is not copied during the sync and the sync script does a `git checkout` on the file to ensure that the existing version in the TFLM tree remains.

In PR #2476, we needed to add a runtime_shape.cc file. This PR ensures that the runtime_shape.cc file will not be removed during the sync by performing a `git checkout` on the existing file.

BUG=323856831