### PR TITLE
Fix incorrect library name in micro_op_resolver build file

### DIFF
--- a/tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver/templates/BUILD.mako
+++ b/tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver/templates/BUILD.mako
@@ -3,7 +3,7 @@
 load(
     "//tensorflow/lite/micro:build_def.bzl",
     "generate_cc_arrays",
-    "tflm_library",
+    "tflm_cc_library",
     "tflm_cc_test",
 )
 


### PR DESCRIPTION
BUG=#2772