### PR TITLE
Fix Ethos-U driver build.

### DIFF
--- a/tensorflow/lite/micro/tools/make/ext_libs/ethos_u.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/ethos_u.inc
@@ -38,7 +38,14 @@ endif
 
 THIRD_PARTY_CC_HDRS += $(shell find $(ETHOSU_DRIVER_PATH)/include -name "*.h")
 ifeq (,$(ETHOSU_DRIVER_LIBS))
-    THIRD_PARTY_CC_SRCS += $(shell find $(ETHOSU_DRIVER_PATH)/src -name "*.c")
+    THIRD_PARTY_CC_SRCS = $(ETHOSU_DRIVER_PATH)/src/ethosu_pmu.c \
+                          $(ETHOSU_DRIVER_PATH)/src/ethosu_driver.c
+    # Add the Ethos-U device-specific driver source.
+    ifeq ($(ETHOSU_ARCH), u85)
+      THIRD_PARTY_CC_SRCS += $(ETHOSU_DRIVER_PATH)/src/ethosu_device_u85.c
+    else
+      THIRD_PARTY_CC_SRCS += $(ETHOSU_DRIVER_PATH)/src/ethosu_device_u55_u65.c
+    endif
 else
     MICROLITE_LIBS += $(ETHOSU_DRIVER_LIBS)
 endif


### PR DESCRIPTION
The updated Ethos-U driver v24.05 (introduced in #2626), contains a second set of device functions for the U85. This can cause the linker to link the functions of the U85, instead of the U55-U65, if they're both included in the driver's sources files. Therefore a glob pattern can no longer be used to collect the driver's source files in the Makefile.

BUG=#2639