### PR TITLE
test(compression): remove the test log hexdump of the Python metadata

### DIFF
--- a/tensorflow/lite/micro/compression/BUILD
+++ b/tensorflow/lite/micro/compression/BUILD
@@ -92,7 +92,6 @@ py_test(
     deps = [
         "metadata_py",
         "@flatbuffers//:runtime_py",
-        requirement("hexdump"),
         requirement("tensorflow"),
     ],
 )

--- a/tensorflow/lite/micro/compression/metadata_test.py
+++ b/tensorflow/lite/micro/compression/metadata_test.py
@@ -17,7 +17,6 @@ flatbuffer machinery with Python.
 """
 
 from dataclasses import dataclass
-import hexdump
 import flatbuffers
 import tensorflow as tf
 
@@ -102,9 +101,9 @@ class TestReadEqualsWrite(tf.test.TestCase):
 
     self.assertEqual(metadata.schemaVersion, _EXPECTED_SCHEMA_VERSION)
 
-  def testPrintFlatbuffer(self):
-    # Print a representation of the binary flatbuffer for debugging purposes.
-    print(hexdump.hexdump(self.flatbuffer, result='return'))
+  def testPrintFlatbufferLen(self):
+    """Print the flatbuffer length for the log.
+    """
     print(f"length: {len(self.flatbuffer)}")
 
 

--- a/third_party/python_requirements.in
+++ b/third_party/python_requirements.in
@@ -27,7 +27,6 @@
 # it is run.
 
 bitarray
-hexdump
 tensorflow
 twine
 numpy

--- a/third_party/python_requirements.txt
+++ b/third_party/python_requirements.txt
@@ -473,9 +473,6 @@ h5py==3.12.1 \
     # via
     #   keras
     #   tensorflow
-hexdump==3.3 \
-    --hash=sha256:d781a43b0c16ace3f9366aade73e8ad3a7bd5137d58f0b45ab2d3f54876f20db
-    # via -r third_party/python_requirements.in
 idna==3.10 \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3


### PR DESCRIPTION
Remove the hexdump of the compression metadata to the test log
during the Python compression metadata test, and the requirement
for the hexdump Python package. This dump was helpful during
development of the compression metadata flatbuffer schema to
assess how changes were represented, affecting the size and the
scaling of the size.

Unfortunately, requiring the hexdump module creates problems when
Google imports this code internally, so remove it for now.

The C++ metadata test still prints a hexdump; however, the C++
flatbuffer library writes the flatbuffer slightly differently.
Within the bounds of the flatbuffer specifications, different
library writers can make different, compatible implementation
choices.

BUG=see description