### PR TITLE
refactor: move misplaced TF_LITE_REMOVE_VIRTUAL_DELETEs to private:

### DIFF
--- a/tensorflow/lite/micro/arena_allocator/non_persistent_arena_buffer_allocator.h
+++ b/tensorflow/lite/micro/arena_allocator/non_persistent_arena_buffer_allocator.h
@@ -74,8 +74,6 @@ class NonPersistentArenaBufferAllocator : public INonPersistentBufferAllocator {
   // takes in account any temporary allocations.
   size_t GetAvailableMemory(size_t alignment) const override;
 
-  TF_LITE_REMOVE_VIRTUAL_DELETE
-
  private:
   // The memory arena that this allocator manages.
   uint8_t* const buffer_head_;
@@ -97,6 +95,8 @@ class NonPersistentArenaBufferAllocator : public INonPersistentBufferAllocator {
   // Count of outstanding temp buffers.
   int temp_buffer_count_ = 0;
   bool resizable_buffer_allocated_ = false;
+
+  TF_LITE_REMOVE_VIRTUAL_DELETE
 };
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/arena_allocator/persistent_arena_buffer_allocator.h
+++ b/tensorflow/lite/micro/arena_allocator/persistent_arena_buffer_allocator.h
@@ -39,7 +39,6 @@ class PersistentArenaBufferAllocator : public IPersistentBufferAllocator {
   // Returns the size of all persistent allocations in bytes.
   size_t GetPersistentUsedBytes() const override;
 
-  TF_LITE_REMOVE_VIRTUAL_DELETE
  private:
   // The memory arena that this allocator manages.
   uint8_t* const buffer_head_;
@@ -51,6 +50,8 @@ class PersistentArenaBufferAllocator : public IPersistentBufferAllocator {
   // So in essence, the allocated region grows from the bottom and emulates
   // SingleArenaBufferAllocator's persistent part.
   uint8_t* tail_temp_;
+
+  TF_LITE_REMOVE_VIRTUAL_DELETE
 };
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/arena_allocator/single_arena_buffer_allocator.h
+++ b/tensorflow/lite/micro/arena_allocator/single_arena_buffer_allocator.h
@@ -110,8 +110,6 @@ class SingleArenaBufferAllocator : public INonPersistentBufferAllocator,
   // account any temporary allocations.
   size_t GetUsedBytes() const;
 
-  TF_LITE_REMOVE_VIRTUAL_DELETE
-
  protected:
   // Returns a pointer to the current end of the head buffer.
   uint8_t* head() const;
@@ -137,6 +135,8 @@ class SingleArenaBufferAllocator : public INonPersistentBufferAllocator,
   intptr_t temp_buffer_ptr_check_sum_ = 0;
   // Count of outstanding temp buffers.
   int temp_buffer_count_ = 0;
+
+  TF_LITE_REMOVE_VIRTUAL_DELETE
 };
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -65,10 +65,10 @@ class MicroBuiltinDataAllocator : public TfLiteBridgeBuiltinDataAllocator {
     // of the model.
   }
 
-  TF_LITE_REMOVE_VIRTUAL_DELETE
-
  private:
   IPersistentBufferAllocator* persistent_allocator_;
+
+  TF_LITE_REMOVE_VIRTUAL_DELETE
 };
 
 MicroMemoryPlanner* CreateMemoryPlanner(

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -44,8 +44,6 @@ TFLMRegistration* Register_DETECTION_POSTPROCESS();
 template <unsigned int tOpCount>
 class MicroMutableOpResolver : public MicroOpResolver {
  public:
-  TF_LITE_REMOVE_VIRTUAL_DELETE
-
   explicit MicroMutableOpResolver() {}
 
   const TFLMRegistration* FindOp(tflite::BuiltinOperator op) const override {
@@ -704,6 +702,8 @@ class MicroMutableOpResolver : public MicroOpResolver {
   BuiltinOperator builtin_codes_[tOpCount];
   TfLiteBridgeBuiltinParseFunction builtin_parsers_[tOpCount];
   unsigned int num_buitin_ops_ = 0;
+
+  TF_LITE_REMOVE_VIRTUAL_DELETE
 };
 
 };  // namespace tflite


### PR DESCRIPTION
Move several TF_LITE_REMOVE_VIRTUAL_DELETE declarations that are
wrongly in a public section of their classes. To have the intended
effect, as documented in t/l/m/compatibility.h, these must be in a
private section.

BUG=see description