### PR TITLE
build(bazel): add integrity check to nnlib_hifi4 download

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -101,6 +101,7 @@ py_pkg_cc_deps(
 http_archive(
     name = "nnlib_hifi4",
     build_file = "@tflite_micro//third_party/xtensa/nnlib_hifi4:nnlib_hifi4.BUILD",
+    integrity = "sha256-ulZ+uY4dRsbDUMZbZtD972eghclWQrqYRb0Y4Znfyyc=",
     strip_prefix = "nnlib-hifi4-34f5f995f28d298ae2b6e2ba6e76c32a5cb34989",
     urls = ["https://github.com/foss-xtensa/nnlib-hifi4/archive/34f5f995f28d298ae2b6e2ba6e76c32a5cb34989.zip"],
 )


### PR DESCRIPTION
build(bazel): add integrity check to nnlib_hifi4 download

Add an integrity check to the http_archive() download of nnlib_hifi4 in
order to make the build more hermetic, reduce the security risk that a
remote file changes, and silence the noisy warning on the console during
the build:

    DEBUG: Rule 'nnlib_hifi4' indicated that a canonical reproducible
    form can be obtained by modifying arguments integrity[....]

BUG=description