### PR TITLE
Add py_library generate_test_for_model to tflite-micro package

### DIFF
--- a/python/tflite_micro/BUILD
+++ b/python/tflite_micro/BUILD
@@ -78,8 +78,8 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         requirement("numpy"),
-        "//tensorflow/lite/tools:flatbuffer_utils",
         "//tensorflow/lite/micro/tools:generate_test_for_model",
+        "//tensorflow/lite/tools:flatbuffer_utils",
     ],
 )
 
@@ -133,9 +133,9 @@ py_package(
     # in the tflm tree.
     packages = [
         "python.tflite_micro",
+        "tensorflow.lite.micro.tools.generate_test_for_model",
         "tensorflow.lite.python",
         "tensorflow.lite.tools.flatbuffer_utils",
-        "tensorflow.lite.micro.tools.generate_test_for_model",
     ],
     deps = [
         ":postinstall_check",

--- a/python/tflite_micro/BUILD
+++ b/python/tflite_micro/BUILD
@@ -79,6 +79,7 @@ py_library(
     deps = [
         requirement("numpy"),
         "//tensorflow/lite/tools:flatbuffer_utils",
+        "//tensorflow/lite/micro/tools:generate_test_for_model",
     ],
 )
 
@@ -134,6 +135,7 @@ py_package(
         "python.tflite_micro",
         "tensorflow.lite.python",
         "tensorflow.lite.tools.flatbuffer_utils",
+        "tensorflow.lite.micro.tools.generate_test_for_model",
     ],
     deps = [
         ":postinstall_check",

--- a/tensorflow/lite/micro/tools/BUILD
+++ b/tensorflow/lite/micro/tools/BUILD
@@ -32,6 +32,7 @@ py_library(
     name = "generate_test_for_model",
     srcs = ["generate_test_for_model.py"],
     srcs_version = "PY3",
+    visibility = ["//:__subpackages__"],
     deps = [
         "//tensorflow/lite/python:schema_py",
     ],


### PR DESCRIPTION
This enables running bazel run
..:generate_micro_mutable_op_resolver_from_model_test when tflite_micro is installed.

BUG=partially fixing https://github.com/tensorflow/tflite-micro/issues/2564