### PR TITLE
Parse StreamingConv2D operator

### DIFF
--- a/tensorflow/lite/core/api/flatbuffer_conversions.cc
+++ b/tensorflow/lite/core/api/flatbuffer_conversions.cc
@@ -921,6 +921,9 @@ TfLiteStatus ParseOpDataTfLite(const Operator* op, BuiltinOperator op_type,
     case BuiltinOperator_STABLEHLO_PAD: {
       return ParseStablehloPad(op, error_reporter, allocator, builtin_data);
     }
+    case BuiltinOperator_TEMP_STREAMING_CONV_2D: {
+      return ParseConv2D(op, error_reporter, allocator, builtin_data);
+    }
     // TODO: skip param parsing for now since ops below don't have kernels
     case BuiltinOperator_STABLEHLO_SLICE:
     case BuiltinOperator_STABLEHLO_BROADCAST_IN_DIM:


### PR DESCRIPTION
The prototype streaming conv2d operator re-uses the Conv2D options, so we can re-use the ParseConv2D function for parsing the flatbuffer options.

BUG=b/327502734