### PR TITLE
Remove #definitions of MAX_RFFT_PWR, MIN_RFFT_PWR from Xtensa flags

### DIFF
--- a/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
@@ -39,8 +39,6 @@ PLATFORM_FLAGS = \
   -DTF_LITE_USE_CTIME \
   --xtensa-core=$(XTENSA_CORE) \
   -mcoproc \
-  -DMAX_RFFT_PWR=9 \
-  -DMIN_RFFT_PWR=MAX_RFFT_PWR \
   $(TARGET_ARCH_DEFINES) \
   -mlongcalls
 


### PR DESCRIPTION
First, the definition -DMIN_RFFT_PWR=MAX_RFFT_PWR
is meaningless, because MAX_RFFT_PWR doesn't evaluate to a number. That's a bug.
Second, both #definitions are only applicable when building Nature DSP for hifi3 and hifimini. Later archs (hifi4, hifi5) stopped using them. That's confusing to define them for all archs.
Finally, there are a lot of possible #definitions and there's no reason to define these particular two in the main Xtensa makefile. A user can add any #define to XTENSA_EXTRA_CFLAGS.
BUG=340206722