### PR TITLE
Add GNU Make rule to print GENDIR

### DIFF
--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -935,6 +935,9 @@ endif
 # Just build the test targets
 build: $(MICROLITE_BUILD_TARGETS)
 
+list_gendir:
+	@echo $(GENDIR)
+
 list_library_sources:
 	@echo $(MICROLITE_CC_SRCS) $(MICROLITE_CC_KERNEL_SRCS)
 


### PR DESCRIPTION
Useful when the TFLM makefile is called recursively and build artifacts used.

BUG=b/327609938