### PR TITLE
ci(bazel): improve logging of bazel CI tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,6 +33,15 @@ build --cxxopt -std=c++17
 # Treat warnings as errors
 build --copt -Werror
 
+# Common options for --config=ci
+build:ci --curses=no 
+build:ci --color=no 
+build:ci --noshow_progress
+build:ci --noshow_loading_progress
+build:ci --show_timestamps
+build:ci --terminal_columns=0
+build:ci --verbose_failures
+
 # When building with the address sanitizer
 # E.g., bazel build --config asan
 build:asan --repo_env CC=clang

--- a/tensorflow/lite/micro/tools/ci_build/test_bazel.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_bazel.sh
@@ -15,6 +15,7 @@
 # ==============================================================================
 
 set -e
+set -x
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR=${SCRIPT_DIR}/../../../../..
@@ -27,8 +28,10 @@ source tensorflow/lite/micro/tools/ci_build/helper_functions.sh
 # having build_test but that was removed with #194.
 
 CC=clang readable_run bazel build ... \
+  --config=ci \
   --build_tag_filters=-no_oss
 CC=clang readable_run bazel test ... \
+  --config=ci \
   --test_tag_filters=-no_oss --build_tag_filters=-no_oss \
   --test_output=errors
 

--- a/tensorflow/lite/micro/tools/ci_build/test_bazel_asan.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_bazel_asan.sh
@@ -15,6 +15,7 @@
 # ==============================================================================
 
 set -e
+set -x
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR=${SCRIPT_DIR}/../../../../..
@@ -27,8 +28,11 @@ source tensorflow/lite/micro/tools/ci_build/helper_functions.sh
 # having build_test but that was removed with #194.
 
 CC=clang readable_run bazel build tensorflow/lite/micro/... \
+  --config=ci \
   --config=asan --build_tag_filters=-no_oss,-noasan
+
 CC=clang readable_run bazel test tensorflow/lite/micro/... \
+  --config=ci \
   --config=asan \
   --test_tag_filters=-no_oss,-noasan --build_tag_filters=-no_oss,-noasan \
   --test_output=errors

--- a/tensorflow/lite/micro/tools/ci_build/test_bazel_msan.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_bazel_msan.sh
@@ -15,6 +15,7 @@
 # ==============================================================================
 
 set -e
+set -x
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR=${SCRIPT_DIR}/../../../../..
@@ -27,8 +28,11 @@ source tensorflow/lite/micro/tools/ci_build/helper_functions.sh
 # having build_test but that was removed with #194.
 
 CC=clang readable_run bazel build tensorflow/lite/micro/... \
+  --config=ci \
   --config=msan --build_tag_filters=-no_oss,-nomsan
+
 CC=clang readable_run bazel test tensorflow/lite/micro/... \
+  --config=ci \
   --config=msan \
   --test_tag_filters=-no_oss,-nomsan --build_tag_filters=-no_oss,-nomsan \
   --test_output=errors

--- a/tensorflow/lite/micro/tools/ci_build/test_bazel_tflite_tools.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_bazel_tflite_tools.sh
@@ -15,6 +15,7 @@
 # ==============================================================================
 
 set -e
+set -x
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR=${SCRIPT_DIR}/../../../../..
@@ -23,4 +24,5 @@ cd "${ROOT_DIR}"
 source tensorflow/lite/micro/tools/ci_build/helper_functions.sh
 
 readable_run bazel test tensorflow/lite/tools/... \
+  --config=ci \
   --test_output=errors


### PR DESCRIPTION
Improve the logging of Bazel commands run in CI by setting several
options that turn off, e.g., progress messages intended for interactive
shells, and turn on, e.g., more verbose output when something fails.

--curses=no: Disables curses output (interactive console command
codes) to make the logs more compatible with non-interactive
environments, ensuring the output is clean and readable in logs.

--color=no: Disables colored output, as color codes can clutter
log files and are not typically useful in non-interactive
environments, making logs easier to parse.

--noshow_progress: Prevents progress updates (like the loading
spinner or percentage indicators) from being shown in the logs,
keeping the logs focused on actual output and errors rather than
transient progress information.

--noshow_loading_progress: Suppresses loading progress messages,
reducing noise in the logs and improving readability, as loading
messages are not usually helpful in debugging build failures.

--show_timestamps: Adds timestamps to each log entry, making it
easier to trace and debug performance issues or understand the
timing and duration of different steps in the build process.

--terminal_columns=0: Sets terminal columns to 0, allowing Bazel
to use the full width of the output log, which prevents line
wrapping issues and improves readability.

--verbose_failures: Enables detailed error information for failed
targets, including a full record of the command that caused the
failure.

BUG=#2742