### PR TITLE
build(bazel): replace cc_* with tflm_cc_* in remaining TFLM code

### DIFF
--- a/tensorflow/lite/micro/BUILD
+++ b/tensorflow/lite/micro/BUILD
@@ -405,7 +405,7 @@ tflm_cc_library(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "micro_log_test",
     srcs = [
         "micro_log_test.cc",
@@ -417,7 +417,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "micro_mutable_op_resolver_test",
     srcs = [
         "micro_mutable_op_resolver_test.cc",
@@ -429,7 +429,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "micro_interpreter_context_test",
     srcs = [
         "micro_interpreter_context_test.cc",
@@ -443,7 +443,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "fake_micro_context_test",
     srcs = [
         "fake_micro_context_test.cc",
@@ -457,7 +457,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "micro_interpreter_test",
     srcs = [
         "micro_interpreter_test.cc",
@@ -474,7 +474,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "micro_allocator_test",
     srcs = [
         "micro_allocator_test.cc",
@@ -492,7 +492,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "micro_allocation_info_test",
     srcs = [
         "micro_allocation_info_test.cc",
@@ -504,7 +504,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "recording_micro_allocator_test",
     srcs = [
         "recording_micro_allocator_test.cc",
@@ -519,7 +519,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "flatbuffer_utils_test",
     srcs = [
         "flatbuffer_utils_test.cc",
@@ -534,7 +534,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "memory_helpers_test",
     srcs = [
         "memory_helpers_test.cc",
@@ -546,7 +546,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "span_test",
     size = "small",
     srcs = [
@@ -558,7 +558,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "testing_helpers_test",
     srcs = [
         "testing_helpers_test.cc",
@@ -570,7 +570,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "micro_utils_test",
     srcs = [
         "micro_utils_test.cc",
@@ -581,7 +581,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "micro_time_test",
     srcs = [
         "micro_time_test.cc",
@@ -592,7 +592,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "micro_resource_variable_test",
     srcs = ["micro_resource_variable_test.cc"],
     deps = [
@@ -601,7 +601,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "memory_arena_threshold_test",
     srcs = [
         "memory_arena_threshold_test.cc",
@@ -615,7 +615,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "static_vector_test",
     size = "small",
     srcs = [

--- a/tensorflow/lite/micro/arena_allocator/BUILD
+++ b/tensorflow/lite/micro/arena_allocator/BUILD
@@ -1,6 +1,7 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
     "tflm_cc_library",
+    "tflm_cc_test",
 )
 
 package(
@@ -34,7 +35,7 @@ tflm_cc_library(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "non_persistent_arena_buffer_allocator_test",
     srcs = ["non_persistent_arena_buffer_allocator_test.cc"],
     deps = [
@@ -58,7 +59,7 @@ tflm_cc_library(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "persistent_arena_buffer_allocator_test",
     srcs = ["persistent_arena_buffer_allocator_test.cc"],
     deps = [
@@ -86,7 +87,7 @@ tflm_cc_library(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "simple_memory_allocator_test",
     srcs = [
         "single_arena_buffer_allocator_test.cc",
@@ -114,7 +115,7 @@ tflm_cc_library(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "recording_simple_memory_allocator_test",
     srcs = [
         "recording_single_arena_buffer_allocator_test.cc",

--- a/tensorflow/lite/micro/benchmarks/BUILD
+++ b/tensorflow/lite/micro/benchmarks/BUILD
@@ -1,5 +1,12 @@
 # Description:
 #   TensorFlow Lite microcontroller benchmarks.
+
+load(
+    "//tensorflow/lite/micro:build_def.bzl",
+    "tflm_cc_binary",
+    "tflm_cc_library",
+)
+
 package(
     # Disabling layering_check because of http://b/177257332
     features = ["-layering_check"],
@@ -11,7 +18,7 @@ package_group(
     packages = ["//tensorflow/lite/micro"],
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_benchmark",
     hdrs = [
         "micro_benchmark.h",
@@ -29,7 +36,7 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "keyword_scrambled_model_data",
     srcs = [
         "//tensorflow/lite/micro/models:generated_keyword_scrambled_model_cc",
@@ -42,7 +49,7 @@ cc_library(
     ],
 )
 
-cc_binary(
+tflm_cc_binary(
     name = "keyword_benchmark",
     srcs = ["keyword_benchmark.cc"],
     deps = [
@@ -57,7 +64,7 @@ cc_binary(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "keyword_scrambled_8bit_model_data",
     srcs = [
         "//tensorflow/lite/micro/models:generated_keyword_scrambled_8bit_model_cc",
@@ -68,7 +75,7 @@ cc_library(
     visibility = ["//visibility:private"],
 )
 
-cc_binary(
+tflm_cc_binary(
     name = "keyword_benchmark_8bit",
     srcs = ["keyword_benchmark_8bit.cc"],
     deps = [
@@ -82,7 +89,7 @@ cc_binary(
     ],
 )
 
-cc_binary(
+tflm_cc_binary(
     name = "person_detection_benchmark",
     srcs = ["person_detection_benchmark.cc"],
     deps = [

--- a/tensorflow/lite/micro/examples/hello_world/BUILD
+++ b/tensorflow/lite/micro/examples/hello_world/BUILD
@@ -5,6 +5,7 @@ load("@tflm_pip_deps//:requirements.bzl", "requirement")
 load(
     "//tensorflow/lite/micro:build_def.bzl",
     "tflm_cc_library",
+    "tflm_cc_test",
 )
 
 package(
@@ -25,7 +26,7 @@ tflm_cc_library(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "hello_world_test",
     srcs = [
         "hello_world_test.cc",

--- a/tensorflow/lite/micro/examples/micro_speech/BUILD
+++ b/tensorflow/lite/micro/examples/micro_speech/BUILD
@@ -2,7 +2,12 @@
 #   TensorFlow Lite microcontroller example.
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("@tflm_pip_deps//:requirements.bzl", "requirement")
-load("//tensorflow/lite/micro:build_def.bzl", "generate_cc_arrays")
+load(
+    "//tensorflow/lite/micro:build_def.bzl",
+    "generate_cc_arrays",
+    "tflm_cc_library",
+    "tflm_cc_test",
+)
 
 package(
     default_visibility = ["//visibility:public"],
@@ -107,7 +112,7 @@ generate_cc_arrays(
     out = "models/audio_preprocessor_int8_model_data.h",
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_speech_model_data",
     srcs = [
         ":generated_micro_speech_model_cc",
@@ -117,7 +122,7 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "audio_preprocessor_model_data",
     srcs = [
         ":generated_audio_preprocessor_model_cc",
@@ -127,7 +132,7 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "audio_sample_test_data_30ms",
     srcs = [
         ":generated_no_30ms_wav_cc",
@@ -139,7 +144,7 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "audio_sample_test_data_1000ms",
     srcs = [
         ":generated_no_1000ms_wav_cc",
@@ -155,14 +160,14 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_model_settings",
     hdrs = [
         "micro_model_settings.h",
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "micro_speech_test",
     srcs = [
         "micro_speech_test.cc",

--- a/tensorflow/lite/micro/examples/person_detection/BUILD
+++ b/tensorflow/lite/micro/examples/person_detection/BUILD
@@ -1,6 +1,12 @@
 # Description:
 #   TensorFlow Lite for Microcontrollers Vision Example.
-load("//tensorflow/lite/micro:build_def.bzl", "generate_cc_arrays")
+load(
+    "//tensorflow/lite/micro:build_def.bzl",
+    "generate_cc_arrays",
+    "tflm_cc_binary",
+    "tflm_cc_library",
+    "tflm_cc_test",
+)
 
 package(
     default_visibility = ["//visibility:public"],
@@ -9,7 +15,7 @@ package(
     licenses = ["notice"],
 )
 
-cc_library(
+tflm_cc_library(
     name = "model_settings",
     srcs = [
         "model_settings.cc",
@@ -43,7 +49,7 @@ generate_cc_arrays(
     out = "testdata/person_image_data.h",
 )
 
-cc_library(
+tflm_cc_library(
     name = "person_detect_model_data",
     srcs = [
         "//tensorflow/lite/micro/models:generated_person_detect_model_cc",
@@ -53,7 +59,7 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "simple_images_test_data",
     srcs = [
         ":generated_no_person_bmp_cc",
@@ -68,7 +74,7 @@ cc_library(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "person_detection_test",
     srcs = ["person_detection_test.cc"],
     deps = [
@@ -84,7 +90,7 @@ cc_test(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "image_provider",
     srcs = [
         "image_provider.cc",
@@ -98,7 +104,7 @@ cc_library(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "image_provider_test",
     srcs = [
         "image_provider_test.cc",
@@ -111,7 +117,7 @@ cc_test(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "detection_responder",
     srcs = [
         "detection_responder.cc",
@@ -125,7 +131,7 @@ cc_library(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "detection_responder_test",
     srcs = [
         "detection_responder_test.cc",
@@ -136,7 +142,7 @@ cc_test(
     ],
 )
 
-cc_binary(
+tflm_cc_binary(
     name = "person_detection",
     srcs = [
         "main.cc",

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -2,6 +2,7 @@ load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load(
     "//tensorflow/lite/micro:build_def.bzl",
     "tflm_cc_library",
+    "tflm_cc_test",
     "tflm_copts",
     "tflm_kernel_cc_library",
 )
@@ -387,7 +388,7 @@ tflm_kernel_cc_library(
 # C++ tests
 ####################################
 
-cc_test(
+tflm_cc_test(
     name = "activations_test",
     srcs = [
         "activations_test.cc",
@@ -401,7 +402,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "add_n_test",
     srcs = [
         "add_n_test.cc",
@@ -416,7 +417,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "add_test",
     srcs = [
         "add_test.cc",
@@ -430,7 +431,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "arg_min_max_test",
     srcs = [
         "arg_min_max_test.cc",
@@ -444,7 +445,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "batch_matmul_test",
     srcs = [
         "batch_matmul_test.cc",
@@ -458,7 +459,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "batch_to_space_nd_test",
     srcs = [
         "batch_to_space_nd_test.cc",
@@ -472,7 +473,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "broadcast_args_test",
     srcs = [
         "broadcast_args_test.cc",
@@ -486,7 +487,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "broadcast_to_test",
     srcs = [
         "broadcast_to_test.cc",
@@ -500,7 +501,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "call_once_test",
     srcs = ["call_once_test.cc"],
     deps = [
@@ -512,7 +513,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "cast_test",
     srcs = ["cast_test.cc"],
     deps = [
@@ -525,7 +526,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "ceil_test",
     srcs = [
         "ceil_test.cc",
@@ -539,7 +540,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "circular_buffer_test",
     srcs = [
         "circular_buffer_test.cc",
@@ -555,7 +556,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "comparisons_test",
     srcs = [
         "comparisons_test.cc",
@@ -568,7 +569,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "concatenation_test",
     srcs = [
         "concatenation_test.cc",
@@ -581,7 +582,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "conv_test",
     srcs = [
         "conv_test.cc",
@@ -597,7 +598,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "cumsum_test",
     srcs = [
         "cumsum_test.cc",
@@ -612,7 +613,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "depth_to_space_test",
     srcs = [
         "depth_to_space_test.cc",
@@ -627,7 +628,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "depthwise_conv_test",
     srcs = [
         "depthwise_conv_test.cc",
@@ -641,7 +642,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "dequantize_test",
     srcs = [
         "dequantize_test.cc",
@@ -654,7 +655,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "detection_postprocess_test",
     srcs = [
         "detection_postprocess_test.cc",
@@ -670,7 +671,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "div_test",
     srcs = [
         "div_test.cc",
@@ -683,7 +684,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "elementwise_test",
     srcs = ["elementwise_test.cc"],
     deps = [
@@ -696,7 +697,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "elu_test",
     srcs = [
         "elu_test.cc",
@@ -711,7 +712,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "embedding_lookup_test",
     srcs = [
         "embedding_lookup_test.cc",
@@ -726,7 +727,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "exp_test",
     srcs = ["exp_test.cc"],
     deps = [
@@ -739,7 +740,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "expand_dims_test",
     srcs = ["expand_dims_test.cc"],
     deps = [
@@ -752,7 +753,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "fill_test",
     srcs = [
         "fill_test.cc",
@@ -766,7 +767,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "floor_div_test",
     srcs = ["floor_div_test.cc"],
     deps = [
@@ -779,7 +780,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "floor_mod_test",
     srcs = ["floor_mod_test.cc"],
     deps = [
@@ -792,7 +793,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "floor_test",
     srcs = [
         "floor_test.cc",
@@ -806,7 +807,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "fully_connected_test",
     srcs = [
         "fully_connected_test.cc",
@@ -821,7 +822,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "gather_test",
     srcs = [
         "gather_test.cc",
@@ -836,7 +837,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "gather_nd_test",
     srcs = [
         "gather_nd_test.cc",
@@ -851,7 +852,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "hard_swish_test",
     srcs = ["hard_swish_test.cc"],
     deps = [
@@ -863,7 +864,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "if_test",
     srcs = ["if_test.cc"],
     deps = [
@@ -877,7 +878,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "l2norm_test",
     srcs = [
         "l2norm_test.cc",
@@ -891,7 +892,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "l2_pool_2d_test",
     srcs = [
         "l2_pool_2d_test.cc",
@@ -906,7 +907,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "leaky_relu_test",
     srcs = [
         "leaky_relu_test.cc",
@@ -921,7 +922,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "logical_test",
     srcs = [
         "logical_test.cc",
@@ -935,7 +936,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "logistic_test",
     srcs = [
         "logistic_test.cc",
@@ -949,7 +950,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "log_softmax_test",
     srcs = [
         "log_softmax_test.cc",
@@ -964,7 +965,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "lstm_eval_test",
     srcs = [
         "lstm_eval_test.cc",
@@ -976,7 +977,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "maximum_minimum_test",
     srcs = [
         "maximum_minimum_test.cc",
@@ -990,7 +991,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "mirror_pad_test",
     srcs = [
         "mirror_pad_test.cc",
@@ -1004,7 +1005,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "mul_test",
     srcs = [
         "mul_test.cc",
@@ -1017,7 +1018,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "neg_test",
     srcs = [
         "neg_test.cc",
@@ -1031,7 +1032,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "pack_test",
     srcs = [
         "pack_test.cc",
@@ -1045,7 +1046,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "pad_test",
     srcs = [
         "pad_test.cc",
@@ -1063,7 +1064,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "pooling_test",
     srcs = [
         "pooling_test.cc",
@@ -1076,7 +1077,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "prelu_test",
     srcs = [
         "prelu_test.cc",
@@ -1089,7 +1090,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "quantization_util_test",
     srcs = [
         "quantization_util_test.cc",
@@ -1101,7 +1102,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "quantize_test",
     srcs = [
         "quantize_test.cc",
@@ -1114,7 +1115,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "reduce_test",
     srcs = [
         "reduce_test.cc",
@@ -1128,7 +1129,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "reshape_test",
     srcs = [
         "reshape_test.cc",
@@ -1143,7 +1144,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "resize_bilinear_test",
     srcs = [
         "resize_bilinear_test.cc",
@@ -1157,7 +1158,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "resize_nearest_neighbor_test",
     srcs = [
         "resize_nearest_neighbor_test.cc",
@@ -1171,7 +1172,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "round_test",
     srcs = [
         "round_test.cc",
@@ -1185,7 +1186,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "select_test",
     srcs = [
         "select_test.cc",
@@ -1199,7 +1200,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "shape_test",
     srcs = ["shape_test.cc"],
     deps = [
@@ -1211,7 +1212,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "slice_test",
     srcs = ["slice_test.cc"],
     deps = [
@@ -1223,7 +1224,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "softmax_test",
     srcs = [
         "softmax_test.cc",
@@ -1237,7 +1238,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "space_to_batch_nd_test",
     srcs = [
         "space_to_batch_nd_test.cc",
@@ -1251,7 +1252,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "space_to_depth_test",
     srcs = [
         "space_to_depth_test.cc",
@@ -1266,7 +1267,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "split_test",
     srcs = [
         "split_test.cc",
@@ -1281,7 +1282,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "split_v_test",
     srcs = [
         "split_v_test.cc",
@@ -1296,7 +1297,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "squared_difference_test",
     srcs = [
         "squared_difference_test.cc",
@@ -1309,7 +1310,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "squeeze_test",
     srcs = ["squeeze_test.cc"],
     deps = [
@@ -1321,7 +1322,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "strided_slice_test",
     srcs = [
         "strided_slice_test.cc",
@@ -1335,7 +1336,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "sub_test",
     srcs = [
         "sub_test.cc",
@@ -1348,7 +1349,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "svdf_test",
     srcs = [
         "svdf_test.cc",
@@ -1361,7 +1362,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "tanh_test",
     srcs = ["tanh_test.cc"],
     deps = [
@@ -1372,7 +1373,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "transpose_test",
     srcs = ["transpose_test.cc"],
     deps = [
@@ -1383,7 +1384,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "transpose_conv_test",
     srcs = [
         "transpose_conv_test.cc",
@@ -1399,7 +1400,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "unidirectional_sequence_lstm_test",
     srcs = [
         "unidirectional_sequence_lstm_test.cc",
@@ -1416,7 +1417,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "unpack_test",
     srcs = [
         "unpack_test.cc",
@@ -1430,7 +1431,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "while_test",
     srcs = [
         "while_test.cc",
@@ -1444,7 +1445,7 @@ cc_test(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "zeros_like_test",
     srcs = ["zeros_like_test.cc"],
     deps = [

--- a/tensorflow/lite/micro/kernels/testdata/BUILD
+++ b/tensorflow/lite/micro/kernels/testdata/BUILD
@@ -1,5 +1,9 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("@tflm_pip_deps//:requirements.bzl", "requirement")
+load(
+    "//tensorflow/lite/micro:build_def.bzl",
+    "tflm_cc_library",
+)
 
 package(
     default_visibility = ["//tensorflow/lite/micro/kernels:__pkg__"],
@@ -12,14 +16,14 @@ package(
 # C++ libraries
 ####################################
 
-cc_library(
+tflm_cc_library(
     name = "conv_test_data",
     srcs = ["conv_test_data.cc"],
     hdrs = ["conv_test_data.h"],
     deps = ["//tensorflow/lite/c:common"],
 )
 
-cc_library(
+tflm_cc_library(
     name = "lstm_test_data",
     srcs = ["lstm_test_data.cc"],
     hdrs = [

--- a/tensorflow/lite/micro/testing/BUILD
+++ b/tensorflow/lite/micro/testing/BUILD
@@ -1,6 +1,11 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("@tflm_pip_deps//:requirements.bzl", "requirement")
 load(
+    "//tensorflow/lite/micro:build_def.bzl",
+    "tflm_cc_library",
+    "tflm_cc_test",
+)
+load(
     "//tensorflow:extra_rules.bzl",
     "tflm_kernel_friends",
 )
@@ -26,7 +31,7 @@ package_group(
     packages = tflm_kernel_friends(),
 )
 
-cc_library(
+tflm_cc_library(
     name = "micro_test",
     hdrs = [
         "micro_test.h",
@@ -46,7 +51,7 @@ cc_library(
     ],
 )
 
-cc_test(
+tflm_cc_test(
     name = "util_test",
     srcs = [
         "util_test.cc",
@@ -56,7 +61,7 @@ cc_test(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "test_conv_model",
     srcs = [
         "test_conv_model.cc",

--- a/tensorflow/lite/micro/tools/benchmarking/BUILD
+++ b/tensorflow/lite/micro/tools/benchmarking/BUILD
@@ -1,11 +1,17 @@
-cc_library(
+load(
+    "//tensorflow/lite/micro:build_def.bzl",
+    "tflm_cc_binary",
+    "tflm_cc_library",
+)
+
+tflm_cc_library(
     name = "op_resolver",
     hdrs = ["op_resolver.h"],
     visibility = ["//tensorflow/lite/micro/tools:__subpackages__"],
     deps = ["//tensorflow/lite/micro:op_resolvers"],
 )
 
-cc_library(
+tflm_cc_library(
     name = "metrics",
     srcs = ["metrics.cc"],
     hdrs = ["metrics.h"],
@@ -17,7 +23,7 @@ cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "generic_benchmark_lib",
     srcs = ["generic_model_benchmark.cc"],
     hdrs = ["show_meta_data.h"],
@@ -37,7 +43,7 @@ cc_library(
     ],
 )
 
-cc_binary(
+tflm_cc_binary(
     name = "tflm_benchmark",
     deps = [":generic_benchmark_lib"],
 )

--- a/tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver/templates/BUILD.mako
+++ b/tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver/templates/BUILD.mako
@@ -3,6 +3,7 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
     "generate_cc_arrays",
+    "tflm_library",
     "tflm_cc_test",
 )
 
@@ -61,7 +62,7 @@ tflm_cc_library(
     ],
 )
 
-cc_library(
+tflm_cc_library(
     name = "gen_micro_op_resolver",
     hdrs = ["gen_micro_mutable_op_resolver.h",],
     visibility = ["//visibility:public"],

--- a/tensorflow/lite/micro/tools/project_generation/BUILD.testing
+++ b/tensorflow/lite/micro/tools/project_generation/BUILD.testing
@@ -1,10 +1,15 @@
 # standalone BUILD file used to test project generation with bazel.
+#
+load("//tensorflow/lite/micro:build_def.bzl",
+    "tflm_cc_library",
+    "tflm_copts",
+)
 
-cc_library(
+tflm_cc_library(
   name = "libtflm",
   srcs = glob(["tensorflow/**/*.cc", "tensorflow/**/*.c", "third_party/**/*.cc", "third_party/**/*.c"]),
   hdrs = glob(["tensorflow/**/*.h", "third_party/**/*.h"]),
-  copts = [
+  copts = tflm_copts() + [
     "-Ithird_party/gemmlowp",
     "-Ithird_party/flatbuffers/include",
     "-Ithird_party/kissfft",


### PR DESCRIPTION
Replace cc_* targets remaining in TFLM code with tflm_cc_*
targets. These are targets which did not formerly use the common
copts. Avoid changing imported TFLite code, if for no other
reason than to avoid merge conflicts during the automatic sync
with upstream TFLite.

BUG=#2636