### PR TITLE
Fix corstone-300 simulator path

### DIFF
--- a/tensorflow/lite/micro/tools/make/targets/cortex_m_corstone_300_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/cortex_m_corstone_300_makefile.inc
@@ -16,7 +16,7 @@
 # ARM Cortex M makefile targeted for a FVP based on Arm Corstone-300 software.
 # For more info see: tensorflow/lite/micro/cortex_m_corstone_300/README.md
 
-export PATH := $(DOWNLOADS_DIR)/corstone300/models/Linux64_GCC-6.4:$(PATH)
+export PATH := $(DOWNLOADS_DIR)/corstone300/models/Linux64_GCC-9.3:$(PATH)
 DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/corstone_300_download.sh $(DOWNLOADS_DIR) $(TENSORFLOW_ROOT))
 ifneq ($(DOWNLOAD_RESULT), SUCCESS)
   $(error Something went wrong with the Arm Corstone-300 software download: $(DOWNLOAD_RESULT))


### PR DESCRIPTION
@tensorflow/micro

PR#2573 updated the corstone-300 simulator download.  This resulted in the path to the simulator binary changing.  This PR updates the PATH environment.

bug=fixes #2578