### PR TITLE
build(py): add hexdump requirement

### DIFF
--- a/third_party/python_requirements.in
+++ b/third_party/python_requirements.in
@@ -26,6 +26,7 @@
 # is sensitive to the Python environment (interpreter version, etc.) in which
 # it is run.
 
+hexdump
 tensorflow
 twine
 numpy

--- a/third_party/python_requirements.txt
+++ b/third_party/python_requirements.txt
@@ -305,6 +305,9 @@ h5py==3.10.0 \
     --hash=sha256:f42e6c30698b520f0295d70157c4e202a9e402406f50dc08f5a7bc416b24e52d \
     --hash=sha256:fd6f6d1384a9f491732cee233b99cd4bfd6e838a8815cc86722f9d2ee64032af
     # via tensorflow
+hexdump==3.3 \
+    --hash=sha256:d781a43b0c16ace3f9366aade73e8ad3a7bd5137d58f0b45ab2d3f54876f20db
+    # via -r third_party/python_requirements.in
 idna==3.6 \
     --hash=sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca \
     --hash=sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f


### PR DESCRIPTION
Add the Python distribution package `hexdump`, to be used in tests
and utilities which display raw memory.

BUG=#2636