### PR TITLE
Remove Wave as dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
         run: |
           sudo ci/install_bazelisk.sh
           pip3 install Pillow
-          pip3 install Wave
           pip3 install numpy
       - name: Test
         run: |
@@ -56,7 +55,6 @@ jobs:
         run: |
           sudo ci/install_bazelisk.sh
           pip3 install Pillow
-          pip3 install Wave
           pip3 install numpy
       - name: Test
         run: |
@@ -77,7 +75,6 @@ jobs:
         run: |
           sudo ci/install_bazelisk.sh
           pip3 install Pillow
-          pip3 install Wave
           pip3 install numpy
       - name: Fix kernel mmap rnd bits
         # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
@@ -103,7 +100,6 @@ jobs:
         run: |
           sudo ci/install_bazelisk.sh
           pip3 install Pillow
-          pip3 install Wave
           pip3 install numpy
       - name: Fix kernel mmap rnd bits
         # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
@@ -128,7 +124,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install Pillow
-          pip3 install Wave
           pip3 install numpy
       - name: Test
         run: |
@@ -149,7 +144,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install Pillow
-          pip3 install Wave
           pip3 install numpy
       - name: Test
         run: |
@@ -170,7 +164,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install Pillow
-          pip3 install Wave
           pip3 install numpy
       - name: Test
         run: |
@@ -223,7 +216,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install Pillow
-          pip3 install Wave
           pip3 install numpy
       - name: Test
         run: |
@@ -244,7 +236,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install Pillow
-          pip3 install Wave
           pip3 install numpy
       - name: Test
         run: |
@@ -266,7 +257,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install Pillow
-          pip3 install Wave
           pip3 install numpy
       - name: Test
         run: |
@@ -288,7 +278,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install Pillow
-          pip3 install Wave
           pip3 install numpy
       - name: Test
         run: |
@@ -310,7 +299,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install Pillow
-          pip3 install Wave
           pip3 install numpy
       - name: Test
         run: |

--- a/.github/workflows/cortex_m.yml
+++ b/.github/workflows/cortex_m.yml
@@ -48,7 +48,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install Pillow
-          pip3 install Wave
           pip3 install numpy
       - name: Test
         run: |
@@ -73,7 +72,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install Pillow
-          pip3 install Wave
           pip3 install numpy
       - name: Test
         run: |

--- a/.github/workflows/generate_integration_tests.yml
+++ b/.github/workflows/generate_integration_tests.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install Pillow
-          pip3 install Wave
           pip3 install numpy
       - name: Test
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,8 +178,8 @@ Below are some tips that might be useful and improve the development experience.
 * Get a copy of [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint)
   or install it:
 
-* Install Pillow and Wave.  For example, [here](ci/Dockerfile.micro) is what we
-  do for the TFLM continuous integration Docker container.
+* Install Pillow.  For example, [here](ci/Dockerfile.micro) is what we do for
+  the TFLM continuous integration Docker container.
 
   ```
   pip install cpplint

--- a/ci/Dockerfile.micro
+++ b/ci/Dockerfile.micro
@@ -59,7 +59,6 @@ RUN pip install yapf==0.32.0
 # https://github.com/tensorflow/tflite-micro/pull/337
 # https://github.com/tensorflow/tflite-micro/pull/410
 RUN pip install Pillow
-RUN pip install Wave
 
 # necessary bits for create_size_log scripts
 RUN pip install pandas


### PR DESCRIPTION
The Wave pypi package was recently updated, and the new version caused failures in our CI for pip installing it. From what I can tell, this package is no longer being used, so this PR simply removes it as a build dependency.

BUG=b/329887147