### PR TITLE
Adds GetCurrentOperatorIndex to micro_interpreter

### DIFF
--- a/tensorflow/lite/micro/micro_interpreter_graph.cc
+++ b/tensorflow/lite/micro/micro_interpreter_graph.cc
@@ -61,12 +61,15 @@ TfLiteStatus MicroInterpreterGraph::InitSubgraphs() {
        subgraph_idx++) {
     current_subgraph_index_ = subgraph_idx;
     uint32_t operators_size = NumSubgraphOperators(model_, subgraph_idx);
-    for (current_operator_index_ = 0; current_operator_index_ < operators_size; ++current_operator_index_) {
-      TfLiteNode* node =
-          &(subgraph_allocations_[subgraph_idx].node_and_registrations[current_operator_index_].node);
-      const TFLMRegistration* registration = subgraph_allocations_[subgraph_idx]
-                                                 .node_and_registrations[current_operator_index_]
-                                                 .registration;
+    for (current_operator_index_ = 0; current_operator_index_ < operators_size;
+         ++current_operator_index_) {
+      TfLiteNode* node = &(subgraph_allocations_[subgraph_idx]
+                               .node_and_registrations[current_operator_index_]
+                               .node);
+      const TFLMRegistration* registration =
+          subgraph_allocations_[subgraph_idx]
+              .node_and_registrations[current_operator_index_]
+              .registration;
       size_t init_data_size;
       const char* init_data;
       if (registration->builtin_code == BuiltinOperator_CUSTOM) {
@@ -95,21 +98,26 @@ TfLiteStatus MicroInterpreterGraph::PrepareSubgraphs() {
        subgraph_idx++) {
     current_subgraph_index_ = subgraph_idx;
     uint32_t operators_size = NumSubgraphOperators(model_, subgraph_idx);
-    for (current_operator_index_ = 0; current_operator_index_ < operators_size; ++current_operator_index_) {
-      TfLiteNode* node =
-          &(subgraph_allocations_[subgraph_idx].node_and_registrations[current_operator_index_].node);
-      const TFLMRegistration* registration = subgraph_allocations_[subgraph_idx]
-                                                 .node_and_registrations[current_operator_index_]
-                                                 .registration;
+    for (current_operator_index_ = 0; current_operator_index_ < operators_size;
+         ++current_operator_index_) {
+      TfLiteNode* node = &(subgraph_allocations_[subgraph_idx]
+                               .node_and_registrations[current_operator_index_]
+                               .node);
+      const TFLMRegistration* registration =
+          subgraph_allocations_[subgraph_idx]
+              .node_and_registrations[current_operator_index_]
+              .registration;
       if (registration->prepare != nullptr) {
         TfLiteStatus prepare_status = registration->prepare(context_, node);
         if (prepare_status != kTfLiteOk) {
           MicroPrintf("Node %s (number %df) failed to prepare with status %d",
-                      OpNameFromRegistration(registration), current_operator_index_, prepare_status);
+                      OpNameFromRegistration(registration),
+                      current_operator_index_, prepare_status);
           return kTfLiteError;
         }
       }
-      allocator_->FinishPrepareNodeAllocations(/*node_id=*/current_operator_index_);
+      allocator_->FinishPrepareNodeAllocations(
+          /*node_id=*/current_operator_index_);
     }
   }
   current_subgraph_index_ = previous_subgraph_idx;
@@ -125,12 +133,15 @@ TfLiteStatus MicroInterpreterGraph::ResetSubgraphs() {
        subgraph_idx++) {
     current_subgraph_index_ = subgraph_idx;
     uint32_t operators_size = NumSubgraphOperators(model_, subgraph_idx);
-    for (current_operator_index_ = 0; current_operator_index_ < operators_size; ++current_operator_index_) {
-      TfLiteNode* node =
-          &(subgraph_allocations_[subgraph_idx].node_and_registrations[current_operator_index_].node);
-      const TFLMRegistration* registration = subgraph_allocations_[subgraph_idx]
-                                                 .node_and_registrations[current_operator_index_]
-                                                 .registration;
+    for (current_operator_index_ = 0; current_operator_index_ < operators_size;
+         ++current_operator_index_) {
+      TfLiteNode* node = &(subgraph_allocations_[subgraph_idx]
+                               .node_and_registrations[current_operator_index_]
+                               .node);
+      const TFLMRegistration* registration =
+          subgraph_allocations_[subgraph_idx]
+              .node_and_registrations[current_operator_index_]
+              .registration;
       // registration is allocated outside the interpreter, so double check to
       // make sure it's not nullptr;
       if (registration != nullptr && registration->reset != nullptr) {
@@ -152,12 +163,15 @@ TfLiteStatus MicroInterpreterGraph::FreeSubgraphs() {
        subgraph_idx++) {
     current_subgraph_index_ = subgraph_idx;
     uint32_t operators_size = NumSubgraphOperators(model_, subgraph_idx);
-    for (current_operator_index_ = 0; current_operator_index_ < operators_size; ++current_operator_index_) {
-      TfLiteNode* node =
-          &(subgraph_allocations_[subgraph_idx].node_and_registrations[current_operator_index_].node);
-      const TFLMRegistration* registration = subgraph_allocations_[subgraph_idx]
-                                                 .node_and_registrations[current_operator_index_]
-                                                 .registration;
+    for (current_operator_index_ = 0; current_operator_index_ < operators_size;
+         ++current_operator_index_) {
+      TfLiteNode* node = &(subgraph_allocations_[subgraph_idx]
+                               .node_and_registrations[current_operator_index_]
+                               .node);
+      const TFLMRegistration* registration =
+          subgraph_allocations_[subgraph_idx]
+              .node_and_registrations[current_operator_index_]
+              .registration;
       // registration is allocated outside the interpreter, so double check to
       // make sure it's not nullptr;
       if (registration != nullptr && registration->free != nullptr) {
@@ -182,12 +196,15 @@ TfLiteStatus MicroInterpreterGraph::InvokeSubgraph(int subgraph_idx) {
     return kTfLiteError;
   }
   uint32_t operators_size = NumSubgraphOperators(model_, subgraph_idx);
-  for (current_operator_index_ = 0; current_operator_index_ < operators_size; ++current_operator_index_) {
-    TfLiteNode* node =
-        &(subgraph_allocations_[subgraph_idx].node_and_registrations[current_operator_index_].node);
-    const TFLMRegistration* registration = subgraph_allocations_[subgraph_idx]
-                                               .node_and_registrations[current_operator_index_]
-                                               .registration;
+  for (current_operator_index_ = 0; current_operator_index_ < operators_size;
+       ++current_operator_index_) {
+    TfLiteNode* node = &(subgraph_allocations_[subgraph_idx]
+                             .node_and_registrations[current_operator_index_]
+                             .node);
+    const TFLMRegistration* registration =
+        subgraph_allocations_[subgraph_idx]
+            .node_and_registrations[current_operator_index_]
+            .registration;
 
 // This ifdef is needed (even though ScopedMicroProfiler itself is a no-op with
 // -DTF_LITE_STRIP_ERROR_STRINGS) because the function OpNameFromRegistration is
@@ -209,7 +226,8 @@ TfLiteStatus MicroInterpreterGraph::InvokeSubgraph(int subgraph_idx) {
 
     if (invoke_status == kTfLiteError) {
       MicroPrintf("Node %s (number %d) failed to invoke with status %d",
-                  OpNameFromRegistration(registration), current_operator_index_, invoke_status);
+                  OpNameFromRegistration(registration), current_operator_index_,
+                  invoke_status);
       return kTfLiteError;
     } else if (invoke_status != kTfLiteOk) {
       return invoke_status;

--- a/tensorflow/lite/micro/micro_interpreter_graph.h
+++ b/tensorflow/lite/micro/micro_interpreter_graph.h
@@ -87,8 +87,8 @@ class MicroInterpreterGraph : public MicroGraph {
   int GetCurrentSubgraphIndex() { return current_subgraph_index_; }
 
   // Get the current operator index inside a subgraph.
-  // The couple GetCurrentSubgraphIndex GetCurrentSubgraphIndex creates a unique identifier 
-  // of the operator inside the subgraph
+  // The couple GetCurrentSubgraphIndex GetCurrentSubgraphIndex creates a unique
+  // identifier of the operator inside the subgraph
   int GetCurrentOperatorIndex() { return current_operator_index_; }
 
   // Gets the list of allocations for each subgraph. This is the source of truth

--- a/tensorflow/lite/micro/micro_interpreter_graph.h
+++ b/tensorflow/lite/micro/micro_interpreter_graph.h
@@ -86,7 +86,12 @@ class MicroInterpreterGraph : public MicroGraph {
   // to be the subgraph of that operator.
   int GetCurrentSubgraphIndex() { return current_subgraph_index_; }
 
-  // Gets the list of alloctions for each subgraph. This is the source of truth
+  // Get the current operator index inside a subgraph.
+  // The couple GetCurrentSubgraphIndex GetCurrentSubgraphIndex creates a unique identifier 
+  // of the operator inside the subgraph
+  int GetCurrentOperatorIndex() { return current_operator_index_; }
+
+  // Gets the list of allocations for each subgraph. This is the source of truth
   // for all per-subgraph allocation data.
   SubgraphAllocations* GetAllocations() { return subgraph_allocations_; }
 
@@ -99,6 +104,7 @@ class MicroInterpreterGraph : public MicroGraph {
   MicroAllocator* allocator_;
   SubgraphAllocations* subgraph_allocations_ = nullptr;
   int current_subgraph_index_;
+  uint32_t current_operator_index_;
   MicroResourceVariables* resource_variables_;
   const flatbuffers::Vector<flatbuffers::Offset<SubGraph>>* subgraphs_;
 


### PR DESCRIPTION
In this way an AOT can add metadata that could then be accessed with the couple GetCurrentSubgraphIndex, GetCurrentOperatorIndex.
These can be accessed from tflite::GetMicroContext(context)->graph()

Refers to #2593
BUG=#2593