### PR TITLE
Replace test with invalid-enum-load

### DIFF
--- a/tensorflow/lite/micro/memory_helpers_test.cc
+++ b/tensorflow/lite/micro/memory_helpers_test.cc
@@ -180,8 +180,8 @@ TF_LITE_MICRO_TEST(TestTypeSizeOf) {
                           tflite::TfLiteTypeSizeOf(kTfLiteComplex128, &size));
   TF_LITE_MICRO_EXPECT_EQ(sizeof(double) * 2, size);
 
-  TF_LITE_MICRO_EXPECT_NE(
-      kTfLiteOk, tflite::TfLiteTypeSizeOf(static_cast<TfLiteType>(-1), &size));
+  TF_LITE_MICRO_EXPECT_NE(kTfLiteOk,
+                          tflite::TfLiteTypeSizeOf(kTfLiteNoType, &size));
 }
 
 TF_LITE_MICRO_TEST(TestBytesRequiredForTensor) {


### PR DESCRIPTION
The TestTypeSizeOf was casting an invalid value for TfLiteType into a variable of that type. This is undefined behavior and triggered ubsan. This PR replaces this test case with using kTfLiteNoType, which will still trigger the default failure case for TfLiteTypeSizeOf.

BUG=b/333708102