### PR TITLE
refactor: move tflite::Span to independent header

### DIFF
--- a/codegen/runtime/BUILD
+++ b/codegen/runtime/BUILD
@@ -14,5 +14,6 @@ cc_library(
         "//tensorflow/lite/micro:micro_context",
         "//tensorflow/lite/micro:micro_graph",
         "//tensorflow/lite/micro:micro_log",
+        "//tensorflow/lite/micro:span",
     ],
 )

--- a/codegen/runtime/micro_codegen_context.h
+++ b/codegen/runtime/micro_codegen_context.h
@@ -19,24 +19,9 @@ limitations under the License.
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/micro_context.h"
 #include "tensorflow/lite/micro/micro_graph.h"
+#include "tensorflow/lite/micro/span.h"
 
 namespace tflite {
-
-// A poor man's std::span, we should consider using the Pigweed span instead.
-template <typename T>
-class Span {
- public:
-  constexpr Span(T* data, size_t size) noexcept : data_(data), size_(size) {}
-
-  constexpr T& operator[](size_t idx) const noexcept { return *(data_ + idx); }
-
-  constexpr T* data() const noexcept { return data_; }
-  constexpr size_t size() const noexcept { return size_; }
-
- private:
-  T* data_;
-  size_t size_;
-};
 
 struct Subgraph {
   Span<const size_t> inputs;

--- a/tensorflow/lite/micro/BUILD
+++ b/tensorflow/lite/micro/BUILD
@@ -402,6 +402,12 @@ cc_library(
 )
 
 cc_library(
+    name = "span",
+    hdrs = ["span.h"],
+    copts = micro_copts(),
+)
+
+cc_library(
     name = "system_setup",
     srcs = [
         "system_setup.cc",

--- a/tensorflow/lite/micro/span.h
+++ b/tensorflow/lite/micro/span.h
@@ -1,0 +1,42 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// A poor man's std::span, we should consider using the Pigweed span instead.
+
+#ifndef TENSORFLOW_LITE_MICRO_SPAN_H_
+#define TENSORFLOW_LITE_MICRO_SPAN_H_
+
+#include <cstddef>
+
+namespace tflite {
+
+template <typename T>
+class Span {
+ public:
+  constexpr Span(T* data, size_t size) noexcept : data_(data), size_(size) {}
+
+  constexpr T& operator[](size_t idx) const noexcept { return *(data_ + idx); }
+
+  constexpr T* data() const noexcept { return data_; }
+  constexpr size_t size() const noexcept { return size_; }
+
+ private:
+  T* data_;
+  size_t size_;
+};
+
+}  // end namespace tflite
+
+#endif  // TENSORFLOW_LITE_MICRO_SPAN_H_

--- a/tensorflow/lite/micro/span.h
+++ b/tensorflow/lite/micro/span.h
@@ -13,8 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// A poor man's std::span, we should consider using the Pigweed span instead.
-
 #ifndef TENSORFLOW_LITE_MICRO_SPAN_H_
 #define TENSORFLOW_LITE_MICRO_SPAN_H_
 
@@ -22,6 +20,7 @@ limitations under the License.
 
 namespace tflite {
 
+// A poor man's std::span, we should consider using the Pigweed span instead.
 template <typename T>
 class Span {
  public:


### PR DESCRIPTION
Hoist the universally-useful tflite::Span out of
codegen/runtime/micro_codegen_context.h and into an independent header
usable from elsewhere in the project.

BUG=#2636