### PR TITLE
Fix tests_entry & tests_post workflows (#2493)

### DIFF
--- a/.github/workflows/tests_entry.yml
+++ b/.github/workflows/tests_entry.yml
@@ -31,7 +31,7 @@ jobs:
         if: github.event.action == 'labeled' &&
           !(github.event.label.name == 'ci:run' ||
             github.event.label.name == 'ci:ready_to_merge' ||
-            github.event.label.name = 'ci:run_full')
+            github.event.label.name == 'ci:run_full')
         run: exit 1
 
   ci-ready-to-merge:
@@ -81,7 +81,7 @@ jobs:
     steps:
       - name: remove-cirun-full
         if: github.event.action == 'labeled' &&
-            github.event.label.name = 'ci:run_full'
+            github.event.label.name == 'ci:run_full'
         uses: actions/github-script@v5
         with:
           github-token: ${{ secrets.TFLM_BOT_REPO_TOKEN }}

--- a/.github/workflows/tests_post.yml
+++ b/.github/workflows/tests_post.yml
@@ -11,53 +11,7 @@ on:
       - labeled
 
 jobs:
-  riscv_postmerge:
-    if: github.event.pull_request.merged == true ||
-        (github.event.action == 'labeled' &&
-         github.event.label.name == 'ci:run_full')
-    uses: ./.github/workflows/riscv_postmerge.yml
-    with:
-      trigger-sha: ${{ github.event.pull_request.head.sha }}
-    secrets:
-      tflm-bot-token: ${{ secrets.TFLM_BOT_PACKAGE_READ_TOKEN }}
-
-  xtensa_postmerge:
-    if: github.event.pull_request.merged == true ||
-        (github.event.action == 'labeled' &&
-         github.event.label.name == 'ci:run_full')
-    uses: ./.github/workflows/xtensa_postmerge.yml
-    with:
-      trigger-sha: ${{ github.event.pull_request.head.sha }}
-    secrets:
-      tflm-bot-token: ${{ secrets.TFLM_BOT_PACKAGE_READ_TOKEN }}
-
-  cortex_m_ci_full:
-    if: github.event.action == 'labeled' &&
-         github.event.label.name == 'ci:run_full'
-    uses: ./.github/workflows/cortex_m.yml
-    with:
-      trigger-sha: ${{ github.event.pull_request.head.sha }}
-    secrets:
-      tflm-bot-token: ${{ secrets.TFLM_BOT_PACKAGE_READ_TOKEN }}
-
-  issue_on_error:
-    needs: [riscv_postmerge, xtensa_postmerge, cortex_m_ci_full]
-    if: ${{ always() && contains(needs.*.result, 'failure') &&
-            !contains(github.event.pull_request.labels.*.name, 'ci:run_full') }}
-    uses: ./.github/workflows/issue_on_error.yml
-    with:
-      repo: ${{ github.repository}}
-      workflow: ${{ github.workflow }}
-      run_number: ${{ github.run_number }}
-      run_id: ${{ github.run_id }}
-      flag_label: ci:bot_issue
-      pr_number: ${{ github.event.number }}
-      pr_link: ${{ github.event.pull_request._links.html.href }}
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
-
   ci_run_full:
-    needs: [issue_on_error]
     runs-on: ubuntu-latest
     steps:
       - name: remove-cirun-full
@@ -74,3 +28,49 @@ jobs:
               name: 'ci:run_full'
             })
         continue-on-error: true
+
+  riscv_postmerge:
+    needs: [ci_run_full]
+    if: always() && github.event.pull_request.merged == true ||
+        (github.event.action == 'labeled' &&
+         github.event.label.name == 'ci:run_full')
+    uses: ./.github/workflows/riscv_postmerge.yml
+    with:
+      trigger-sha: ${{ github.event.pull_request.head.sha }}
+    secrets:
+      tflm-bot-token: ${{ secrets.TFLM_BOT_PACKAGE_READ_TOKEN }}
+
+  xtensa_postmerge:
+    needs: [ci_run_full]
+    if: always() && github.event.pull_request.merged == true ||
+        (github.event.action == 'labeled' &&
+         github.event.label.name == 'ci:run_full')
+    uses: ./.github/workflows/xtensa_postmerge.yml
+    with:
+      trigger-sha: ${{ github.event.pull_request.head.sha }}
+    secrets:
+      tflm-bot-token: ${{ secrets.TFLM_BOT_PACKAGE_READ_TOKEN }}
+
+  cortex_m_ci_full:
+    needs: [ci_run_full]
+    uses: ./.github/workflows/cortex_m.yml
+    with:
+      trigger-sha: ${{ github.event.pull_request.head.sha }}
+    secrets:
+      tflm-bot-token: ${{ secrets.TFLM_BOT_PACKAGE_READ_TOKEN }}
+
+  issue_on_error:
+    needs: [riscv_postmerge, xtensa_postmerge, cortex_m_ci_full]
+    if: ${{ always() && contains(needs.*.result, 'failure') &&
+            github.event.pull_request.merged == true }}
+    uses: ./.github/workflows/issue_on_error.yml
+    with:
+      repo: ${{ github.repository}}
+      workflow: ${{ github.workflow }}
+      run_number: ${{ github.run_number }}
+      run_id: ${{ github.run_id }}
+      flag_label: ci:bot_issue
+      pr_number: ${{ github.event.number }}
+      pr_link: ${{ github.event.pull_request._links.html.href }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The tests_entry workflow was invalid due to parsing error when a `==` was expected instead of `=`. The tests_post needed to remove the ci:run_full label.

BUG=b/327686165