### PR TITLE
style: add .style.yapf to control yapf styling of Python code

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,3 @@
+[style]
+based_on_style = pep8
+indent_width = 2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,7 +190,7 @@ Below are some tips that might be useful and improve the development experience.
 
   ```
   pip install yapf
-  yapf log_parser.py -i --style='{based_on_style: pep8, indent_width: 2}'
+  yapf log_parser.py -i'
   ```
 
 * Add a git hook to check for code style etc. prior to creating a pull request:

--- a/tensorflow/lite/micro/tools/make/pigweed.patch
+++ b/tensorflow/lite/micro/tools/make/pigweed.patch
@@ -14,15 +14,6 @@ diff --git a/pw_presubmit/py/pw_presubmit/format_code.py b/pw_presubmit/py/pw_pr
 index 19d09546..c1ff6b5a 100755
 --- a/pw_presubmit/py/pw_presubmit/format_code.py
 +++ b/pw_presubmit/py/pw_presubmit/format_code.py
-@@ -142,7 +142,7 @@ def fix_go_format(files: Iterable[Path]) -> None:
- 
- 
- def _yapf(*args, **kwargs) -> subprocess.CompletedProcess:
--    return log_run(['python', '-m', 'yapf', '--parallel', *args],
-+    return log_run(['python', '-m', 'yapf', '--style', '{based_on_style:pep8,indent_width:2}', '--parallel', *args],
-                    capture_output=True,
-                    **kwargs)
- 
 @@ -229,11 +229,6 @@ def print_format_check(errors: Dict[Path, str],
              except ValueError:
                  return Path(path).resolve()


### PR DESCRIPTION
Add a .style.yapf file so yapf can be used to style Python code without
passing the project's style via command line option. Remove the
corresponding patch to pigweed's call to yapf, used by CI, and instead
let it too rely on .style.yapf. Remove the developer documentation's
instruction to use the command line option.

BUG=description