### PR TITLE
List array.cc in the MICROLITE_CC_BASE_SRC

### DIFF
--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -515,6 +515,7 @@ ifneq ($(BUILD_TYPE), no_tf_lite_static_memory)
 endif
 
 MICROLITE_CC_BASE_SRCS := \
+$(TENSORFLOW_ROOT)tensorflow/lite/array.cc \
 $(wildcard $(TENSORFLOW_ROOT)tensorflow/lite/micro/*.cc) \
 $(wildcard $(TENSORFLOW_ROOT)tensorflow/lite/micro/arena_allocator/*.cc) \
 $(wildcard $(TENSORFLOW_ROOT)tensorflow/lite/micro/memory_planner/*.cc) \
@@ -524,6 +525,7 @@ $(TFL_CC_SRCS)
 MICROLITE_CC_HDRS := \
 $(wildcard $(TENSORFLOW_ROOT)signal/micro/kernels/*.h) \
 $(wildcard $(TENSORFLOW_ROOT)signal/src/*.h) \
+$(TENSORFLOW_ROOT)tensorflow/lite/array.h \
 $(wildcard $(TENSORFLOW_ROOT)tensorflow/lite/micro/*.h) \
 $(wildcard $(TENSORFLOW_ROOT)tensorflow/lite/micro/benchmarks/*model_data.h) \
 $(wildcard $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/*.h) \


### PR DESCRIPTION
Hello, 

I'm following the steps in [tensorflow/lite/micro/docs/new_platform_support.md
](https://github.com/kraiskil/tflite-micro/blob/main/tensorflow/lite/micro/docs/new_platform_support.md) document.

I'm compiling the `hello_world` example with a CMakeLists.txt posted below. It fails with
```
tflm_project/tensorflow/lite/kernels/kernel_util.cc:28:10: fatal error: tensorflow/lite/array.h: No such file or directory
   28 | #include "tensorflow/lite/array.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

With the the proposed changes, the build succeeds.
This would be my first contribution to tensorflow. Does it make sense? I don't really know what else this change affects. 

The diff is a bit ugly because I kept the alphabetical order in the file lists - should this be modified?


kalle

--------------------
CMakeListst.txt to compile the generated `hello_world`. 
```
cmake_minimum_required(VERSION 2.8.12)
project( TFLM
	LANGUAGES CXX )
file( GLOB_RECURSE SRCS 
	examples/hello_world/*.cc
	signal/*.cc 
	tensorflow/*.cc
	third_party/*.cc
	)
add_executable( hello_world ${SRCS}) 
target_include_directories( hello_world 
	PUBLIC
		${CMAKE_CURRENT_SOURCE_DIR}/ 
		${CMAKE_CURRENT_SOURCE_DIR}/examples/hello_world
		${CMAKE_CURRENT_SOURCE_DIR}/third_party/flatbuffers/include
		${CMAKE_CURRENT_SOURCE_DIR}/third_party/gemmlowp
		${CMAKE_CURRENT_SOURCE_DIR}/third_party/ruy
		${CMAKE_CURRENT_SOURCE_DIR}/third_party/kissfft
	)
```

