### PR TITLE
build(bazel): introduce tflm_cc_* macros, refactoring away micro_copts

### DIFF
--- a/codegen/build_def.bzl
+++ b/codegen/build_def.bzl
@@ -1,6 +1,6 @@
 """ Build rule for generating ML inference code from TFLite model. """
 
-load("//tensorflow/lite/micro:build_def.bzl", "micro_copts")
+load("//tensorflow/lite/micro:build_def.bzl", "tflm_cc_library")
 
 def tflm_inference_library(
         name,
@@ -25,7 +25,7 @@ def tflm_inference_library(
         visibility = ["//visibility:private"],
     )
 
-    native.cc_library(
+    tflm_cc_library(
         name = name,
         hdrs = [name + ".h"],
         srcs = [name + ".cc"],
@@ -39,6 +39,5 @@ def tflm_inference_library(
             "//tensorflow/lite/micro:micro_common",
             "//tensorflow/lite/micro:micro_context",
         ],
-        copts = micro_copts(),
         visibility = visibility,
     )

--- a/codegen/runtime/BUILD
+++ b/codegen/runtime/BUILD
@@ -1,12 +1,11 @@
-load("//tensorflow/lite/micro:build_def.bzl", "micro_copts")
+load("//tensorflow/lite/micro:build_def.bzl", "tflm_cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+tflm_cc_library(
     name = "micro_codegen_context",
     srcs = ["micro_codegen_context.cc"],
     hdrs = ["micro_codegen_context.h"],
-    copts = micro_copts(),
     deps = [
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/kernels:op_macros",

--- a/python/tflite_micro/BUILD
+++ b/python/tflite_micro/BUILD
@@ -7,7 +7,7 @@ load("@rules_python//python:packaging.bzl", "py_package", "py_wheel")
 load("@tflm_pip_deps//:requirements.bzl", "requirement")
 load(
     "//tensorflow/lite/micro:build_def.bzl",
-    "micro_copts",
+    "tflm_cc_library",
 )
 load(
     "//tensorflow:extra_rules.bzl",
@@ -24,7 +24,7 @@ package_group(
     packages = tflm_python_op_resolver_friends(),
 )
 
-cc_library(
+tflm_cc_library(
     name = "python_ops_resolver",
     srcs = [
         "python_ops_resolver.cc",
@@ -32,7 +32,6 @@ cc_library(
     hdrs = [
         "python_ops_resolver.h",
     ],
-    copts = micro_copts(),
     visibility = [
         ":op_resolver_friends",
         "//tensorflow/lite/micro/integration_tests:__subpackages__",

--- a/signal/micro/kernels/BUILD
+++ b/signal/micro/kernels/BUILD
@@ -1,11 +1,11 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
-    "micro_copts",
+    "tflm_cc_library",
 )
 
 package(licenses = ["notice"])
 
-cc_library(
+tflm_cc_library(
     name = "register_signal_ops",
     srcs = [
         "delay.cc",
@@ -31,7 +31,6 @@ cc_library(
         "irfft.h",
         "rfft.h",
     ],
-    copts = micro_copts(),
     visibility = [
         "//tensorflow/lite/micro",
     ],

--- a/tensorflow/compiler/mlir/lite/core/api/BUILD
+++ b/tensorflow/compiler/mlir/lite/core/api/BUILD
@@ -1,15 +1,19 @@
 load("//tensorflow/lite:build_def.bzl", "tflite_copts")
-load("//tensorflow/lite/micro:build_def.bzl", "micro_copts")
+load(
+    "//tensorflow/lite/micro:build_def.bzl",
+    "tflm_cc_library",
+    "tflm_copts",
+)
 
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],
 )
 
-cc_library(
+tflm_cc_library(
     name = "error_reporter",
     srcs = ["error_reporter.cc"],
     hdrs = ["error_reporter.h"],
-    copts = tflite_copts() + micro_copts(),
+    copts = tflm_copts() + tflite_copts(),
     deps = [],
 )

--- a/tensorflow/lite/core/api/BUILD
+++ b/tensorflow/lite/core/api/BUILD
@@ -1,12 +1,16 @@
 load("//tensorflow/lite:build_def.bzl", "tflite_copts")
-load("//tensorflow/lite/micro:build_def.bzl", "micro_copts")
+load(
+    "//tensorflow/lite/micro:build_def.bzl",
+    "tflm_cc_library",
+    "tflm_copts",
+)
 
 package(
     default_visibility = ["//visibility:private"],
     licenses = ["notice"],
 )
 
-cc_library(
+tflm_cc_library(
     name = "api",
     srcs = [
         "flatbuffer_conversions.cc",
@@ -17,7 +21,7 @@ cc_library(
         "flatbuffer_conversions.h",
         "tensor_utils.h",
     ],
-    copts = tflite_copts() + micro_copts(),
+    copts = tflm_copts() + tflite_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":error_reporter",
@@ -33,13 +37,13 @@ cc_library(
 # also exported by the "api" target, so that targets which only want to depend
 # on these small abstract base class modules can express more fine-grained
 # dependencies without pulling in tensor_utils and flatbuffer_conversions.
-cc_library(
+tflm_cc_library(
     name = "error_reporter",
     hdrs = [
         "error_reporter.h",
         "//tensorflow/compiler/mlir/lite/core/api:error_reporter.h",
     ],
-    copts = tflite_copts() + micro_copts(),
+    copts = tflm_copts() + tflite_copts(),
     visibility = [
         "//visibility:public",
     ],

--- a/tensorflow/lite/experimental/microfrontend/lib/BUILD
+++ b/tensorflow/lite/experimental/microfrontend/lib/BUILD
@@ -144,7 +144,7 @@ cc_test(
     name = "filterbank_test",
     srcs = ["filterbank_test.cc"],
     # Setting copts for experimental code to [], but this code should be fixed
-    # to build with the default copts (micro_copts())
+    # to build with the default copts
     copts = [],
     deps = [
         ":filterbank",
@@ -156,7 +156,7 @@ cc_test(
     name = "frontend_test",
     srcs = ["frontend_test.cc"],
     # Setting copts for experimental code to [], but this code should be fixed
-    # to build with the default copts (micro_copts())
+    # to build with the default copts
     copts = [],
     deps = [
         ":frontend",
@@ -168,7 +168,7 @@ cc_test(
     name = "log_scale_test",
     srcs = ["log_scale_test.cc"],
     # Setting copts for experimental code to [], but this code should be fixed
-    # to build with the default copts (micro_copts())
+    # to build with the default copts
     copts = [],
     deps = [
         ":log_scale",
@@ -180,7 +180,7 @@ cc_test(
     name = "noise_reduction_test",
     srcs = ["noise_reduction_test.cc"],
     # Setting copts for experimental code to [], but this code should be fixed
-    # to build with the default copts (micro_copts())
+    # to build with the default copts
     copts = [],
     deps = [
         ":noise_reduction",
@@ -192,7 +192,7 @@ cc_test(
     name = "pcan_gain_control_test",
     srcs = ["pcan_gain_control_test.cc"],
     # Setting copts for experimental code to [], but this code should be fixed
-    # to build with the default copts (micro_copts())
+    # to build with the default copts
     copts = [],
     deps = [
         ":pcan_gain_control",
@@ -204,7 +204,7 @@ cc_test(
     name = "window_test",
     srcs = ["window_test.cc"],
     # Setting copts for experimental code to [], but this code should be fixed
-    # to build with the default copts (micro_copts())
+    # to build with the default copts
     copts = [],
     deps = [
         ":window",

--- a/tensorflow/lite/kernels/BUILD
+++ b/tensorflow/lite/kernels/BUILD
@@ -1,5 +1,9 @@
 load("//tensorflow/lite:build_def.bzl", "tflite_copts")
-load("//tensorflow/lite/micro:build_def.bzl", "micro_copts")
+load(
+    "//tensorflow/lite/micro:build_def.bzl",
+    "tflm_cc_library",
+    "tflm_copts",
+)
 
 package(
     default_visibility = [
@@ -17,7 +21,7 @@ cc_library(
     deps = ["//tensorflow/lite/micro:micro_log"],
 )
 
-cc_library(
+tflm_cc_library(
     name = "kernel_util",
     srcs = [
         "kernel_util.cc",
@@ -25,7 +29,7 @@ cc_library(
     hdrs = [
         "kernel_util.h",
     ],
-    copts = tflite_copts() + micro_copts(),
+    copts = tflm_copts() + tflite_copts(),
     deps = [
         "//tensorflow/lite:array",
         "//tensorflow/lite:kernel_api",

--- a/tensorflow/lite/kernels/internal/BUILD
+++ b/tensorflow/lite/kernels/internal/BUILD
@@ -1,5 +1,9 @@
 load("//tensorflow/lite:build_def.bzl", "tflite_copts")
-load("//tensorflow/lite/micro:build_def.bzl", "micro_copts")
+load(
+    "//tensorflow/lite/micro:build_def.bzl",
+    "tflm_cc_library",
+    "tflm_copts",
+)
 
 package(
     default_visibility = [
@@ -44,11 +48,11 @@ cc_library(
     copts = tflite_copts(),
 )
 
-cc_library(
+tflm_cc_library(
     name = "quantization_util",
     srcs = ["quantization_util.cc"],
     hdrs = ["quantization_util.h"],
-    copts = tflite_copts() + micro_copts(),
+    copts = tflm_copts() + tflite_copts(),
     deps = [
         ":compatibility",
         ":cppmath",

--- a/tensorflow/lite/micro/BUILD
+++ b/tensorflow/lite/micro/BUILD
@@ -1,7 +1,10 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(
     "//tensorflow/lite/micro:build_def.bzl",
-    "micro_copts",
+    "tflm_cc_binary",
+    "tflm_cc_library",
+    "tflm_cc_test",
+    "tflm_copts",
 )
 
 package(
@@ -18,15 +21,14 @@ package_group(
     packages = ["//tensorflow/lite/micro/..."],
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_compatibility",
     hdrs = [
         "compatibility.h",
     ],
-    copts = micro_copts(),
 )
 
-cc_library(
+tflm_cc_library(
     # TODO(b/187093492): Rename to micro_interpreter.
     name = "micro_framework",
     srcs = [
@@ -35,7 +37,6 @@ cc_library(
     hdrs = [
         "micro_interpreter.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":memory_helpers",
         ":micro_allocator",
@@ -53,7 +54,7 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_context",
     srcs = [
         "micro_context.cc",
@@ -61,7 +62,6 @@ cc_library(
     hdrs = [
         "micro_context.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":micro_common",
         ":micro_graph",
@@ -70,7 +70,7 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_interpreter_context",
     srcs = [
         "micro_interpreter_context.cc",
@@ -78,7 +78,6 @@ cc_library(
     hdrs = [
         "micro_interpreter_context.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":memory_helpers",
         ":micro_allocator",
@@ -90,18 +89,17 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_common",
     hdrs = [
         "micro_common.h",
     ],
-    copts = micro_copts(),
     deps = [
         "//tensorflow/lite/c:common",
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "fake_micro_context",
     srcs = [
         "fake_micro_context.cc",
@@ -109,7 +107,6 @@ cc_library(
     hdrs = [
         "fake_micro_context.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":memory_helpers",
         ":micro_arena_constants",
@@ -121,10 +118,9 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_graph",
     hdrs = ["micro_graph.h"],
-    copts = micro_copts(),
     deps = [
         ":micro_common",
         ":micro_resource_variable",
@@ -132,11 +128,10 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_interpreter_graph",
     srcs = ["micro_interpreter_graph.cc"],
     hdrs = ["micro_interpreter_graph.h"],
-    copts = micro_copts(),
     deps = [
         ":memory_helpers",
         ":micro_allocator",
@@ -152,11 +147,10 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "mock_micro_graph",
     srcs = ["mock_micro_graph.cc"],
     hdrs = ["mock_micro_graph.h"],
-    copts = micro_copts(),
     deps = [
         ":micro_allocator",
         ":micro_graph",
@@ -166,7 +160,7 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_allocator",
     srcs = [
         "micro_allocation_info.cc",
@@ -176,7 +170,6 @@ cc_library(
         "micro_allocation_info.h",
         "micro_allocator.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":flatbuffer_utils",
         ":memory_helpers",
@@ -200,20 +193,18 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_arena_constants",
     hdrs = [
         "micro_arena_constants.h",
     ],
-    copts = micro_copts(),
     deps = [],
 )
 
-cc_library(
+tflm_cc_library(
     name = "flatbuffer_utils",
     srcs = ["flatbuffer_utils.cc"],
     hdrs = ["flatbuffer_utils.h"],
-    copts = micro_copts(),
     deps = [
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/schema:schema_fbs",
@@ -221,11 +212,10 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "memory_helpers",
     srcs = ["memory_helpers.cc"],
     hdrs = ["memory_helpers.h"],
-    copts = micro_copts(),
     deps = [
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/kernels/internal:reference",
@@ -235,7 +225,7 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "test_helpers",
     srcs = [
         "test_helper_custom_ops.cc",
@@ -245,7 +235,6 @@ cc_library(
         "test_helper_custom_ops.h",
         "test_helpers.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":memory_helpers",
         ":micro_utils",
@@ -260,7 +249,7 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "op_resolvers",
     srcs = [
         "micro_op_resolver.cc",
@@ -269,7 +258,6 @@ cc_library(
         "micro_mutable_op_resolver.h",
         "micro_op_resolver.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":micro_compatibility",
         ":micro_log",
@@ -283,7 +271,7 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "debug_log",
     srcs = [
         "debug_log.cc",
@@ -291,10 +279,9 @@ cc_library(
     hdrs = [
         "debug_log.h",
     ],
-    copts = micro_copts(),
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_log",
     srcs = [
         "micro_log.cc",
@@ -302,13 +289,12 @@ cc_library(
     hdrs = [
         "micro_log.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":debug_log",
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_resource_variable",
     srcs = [
         "micro_resource_variable.cc",
@@ -316,7 +302,6 @@ cc_library(
     hdrs = [
         "micro_resource_variable.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":micro_allocator",
         ":micro_log",
@@ -326,7 +311,7 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_time",
     srcs = [
         "micro_time.cc",
@@ -334,19 +319,18 @@ cc_library(
     hdrs = [
         "micro_time.h",
     ],
-    copts = micro_copts() + ["-DTF_LITE_USE_CTIME"],
+    copts = tflm_copts() + ["-DTF_LITE_USE_CTIME"],
     deps = ["//tensorflow/lite/c:common"],
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_profiler_interface",
     hdrs = [
         "micro_profiler_interface.h",
     ],
-    copts = micro_copts(),
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_profiler",
     srcs = [
         "micro_profiler.cc",
@@ -354,7 +338,6 @@ cc_library(
     hdrs = [
         "micro_profiler.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":micro_compatibility",
         ":micro_log",
@@ -364,7 +347,7 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_utils",
     srcs = [
         "micro_utils.cc",
@@ -372,7 +355,6 @@ cc_library(
     hdrs = [
         "micro_utils.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":memory_helpers",
         ":micro_log",
@@ -381,7 +363,7 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "recording_allocators",
     srcs = [
         "recording_micro_allocator.cc",
@@ -390,7 +372,6 @@ cc_library(
         "recording_micro_allocator.h",
         "recording_micro_interpreter.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":micro_allocator",
         ":micro_compatibility",
@@ -401,22 +382,20 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "span",
     hdrs = ["span.h"],
-    copts = micro_copts(),
 )
 
-cc_library(
+tflm_cc_library(
     name = "static_vector",
     hdrs = ["static_vector.h"],
-    copts = micro_copts(),
     deps = [
         "//tensorflow/lite/kernels:op_macros",
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "system_setup",
     srcs = [
         "system_setup.cc",
@@ -424,7 +403,6 @@ cc_library(
     hdrs = [
         "system_setup.h",
     ],
-    copts = micro_copts(),
 )
 
 cc_test(

--- a/tensorflow/lite/micro/arena_allocator/BUILD
+++ b/tensorflow/lite/micro/arena_allocator/BUILD
@@ -1,6 +1,6 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
-    "micro_copts",
+    "tflm_cc_library",
 )
 
 package(
@@ -10,22 +10,20 @@ package(
     licenses = ["notice"],
 )
 
-cc_library(
+tflm_cc_library(
     name = "ibuffer_allocator",
     hdrs = [
         "ibuffer_allocator.h",
     ],
-    copts = micro_copts(),
     deps = [
         "//tensorflow/lite/c:common",
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "non_persistent_arena_buffer_allocator",
     srcs = ["non_persistent_arena_buffer_allocator.cc"],
     hdrs = ["non_persistent_arena_buffer_allocator.h"],
-    copts = micro_copts(),
     deps = [
         ":ibuffer_allocator",
         "//tensorflow/lite/c:common",
@@ -46,11 +44,10 @@ cc_test(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "persistent_arena_buffer_allocator",
     srcs = ["persistent_arena_buffer_allocator.cc"],
     hdrs = ["persistent_arena_buffer_allocator.h"],
-    copts = micro_copts(),
     deps = [
         ":ibuffer_allocator",
         "//tensorflow/lite/c:common",
@@ -71,7 +68,7 @@ cc_test(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "simple_memory_allocator",
     srcs = [
         "single_arena_buffer_allocator.cc",
@@ -79,7 +76,6 @@ cc_library(
     hdrs = [
         "single_arena_buffer_allocator.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":ibuffer_allocator",
         "//tensorflow/lite/c:common",
@@ -102,7 +98,7 @@ cc_test(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "recording_simple_memory_allocator",
     srcs = [
         "recording_single_arena_buffer_allocator.cc",
@@ -110,7 +106,6 @@ cc_library(
     hdrs = [
         "recording_single_arena_buffer_allocator.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":simple_memory_allocator",
         "//tensorflow/lite/kernels/internal:compatibility",

--- a/tensorflow/lite/micro/build_def.bzl
+++ b/tensorflow/lite/micro/build_def.bzl
@@ -1,10 +1,34 @@
-def micro_copts():
+def tflm_copts():
+    """Returns the default copts for targets in TFLM.
+
+    This function returns the default copts used by tflm_cc_* targets in TFLM.
+    It is typically unnecessary to use this function directly; however, it may
+    be useful when additively overriding the defaults for a particular target.
+    """
     return [
         "-Wall",
         "-Wno-unused-parameter",
         "-Wnon-virtual-dtor",
         "-DFLATBUFFERS_LOCALE_INDEPENDENT=0",
     ]
+
+def tflm_cc_binary(copts = tflm_copts(), **kwargs):
+    native.cc_binary(
+        copts = copts,
+        **kwargs
+    )
+
+def tflm_cc_library(copts = tflm_copts(), **kwargs):
+    native.cc_library(
+        copts = copts,
+        **kwargs
+    )
+
+def tflm_cc_test(copts = tflm_copts(), **kwargs):
+    native.cc_test(
+        copts = copts,
+        **kwargs
+    )
 
 def generate_cc_arrays(name, src, out, visibility = None):
     native.genrule(
@@ -70,7 +94,7 @@ def tflm_kernel_cc_library(
 
         all_srcs[target] = all_target_srcs
 
-    native.cc_library(
+    tflm_cc_library(
         name = name,
         srcs = select(all_srcs),
         hdrs = hdrs,

--- a/tensorflow/lite/micro/build_def.bzl
+++ b/tensorflow/lite/micro/build_def.bzl
@@ -12,6 +12,14 @@ def tflm_copts():
         "-DFLATBUFFERS_LOCALE_INDEPENDENT=0",
     ]
 
+def micro_copts():
+    """A deprecated alias for tflm_copts, kept for out-of-tree users.
+
+    This deprecated function serves as an alias for tflm_copts(). It is retained
+    for the benefit of code outside the open-source TFLM repository.
+    """
+    return tflm_copts()
+
 def tflm_cc_binary(copts = tflm_copts(), **kwargs):
     native.cc_binary(
         copts = copts,

--- a/tensorflow/lite/micro/examples/hello_world/BUILD
+++ b/tensorflow/lite/micro/examples/hello_world/BUILD
@@ -4,7 +4,7 @@ load("@rules_python//python:defs.bzl", "py_binary")
 load("@tflm_pip_deps//:requirements.bzl", "requirement")
 load(
     "//tensorflow/lite/micro:build_def.bzl",
-    "micro_copts",
+    "tflm_cc_library",
 )
 
 package(
@@ -13,7 +13,7 @@ package(
     licenses = ["notice"],
 )
 
-cc_library(
+tflm_cc_library(
     name = "model",
     srcs = [
         "//tensorflow/lite/micro/examples/hello_world/models:generated_hello_world_float_model_cc",
@@ -23,7 +23,6 @@ cc_library(
         "//tensorflow/lite/micro/examples/hello_world/models:generated_hello_world_float_model_hdr",
         "//tensorflow/lite/micro/examples/hello_world/models:generated_hello_world_int8_model_hdr",
     ],
-    copts = micro_copts(),
 )
 
 cc_test(

--- a/tensorflow/lite/micro/examples/memory_footprint/BUILD
+++ b/tensorflow/lite/micro/examples/memory_footprint/BUILD
@@ -1,7 +1,7 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
     "generate_cc_arrays",
-    "micro_copts",
+    "tflm_cc_library",
 )
 
 package(
@@ -20,7 +20,7 @@ generate_cc_arrays(
     out = "models/simple_add_model_model_data.h",
 )
 
-cc_library(
+tflm_cc_library(
     name = "simple_add_model_data",
     srcs = [
         ":generated_simple_add_model_cc",
@@ -28,7 +28,6 @@ cc_library(
     hdrs = [
         ":generated_simple_add_model_hdr",
     ],
-    copts = micro_copts(),
 )
 
 cc_binary(

--- a/tensorflow/lite/micro/integration_tests/seanet/add/BUILD
+++ b/tensorflow/lite/micro/integration_tests/seanet/add/BUILD
@@ -3,7 +3,8 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
     "generate_cc_arrays",
-    "micro_copts",
+    "tflm_cc_library",
+    "tflm_cc_test",
 )
 
 package(
@@ -829,7 +830,7 @@ generate_cc_arrays(
     out = "add16_golden_int16_test_data.h",
 )
 
-cc_library(
+tflm_cc_library(
     name = "models_and_testdata",
     srcs = [
         "generated_add0_golden_int16_test_data_cc",
@@ -971,15 +972,13 @@ cc_library(
         "generated_add9_input1_int16_test_data_hdr",
         "generated_add9_model_data_hdr",
     ],
-    copts = micro_copts(),
 )
 
-cc_test(
+tflm_cc_test(
     name = "integration_test",
     srcs = [
         "integration_tests.cc",
     ],
-    copts = micro_copts(),
     deps = [
         ":models_and_testdata",
         "//python/tflite_micro:python_ops_resolver",

--- a/tensorflow/lite/micro/integration_tests/seanet/conv/BUILD
+++ b/tensorflow/lite/micro/integration_tests/seanet/conv/BUILD
@@ -3,7 +3,8 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
     "generate_cc_arrays",
-    "micro_copts",
+    "tflm_cc_library",
+    "tflm_cc_test",
 )
 
 package(
@@ -805,7 +806,7 @@ generate_cc_arrays(
     out = "conv21_golden_int16_test_data.h",
 )
 
-cc_library(
+tflm_cc_library(
     name = "models_and_testdata",
     srcs = [
         "generated_conv0_golden_int16_test_data_cc",
@@ -943,15 +944,13 @@ cc_library(
         "generated_conv9_input0_int16_test_data_hdr",
         "generated_conv9_model_data_hdr",
     ],
-    copts = micro_copts(),
 )
 
-cc_test(
+tflm_cc_test(
     name = "integration_test",
     srcs = [
         "integration_tests.cc",
     ],
-    copts = micro_copts(),
     deps = [
         ":models_and_testdata",
         "//python/tflite_micro:python_ops_resolver",

--- a/tensorflow/lite/micro/integration_tests/seanet/leaky_relu/BUILD
+++ b/tensorflow/lite/micro/integration_tests/seanet/leaky_relu/BUILD
@@ -3,7 +3,8 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
     "generate_cc_arrays",
-    "micro_copts",
+    "tflm_cc_library",
+    "tflm_cc_test",
 )
 
 package(
@@ -841,7 +842,7 @@ generate_cc_arrays(
     out = "leaky_relu22_golden_int16_test_data.h",
 )
 
-cc_library(
+tflm_cc_library(
     name = "models_and_testdata",
     srcs = [
         "generated_leaky_relu0_golden_int16_test_data_cc",
@@ -985,15 +986,13 @@ cc_library(
         "generated_leaky_relu9_input0_int16_test_data_hdr",
         "generated_leaky_relu9_model_data_hdr",
     ],
-    copts = micro_copts(),
 )
 
-cc_test(
+tflm_cc_test(
     name = "integration_test",
     srcs = [
         "integration_tests.cc",
     ],
-    copts = micro_copts(),
     deps = [
         ":models_and_testdata",
         "//python/tflite_micro:python_ops_resolver",

--- a/tensorflow/lite/micro/integration_tests/seanet/pad/BUILD
+++ b/tensorflow/lite/micro/integration_tests/seanet/pad/BUILD
@@ -3,7 +3,8 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
     "generate_cc_arrays",
-    "micro_copts",
+    "tflm_cc_library",
+    "tflm_cc_test",
 )
 
 package(
@@ -697,7 +698,7 @@ generate_cc_arrays(
     out = "pad18_golden_int16_test_data.h",
 )
 
-cc_library(
+tflm_cc_library(
     name = "models_and_testdata",
     srcs = [
         "generated_pad0_golden_int16_test_data_cc",
@@ -817,15 +818,13 @@ cc_library(
         "generated_pad9_input0_int16_test_data_hdr",
         "generated_pad9_model_data_hdr",
     ],
-    copts = micro_copts(),
 )
 
-cc_test(
+tflm_cc_test(
     name = "integration_test",
     srcs = [
         "integration_tests.cc",
     ],
-    copts = micro_copts(),
     deps = [
         ":models_and_testdata",
         "//python/tflite_micro:python_ops_resolver",

--- a/tensorflow/lite/micro/integration_tests/seanet/quantize/BUILD
+++ b/tensorflow/lite/micro/integration_tests/seanet/quantize/BUILD
@@ -3,7 +3,8 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
     "generate_cc_arrays",
-    "micro_copts",
+    "tflm_cc_library",
+    "tflm_cc_test",
 )
 
 package(
@@ -85,7 +86,7 @@ generate_cc_arrays(
     out = "quantize1_golden_int32_test_data.h",
 )
 
-cc_library(
+tflm_cc_library(
     name = "models_and_testdata",
     srcs = [
         "generated_quantize0_golden_int16_test_data_cc",
@@ -103,15 +104,13 @@ cc_library(
         "generated_quantize1_input0_int16_test_data_hdr",
         "generated_quantize1_model_data_hdr",
     ],
-    copts = micro_copts(),
 )
 
-cc_test(
+tflm_cc_test(
     name = "integration_test",
     srcs = [
         "integration_tests.cc",
     ],
-    copts = micro_copts(),
     deps = [
         ":models_and_testdata",
         "//python/tflite_micro:python_ops_resolver",

--- a/tensorflow/lite/micro/integration_tests/seanet/strided_slice/BUILD
+++ b/tensorflow/lite/micro/integration_tests/seanet/strided_slice/BUILD
@@ -3,7 +3,8 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
     "generate_cc_arrays",
-    "micro_copts",
+    "tflm_cc_library",
+    "tflm_cc_test",
 )
 
 package(
@@ -1237,7 +1238,7 @@ generate_cc_arrays(
     out = "strided_slice33_golden_int16_test_data.h",
 )
 
-cc_library(
+tflm_cc_library(
     name = "models_and_testdata",
     srcs = [
         "generated_strided_slice0_golden_int16_test_data_cc",
@@ -1447,15 +1448,13 @@ cc_library(
         "generated_strided_slice9_input0_int16_test_data_hdr",
         "generated_strided_slice9_model_data_hdr",
     ],
-    copts = micro_copts(),
 )
 
-cc_test(
+tflm_cc_test(
     name = "integration_test",
     srcs = [
         "integration_tests.cc",
     ],
-    copts = micro_copts(),
     deps = [
         ":models_and_testdata",
         "//python/tflite_micro:python_ops_resolver",

--- a/tensorflow/lite/micro/integration_tests/seanet/sub/BUILD
+++ b/tensorflow/lite/micro/integration_tests/seanet/sub/BUILD
@@ -3,7 +3,8 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
     "generate_cc_arrays",
-    "micro_copts",
+    "tflm_cc_library",
+    "tflm_cc_test",
 )
 
 package(
@@ -253,7 +254,7 @@ generate_cc_arrays(
     out = "sub4_golden_int16_test_data.h",
 )
 
-cc_library(
+tflm_cc_library(
     name = "models_and_testdata",
     srcs = [
         "generated_sub0_golden_int16_test_data_cc",
@@ -299,15 +300,13 @@ cc_library(
         "generated_sub4_input1_int16_test_data_hdr",
         "generated_sub4_model_data_hdr",
     ],
-    copts = micro_copts(),
 )
 
-cc_test(
+tflm_cc_test(
     name = "integration_test",
     srcs = [
         "integration_tests.cc",
     ],
-    copts = micro_copts(),
     deps = [
         ":models_and_testdata",
         "//python/tflite_micro:python_ops_resolver",

--- a/tensorflow/lite/micro/integration_tests/seanet/transpose_conv/BUILD
+++ b/tensorflow/lite/micro/integration_tests/seanet/transpose_conv/BUILD
@@ -3,7 +3,8 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
     "generate_cc_arrays",
-    "micro_copts",
+    "tflm_cc_library",
+    "tflm_cc_test",
 )
 
 package(
@@ -253,7 +254,7 @@ generate_cc_arrays(
     out = "transpose_conv4_golden_int16_test_data.h",
 )
 
-cc_library(
+tflm_cc_library(
     name = "models_and_testdata",
     srcs = [
         "generated_transpose_conv0_golden_int16_test_data_cc",
@@ -299,15 +300,13 @@ cc_library(
         "generated_transpose_conv4_input1_int16_test_data_hdr",
         "generated_transpose_conv4_model_data_hdr",
     ],
-    copts = micro_copts(),
 )
 
-cc_test(
+tflm_cc_test(
     name = "integration_test",
     srcs = [
         "integration_tests.cc",
     ],
-    copts = micro_copts(),
     deps = [
         ":models_and_testdata",
         "//python/tflite_micro:python_ops_resolver",

--- a/tensorflow/lite/micro/integration_tests/templates/BUILD.mako
+++ b/tensorflow/lite/micro/integration_tests/templates/BUILD.mako
@@ -3,7 +3,8 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
     "generate_cc_arrays",
-    "micro_copts",
+    "tflm_cc_library",
+    "tflm_cc_test",
 )
 
 package(
@@ -46,7 +47,7 @@ generate_cc_arrays(
 )
 % endfor
 
-cc_library(
+tflm_cc_library(
     name = "models_and_testdata",
     srcs = [
 % for target in targets:
@@ -66,15 +67,13 @@ cc_library(
         "generated_${target}_golden_${output_dtype}_test_data_hdr",
 % endfor
     ],
-    copts = micro_copts(),
 )
 
-cc_test(
+tflm_cc_test(
     name = "integration_test",
     srcs = [
         "integration_tests.cc",
     ],
-    copts = micro_copts(),
     deps = [
         ":models_and_testdata",
         "//tensorflow/lite/micro:micro_framework",

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -1,5 +1,10 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
-load("//tensorflow/lite/micro:build_def.bzl", "micro_copts", "tflm_kernel_cc_library")
+load(
+    "//tensorflow/lite/micro:build_def.bzl",
+    "tflm_cc_library",
+    "tflm_copts",
+    "tflm_kernel_cc_library",
+)
 load(
     "//tensorflow:extra_rules.bzl",
     "tflm_kernel_friends",
@@ -37,17 +42,16 @@ package_group(
 # C++ libraries
 ####################################
 
-cc_library(
+tflm_cc_library(
     name = "activation_utils",
     hdrs = ["activation_utils.h"],
-    copts = micro_copts(),
     deps = [
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/kernels/internal:cppmath",
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "circular_buffer_flexbuffers_generated_data",
     srcs = [
         "circular_buffer_flexbuffers_generated_data.cc",
@@ -55,10 +59,9 @@ cc_library(
     hdrs = [
         "circular_buffer_flexbuffers_generated_data.h",
     ],
-    copts = micro_copts(),
 )
 
-cc_library(
+tflm_cc_library(
     name = "conv_test_common",
     srcs = [
         "conv_test_common.cc",
@@ -66,7 +69,6 @@ cc_library(
     hdrs = [
         "conv_test.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":kernel_runner",
         ":micro_ops",
@@ -76,7 +78,7 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "detection_postprocess_flexbuffers_generated_data",
     srcs = [
         "detection_postprocess_flexbuffers_generated_data.cc",
@@ -84,16 +86,14 @@ cc_library(
     hdrs = [
         "detection_postprocess_flexbuffers_generated_data.h",
     ],
-    copts = micro_copts(),
 )
 
-cc_library(
+tflm_cc_library(
     name = "kernel_runner",
     srcs = [
         "kernel_runner.cc",
     ],
     hdrs = ["kernel_runner.h"],
-    copts = micro_copts(),
     visibility = [
         "//visibility:public",
     ],
@@ -108,13 +108,12 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "kernel_util",
     srcs = [
         "kernel_util.cc",
     ],
     hdrs = ["kernel_util.h"],
-    copts = micro_copts(),
     visibility = [
         ":kernel_friends",
         ":tflite_micro",
@@ -129,21 +128,19 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "lstm_shared",
     hdrs = [
         "lstm_shared.h",
     ],
-    copts = micro_copts(),
     visibility = ["//tensorflow/lite/micro/kernels/testdata:__pkg__"],
 )
 
-cc_library(
+tflm_cc_library(
     name = "lstm_eval_test_lib",
     hdrs = [
         "lstm_eval_test.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":kernel_util",
         ":micro_ops",
@@ -153,13 +150,12 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_tensor_utils",
     srcs = [
         "micro_tensor_utils.cc",
     ],
     hdrs = ["micro_tensor_utils.h"],
-    copts = micro_copts(),
     deps = [
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/core:macros",
@@ -341,7 +337,7 @@ tflm_kernel_cc_library(
         xtensa_hifi_5_config(): glob(["xtensa/**/*.cc"]),
         xtensa_vision_p6_config(): glob(["xtensa/**/*.cc"]),
     },
-    copts = micro_copts() + select({
+    copts = tflm_copts() + select({
         xtensa_fusion_f1_config(): HIFI4_COPTS,
         xtensa_hifi_3_config(): HIFI3_COPTS,
         xtensa_hifi_3z_config(): HIFI4_COPTS,

--- a/tensorflow/lite/micro/memory_planner/BUILD
+++ b/tensorflow/lite/micro/memory_planner/BUILD
@@ -1,6 +1,6 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
-    "micro_copts",
+    "tflm_cc_library",
 )
 
 package(
@@ -10,19 +10,18 @@ package(
     licenses = ["notice"],
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_memory_planner",
     hdrs = [
         "micro_memory_planner.h",
     ],
-    copts = micro_copts(),
     deps = [
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/core/api",
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "linear_memory_planner",
     srcs = [
         "linear_memory_planner.cc",
@@ -30,7 +29,6 @@ cc_library(
     hdrs = [
         "linear_memory_planner.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":micro_memory_planner",
         "//tensorflow/lite/c:common",
@@ -39,7 +37,7 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "greedy_memory_planner",
     srcs = [
         "greedy_memory_planner.cc",
@@ -47,7 +45,6 @@ cc_library(
     hdrs = [
         "greedy_memory_planner.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":micro_memory_planner",
         "//tensorflow/lite/micro:micro_compatibility",
@@ -77,12 +74,11 @@ cc_test(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "memory_plan_struct",
     hdrs = [
         "memory_plan_struct.h",
     ],
-    copts = micro_copts(),
     deps = [
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/core/api",
@@ -91,13 +87,12 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "non_persistent_buffer_planner_shim",
     srcs = ["non_persistent_buffer_planner_shim.cc"],
     hdrs = [
         "non_persistent_buffer_planner_shim.h",
     ],
-    copts = micro_copts(),
     deps = [
         ":memory_plan_struct",
         ":micro_memory_planner",

--- a/tensorflow/lite/micro/python/interpreter/src/BUILD
+++ b/tensorflow/lite/micro/python/interpreter/src/BUILD
@@ -1,6 +1,6 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
-    "micro_copts",
+    "tflm_cc_library",
 )
 load(
     "//tensorflow:extra_rules.bzl",
@@ -18,13 +18,12 @@ package_group(
 )
 
 # TODO(b/286456378): remove once all internal usage is fixed.
-cc_library(
+tflm_cc_library(
     name = "python_ops_resolver",
     srcs = [],
     hdrs = [
         "python_ops_resolver.h",
     ],
-    copts = micro_copts(),
     visibility = [":op_resolver_friends"],
     deps = [
         "//python/tflite_micro:python_ops_resolver",

--- a/tensorflow/lite/micro/tflite_bridge/BUILD
+++ b/tensorflow/lite/micro/tflite_bridge/BUILD
@@ -1,6 +1,6 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
-    "micro_copts",
+    "tflm_cc_library",
 )
 
 package(
@@ -9,7 +9,7 @@ package(
     licenses = ["notice"],
 )
 
-cc_library(
+tflm_cc_library(
     name = "flatbuffer_conversions_bridge",
     srcs = [
         "flatbuffer_conversions_bridge.cc",
@@ -17,7 +17,6 @@ cc_library(
     hdrs = [
         "flatbuffer_conversions_bridge.h",
     ],
-    copts = micro_copts(),
     visibility = [
         "//tensorflow/lite/micro:__pkg__",
     ],
@@ -29,7 +28,7 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_error_reporter",
     srcs = [
         "micro_error_reporter.cc",
@@ -37,7 +36,6 @@ cc_library(
     hdrs = [
         "micro_error_reporter.h",
     ],
-    copts = micro_copts(),
     deps = [
         "//tensorflow/lite/core/api:error_reporter",
         "//tensorflow/lite/micro:micro_compatibility",

--- a/tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver/templates/BUILD.mako
+++ b/tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver/templates/BUILD.mako
@@ -3,7 +3,7 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
     "generate_cc_arrays",
-    "micro_copts",
+    "tflm_cc_test",
 )
 
 package(
@@ -43,7 +43,7 @@ generate_cc_arrays(
   out = "${target}_golden_${output_dtype}_test_data.h",
 )
 
-cc_library(
+tflm_cc_library(
     name = "models_and_testdata",
     srcs = [
         "generated_${target}_model_data_cc",
@@ -59,7 +59,6 @@ cc_library(
         "generated_${target}_golden_${output_dtype}_test_data_hdr",
 % endif
     ],
-    copts = micro_copts(),
 )
 
 cc_library(
@@ -68,12 +67,11 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
-cc_test(
+tflm_cc_test(
     name = "micro_mutable_op_resolver_test",
     srcs = [
         "micro_mutable_op_resolver_test.cc",
     ],
-    copts = micro_copts(),
     deps = [
         ":gen_micro_op_resolver",
         ":models_and_testdata",


### PR DESCRIPTION
Remove micro_copts() by replacing every cc_* target that used
them with a tflm_cc_* equivalent, and setting those common copts
in one place, inside the tflm_cc_* macro.

This is the first of several commits introducing tflm_cc_* macros
in place of cc_binary, cc_library, and cc_test. Motivated by the
upcoming need to support conditional compilation, the objective
is to centralize build configuration rather than requiring (and
remembering that) each cc_* target in the project add the same
common attributes such as compiler options and select()ed

Alternatives such as setting global options on the command line
or in .bazelrc, even if simplified with a --config option, fail
to preserve flags and hooks for configuration in the case TFLM is
used as an external repository by an application project. Nor is
it easy in that case for individual targets to override an
otherwise global setting.

BUG=#2636