### PR TITLE
fix(py runtime_test): remove test for zero-initialized output tensor

### DIFF
--- a/python/tflite_micro/runtime_test.py
+++ b/python/tflite_micro/runtime_test.py
@@ -160,11 +160,6 @@ class ConvModelTests(test_util.TensorFlowTestCase):
     model_data = generate_test_models.generate_conv_model(True, self.filename)
     tflm_interpreter = runtime.Interpreter.from_bytes(model_data)
 
-    # Initial output values are all 0
-    output = tflm_interpreter.get_output(0)
-    init_output = np.zeros(self.output_shape)
-    self.assertAllEqual(output, init_output)
-
     # Test the output tensor details
     output_details = tflm_interpreter.get_output_details(0)
     self.assertAllEqual(output_details["shape"], self.output_shape)


### PR DESCRIPTION
Remove the test that incorrectly asserts the output tensor is
initially all zeros. The tensor is allocated from a shared memory
arena, and its initial state is not guaranteed to be zero. This
test eventually failed due to variations in memory allocation
during build and runtime; see the failed checks in #2945.

BUG=#2636