### PR TITLE
Fix test_cortex_m_corstone_300 ci job

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_cortex_m_corstone_300.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_cortex_m_corstone_300.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2024 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,4 +51,5 @@ readable_run make -j$(nproc) -f tensorflow/lite/micro/tools/make/Makefile \
   TARGET_ARCH=${TARGET_ARCH} \
   TOOLCHAIN=${TOOLCHAIN} \
   GENERIC_BENCHMARK_MODEL_PATH=tensorflow/lite/micro/models/person_detect.tflite \
+  GENERIC_BENCHMARK_ARENA_SIZE=`expr 150 \* 1024` \
   run_tflm_benchmark

--- a/tensorflow/lite/micro/tools/make/targets/cortex_m_corstone_300_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/cortex_m_corstone_300_makefile.inc
@@ -16,7 +16,13 @@
 # ARM Cortex M makefile targeted for a FVP based on Arm Corstone-300 software.
 # For more info see: tensorflow/lite/micro/cortex_m_corstone_300/README.md
 
-export PATH := $(DOWNLOADS_DIR)/corstone300/models/Linux64_GCC-6.4:$(PATH)
+UNAME_M := $(shell uname -m)
+ifeq ($(UNAME_M), aarch64)
+  export PATH := $(DOWNLOADS_DIR)/corstone300/models/Linux64_armv8l_GCC-9.3:$(PATH)
+else
+  export PATH := $(DOWNLOADS_DIR)/corstone300/models/Linux64_GCC-9.3:$(PATH)
+endif
+
 DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/corstone_300_download.sh $(DOWNLOADS_DIR) $(TENSORFLOW_ROOT))
 ifneq ($(DOWNLOAD_RESULT), SUCCESS)
   $(error Something went wrong with the Arm Corstone-300 software download: $(DOWNLOAD_RESULT))


### PR DESCRIPTION
 * Update path for new corstone300 downloads
 * Add missing benchmark arena size to generic benchmark test
 
BUG=Corstone300 Ci Job fails to run
Author: Ryan O'Shea <ryan.oshea3@arm.com>