### PR TITLE
Import visualize from tensorflow, not tflite-micro

### DIFF
--- a/tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver/generate_micro_mutable_op_resolver_from_model.py
+++ b/tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver/generate_micro_mutable_op_resolver_from_model.py
@@ -23,7 +23,7 @@ from absl import app
 from absl import flags
 from mako import template
 
-from tflite_micro.tensorflow.lite.tools import visualize as visualize
+from tensorflow.lite.tools import visualize
 
 TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), 'templates')
 TEMPLATE_DIR = os.path.abspath(TEMPLATE_DIR)


### PR DESCRIPTION
When running the gen_micro_mutable_op_resolver script as a regular python script without bazel, it cannot find visualize because it is not part of the tflite-micro wheel. When running the script with bazel, bazel can pick up visualize from the path
tflite_micro/tensorflow/lite/tools as long as tflite-micro wheel is not installed. If it is installed, then bazel will only look at that, which it is not a part of.

This PR switches the import to just be from tensorflow, which should work regardless of whether it is from the tf package or relative path.

BUG=#2564