### PR TITLE
Fix typo in Ethos-U Makefile.

### DIFF
--- a/tensorflow/lite/micro/tools/make/ext_libs/ethos_u.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/ethos_u.inc
@@ -38,8 +38,8 @@ endif
 
 THIRD_PARTY_CC_HDRS += $(shell find $(ETHOSU_DRIVER_PATH)/include -name "*.h")
 ifeq (,$(ETHOSU_DRIVER_LIBS))
-    THIRD_PARTY_CC_SRCS = $(ETHOSU_DRIVER_PATH)/src/ethosu_pmu.c \
-                          $(ETHOSU_DRIVER_PATH)/src/ethosu_driver.c
+    THIRD_PARTY_CC_SRCS += $(ETHOSU_DRIVER_PATH)/src/ethosu_pmu.c \
+                           $(ETHOSU_DRIVER_PATH)/src/ethosu_driver.c
     # Add the Ethos-U device-specific driver source.
     ifeq ($(ETHOSU_ARCH), u85)
       THIRD_PARTY_CC_SRCS += $(ETHOSU_DRIVER_PATH)/src/ethosu_device_u85.c


### PR DESCRIPTION
The core platform sources were overwritten by typo. I tested this patch by triggering the Cortex-M workflow manually, and it completed successfully. See the run here in my fork:

https://github.com/iabdalkader/tflite-micro/actions/runs/10113795223

BUG=#2639