### PR TITLE
Fix typo in hello world example

### DIFF
--- a/tensorflow/lite/micro/examples/hello_world/hello_world_test.cc
+++ b/tensorflow/lite/micro/examples/hello_world/hello_world_test.cc
@@ -136,7 +136,7 @@ TfLiteStatus LoadQuantModelAndPerformInference() {
   float golden_inputs_float[kNumTestValues] = {0.77, 1.57, 2.3, 3.14};
 
   // The int8 values are calculated using the following formula
-  // (golden_inputs_float[i] / input->params.scale + input->params.scale)
+  // (golden_inputs_float[i] / input->params.scale + input->params.zero_point)
   int8_t golden_inputs_int8[kNumTestValues] = {-96, -63, -34, 0};
 
   for (int i = 0; i < kNumTestValues; ++i) {


### PR DESCRIPTION
In most other examples, the values are quantized by shifting by the zero point rather than the scale again, so I assume this is a typo.

BUG=typo fix