### PR TITLE
build(bazel): provide means of excluding whl_test locally

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -80,3 +80,7 @@ build:ubsan --copt -O3
 build:ubsan --copt -fno-omit-frame-pointer
 build:ubsan --linkopt -fsanitize=undefined
 build:ubsan --linkopt -lubsan
+
+# Hooks for defining local configuration
+try-import ../bazelrc.local
+try-import bazelrc.local

--- a/python/tflite_micro/BUILD
+++ b/python/tflite_micro/BUILD
@@ -250,6 +250,7 @@ sh_test(
     data = [
         ":whl",
     ],
+    size = "large",
     tags = [
         "noasan",
         "nomsan",


### PR DESCRIPTION
Mark whl_test as size "large", so that it, and other tests of a
similar size, can be excluded with the --test_size_filters
option.

For even more convenience, provide a hook for developers to add
local .bazlerc-style defaults and configurations in
$root/bazelrc.local and ../$root/bazelrc.local.

This gives a convenient means of explicitly excluding whl_test
during local, incremental development runs of `bazel test ...`,
while not surprising users who don't opt in, and without
affecting CI.

whl_test's cached result is invalidated, and the test rerun,
following most git activity, because the git hash appears in the
Python package's version number. This combined with its long
runtime and network dependency makes it a nuisance when running
`bazel test ...` incrementally during development. Of course,
this test be run when developing changes that affect the package,
before pushing commits to main, and in CI.

BUG=see description