### PR TITLE
build(codegen): suppress noise in console output

### DIFF
--- a/codegen/build_def.bzl
+++ b/codegen/build_def.bzl
@@ -20,7 +20,7 @@ def tflm_inference_library(
         srcs = [tflite_model],
         outs = [name + ".h", name + ".cc"],
         tools = ["//codegen:code_generator"],
-        cmd = "$(location //codegen:code_generator) " +
+        cmd = "$(location //codegen:code_generator) --quiet " +
               "--model=$< --output_dir=$(RULEDIR) --output_name=%s" % name,
         visibility = ["//visibility:private"],
     )

--- a/codegen/code_generator.py
+++ b/codegen/code_generator.py
@@ -15,6 +15,7 @@
 """ Generates C/C++ source code capable of performing inference for a model. """
 
 import os
+import pathlib
 
 from absl import app
 from absl import flags
@@ -22,7 +23,6 @@ from collections.abc import Sequence
 
 from tflite_micro.codegen import inference_generator
 from tflite_micro.codegen import graph
-from tflite_micro.tensorflow.lite.tools import flatbuffer_utils
 
 # Usage information:
 # Default:
@@ -48,15 +48,33 @@ _OUTPUT_NAME = flags.DEFINE_string(
           "'model' basename."),
     required=False)
 
+_QUIET = flags.DEFINE_bool(
+    name="quiet",
+    default=False,
+    help="Suppress informational output (e.g., for use in for build system)",
+    required=False)
+
 
 def main(argv: Sequence[str]) -> None:
+  if _QUIET.value:
+    restore = os.environ.get("TF_CPP_MIN_LOG_LEVEL", "0")
+    os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+    from tflite_micro.tensorflow.lite.tools import flatbuffer_utils
+    os.environ["TF_CPP_MIN_LOG_LEVEL"] = restore
+  else:
+    from tflite_micro.tensorflow.lite.tools import flatbuffer_utils
+
   output_dir = _OUTPUT_DIR.value or os.path.dirname(_MODEL_PATH.value)
   output_name = _OUTPUT_NAME.value or os.path.splitext(
       os.path.basename(_MODEL_PATH.value))[0]
 
   model = flatbuffer_utils.read_model(_MODEL_PATH.value)
 
-  print("Generating inference code for model: {}".format(_MODEL_PATH.value))
+  if not _QUIET.value:
+    print("Generating inference code for model: {}".format(_MODEL_PATH.value))
+    output_path = pathlib.Path(output_dir) / output_name
+    print(f"Generating {output_path}.h")
+    print(f"Generating {output_path}.cc")
 
   inference_generator.generate(output_dir, output_name,
                                graph.OpCodeTable([model]), graph.Graph(model))

--- a/codegen/inference_generator.py
+++ b/codegen/inference_generator.py
@@ -35,7 +35,6 @@ class ModelData(TypedDict):
 
 def _render(output_file: pathlib.Path, template_file: pathlib.Path,
             model_data: ModelData) -> None:
-  print("Generating {}".format(output_file))
   t = template.Template(filename=str(template_file))
   with output_file.open('w+') as file:
     file.write(t.render(**model_data))


### PR DESCRIPTION
Add a --quiet option to the code_generator binary so that when it's used
within the build system, it doesn't print unexpected, distracting noise
to the console. Generally, compiler or generator commands don't print
output unless there's an error.

BUG=description