### PR TITLE
build(bazel): always build with TF_LITE_STATIC_MEMORY

### DIFF
--- a/tensorflow/lite/micro/build_def.bzl
+++ b/tensorflow/lite/micro/build_def.bzl
@@ -6,6 +6,7 @@ def tflm_copts():
     be useful when additively overriding the defaults for a particular target.
     """
     return [
+        "-fno-exceptions",
         "-Wall",
         "-Wno-unused-parameter",
         "-Wnon-virtual-dtor",
@@ -28,13 +29,20 @@ def tflm_defines():
     this function directly; however, it may be useful when additively
     overriding the defaults for a particular target.
     """
-    return select({
+    defines = [
+        # Exclude dynamic memory use in shared TFLite code.
+        "TF_LITE_STATIC_MEMORY=1",
+    ]
+
+    defines += select({
         # Include code for the compression feature.
         "//:with_compression_enabled": ["USE_TFLM_COMPRESSION=1"],
 
         # By default, don't include code for the compression feature.
         "//conditions:default": [],
     })
+
+    return defines
 
 def tflm_cc_binary(copts = tflm_copts(), defines = tflm_defines(), **kwargs):
     native.cc_binary(


### PR DESCRIPTION
Add TF_LITE_STATIC_MEMORY to the defines set globally for TFLM builds in
Bazel. TFLM always builds with this set in Make, and it appears to have
been an oversight that it wasn't set during Bazel builds. Not having it
set in Bazel caused some unit tests to pass under Bazel that failed
under Make.

At the same time, add -fno-exceptions. This flag is also always set in
Make builds. Without it, setting TF_LITE_STATIC_MEMORY breaks the build.
TF_LITE_STATIC_MEMORY triggers TF_LITE_REMOVE_VIRTUAL_DELETE in
t/l/m/compatibility.h, which makes operator delete private in certain
classes. When exceptions are enabled, a placement new with those classes
is allowed to throw an exception, and operator delete is implicitly
called during the unwind. The build breaks because operator delete can't
be called if it's private. Disabling exceptions eliminates the unwind
code that calls operator delete implicitly, and thus the build succeeds.

In any case, -fno-exceptions should have been used in Bazel builds,
matching the flags used in Make and the no-exceptions design requirement
of the TFLM project.

BUG=#2636