### PR TITLE
Update Ethos-U driver.

### DIFF
--- a/tensorflow/lite/micro/tools/make/ethos_u_core_driver_download.sh
+++ b/tensorflow/lite/micro/tools/make/ethos_u_core_driver_download.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Called with following arguments:
+# 1 - Path to the downloads folder which is typically
+#     tensorflow/lite/micro/tools/make/downloads
+#
+# This script is called from the Makefile and uses the following convention to
+# enable determination of sucess/failure:
+#
+#   - If the script is successful, the only output on stdout should be SUCCESS.
+#     The makefile checks for this particular string.
+#
+#   - Any string on stdout that is not SUCCESS will be shown in the makefile as
+#     the cause for the script to have failed.
+#
+#   - Any other informational prints should be on stderr.
+
+set -e
+
+TENSORFLOW_ROOT=${2}
+source ${TENSORFLOW_ROOT}tensorflow/lite/micro/tools/make/bash_helpers.sh
+
+DOWNLOADS_DIR=${1}
+if [ ! -d ${DOWNLOADS_DIR} ]; then
+  echo "The top-level downloads directory: ${DOWNLOADS_DIR} does not exist."
+  exit 1
+fi
+
+DOWNLOADED_ETHOS_U_CORE_DRIVER_PATH=${DOWNLOADS_DIR}/ethos_u_core_driver
+
+if [ -d ${DOWNLOADED_ETHOS_U_CORE_DRIVER_PATH} ]; then
+  echo >&2 "${DOWNLOADED_ETHOS_U_CORE_DRIVER_PATH} already exists, skipping the download."
+else
+  UNAME_S=`uname -s`
+  if [ ${UNAME_S} != Linux ]; then
+    echo "OS type ${UNAME_S} not supported."
+    exit 1
+  fi
+
+  git clone "https://review.mlplatform.org/ml/ethos-u/ethos-u-core-driver" \
+      ${DOWNLOADED_ETHOS_U_CORE_DRIVER_PATH} >&2
+  pushd ${DOWNLOADED_ETHOS_U_CORE_DRIVER_PATH} > /dev/null
+  git -c advice.detachedHead=false checkout 9622608a5cc318c0933bcce720b59737d03bfb6f
+  rm -rf .git
+  create_git_repo ./
+  popd > /dev/null
+
+fi
+
+echo "SUCCESS"

--- a/tensorflow/lite/micro/tools/make/ext_libs/ethos_u.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/ethos_u.inc
@@ -30,7 +30,10 @@ endif
 ETHOSU_DEFAULT_DOWNLOAD_DRIVER_PATH := $(MAKEFILE_DIR)/downloads/ethos_u_core_driver
 ETHOSU_DRIVER_PATH := $(ETHOSU_DEFAULT_DOWNLOAD_DRIVER_PATH)
 ifeq ($(ETHOSU_DRIVER_PATH), $(ETHOSU_DEFAULT_DOWNLOAD_DRIVER_PATH))
-  $(call $(or $(shell $(DOWNLOAD_SCRIPT) $(ETHOSU_URL) $(ETHOSU_MD5) $(ETHOSU_DRIVER_PATH) >&2 && echo SUCCESS), $(error $(DOWNLOAD_SCRIPT) failed)))
+DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ethos_u_core_driver_download.sh $(DOWNLOADS_DIR) $(TENSORFLOW_ROOT))
+  ifneq ($(DOWNLOAD_RESULT), SUCCESS)
+    $(error $(DOWNLOAD_SCRIPT) failed)
+  endif
 endif
 
 THIRD_PARTY_CC_HDRS += $(shell find $(ETHOSU_DRIVER_PATH)/include -name "*.h")

--- a/tensorflow/lite/micro/tools/make/ext_libs/ethos_u.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/ethos_u.inc
@@ -67,8 +67,8 @@ else ifeq ($(ETHOSU_ARCH), u65)
 else
   $(error "ETHOSU_ARCH=$(ETHOSU_ARCH) is not supported")
 endif
-CCFLAGS += ${ETHOSU_FLAGS}
-CXXFLAGS += ${ETHOSU_FLAGS}
+CCFLAGS += ${ETHOSU_FLAGS} ${ETHOSU_EXTRA_FLAGS}
+CXXFLAGS += ${ETHOSU_FLAGS} ${ETHOSU_EXTRA_FLAGS}
 
 # Convert downloaded person detect int8 model.
 $(GENERATED_SRCS_DIR)tensorflow/lite/micro/models/person_detect_model_data_vela.cc:

--- a/tensorflow/lite/micro/tools/make/third_party_downloads.inc
+++ b/tensorflow/lite/micro/tools/make/third_party_downloads.inc
@@ -40,5 +40,3 @@ EMBARC_MLI_PRE_COMPILED_URL := "https://github.com/foss-for-synopsys-dwc-arc-pro
 EMBARC_MLI_PRE_COMPILED_MD5 := "173990c2dde4efef6a2c95b92d1f0244"
 
 # Skip md5sum-check since ethos-u-core-driver download link is non-deterministic, see  https://github.com/google/gitiles/issues/84
-ETHOSU_URL := "https://review.mlplatform.org/plugins/gitiles/ml/ethos-u/ethos-u-core-driver/+archive/24455eedb9e8939f8a28ca0101a6f2d171e1b2f9.tar.gz"
-ETHOSU_MD5 := "SKIP_MD5_CHECK"


### PR DESCRIPTION
* Update Ethos-U driver to the latest (v24.05)
* Allow passing extra C flags to the driver from the command line.
* Fixes #2619

Note I tested with `TARGET=cortex_m_corstone_300 test_network_tester_test` and on real hardware as well built with:
```bash
make -j12 -f tensorflow/lite/micro/tools/make/Makefile \
TARGET=cortex_m_generic TARGET_ARCH=cortex-m55 \
CO_PROCESSOR=ethos_u ETHOSU_ARCH=u55 OPTIMIZED_KERNEL_DIR=ethos_u  \
CORE_OPTIMIZATION_LEVEL=-O2 KERNEL_OPTIMIZATION_LEVEL=-O2 \
THIRD_PARTY_KERNEL_OPTIMIZATION_LEVEL=-O2 \
TARGET_TOOLCHAIN_ROOT=/opt/arm-none-eabi/bin/ \ 
TARGET_TOOLCHAIN_PREFIX=arm-none-eabi- BUILD_TYPE=release microlite
```

BUG=#2619