### PR TITLE
feat(python): don't check .sparsity in interpreter

### DIFF
--- a/python/tflite_micro/interpreter_wrapper.cc
+++ b/python/tflite_micro/interpreter_wrapper.cc
@@ -104,11 +104,6 @@ bool CheckTensor(const TfLiteTensor* tensor) {
     return false;
   }
 
-  if (tensor->sparsity != nullptr) {
-    PyErr_SetString(PyExc_ValueError, "TFLM doesn't support sparse tensors");
-    return false;
-  }
-
   int py_type_num = TfLiteTypeToPyArrayType(tensor->type);
   if (py_type_num == NPY_NOTYPE) {
     PyErr_SetString(PyExc_ValueError, "Unknown tensor type.");


### PR DESCRIPTION
Remove the check for sparse tensors in the Python interpreter wrapper.
This fixes a broken build when TF_LITE_STATIC_MEMORY is set, which
should always be the case in TFLM. TfLiteTensor objects don't have a
.sparsity member when TF_LITE_STATIC_MEMORY is set, so this check
can't be made.

This prepares for an upcoming commit setting TF_LITE_STATIC_MEMORY
during Bazel builds. This hasn't caused build failures in Make builds,
which have always set TF_LITE_STATIC_MEMORY, because Make builds don't
build the Python interpreter wrapper.

BUG=#2636