### PR TITLE
Add workaround for newer GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,11 @@ jobs:
           pip3 install Pillow
           pip3 install Wave
           pip3 install numpy
+      - name: Fix kernel mmap rnd bits
+        # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
+        # high-entropy ASLR in much newer kernels that GitHub runners are
+        # using leading to random crashes: https://reviews.llvm.org/D148280
+        run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Test
         run: |
           tensorflow/lite/micro/tools/ci_build/test_bazel_msan.sh
@@ -100,6 +105,11 @@ jobs:
           pip3 install Pillow
           pip3 install Wave
           pip3 install numpy
+      - name: Fix kernel mmap rnd bits
+        # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
+        # high-entropy ASLR in much newer kernels that GitHub runners are
+        # using leading to random crashes: https://reviews.llvm.org/D148280
+        run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Test
         run: |
           tensorflow/lite/micro/tools/ci_build/test_bazel_asan.sh


### PR DESCRIPTION
Asan in llvm 14 provided in ubuntu 22.04 is incompatible with high-entropy ASLR in much newer kernels that GitHub runners are using leading to random crashes: https://reviews.llvm.org/D148280

This workaround comes from the discussion in:
https://github.com/actions/runner-images/issues/9491

BUG=#2501