### PR TITLE
build(bazel): disable codegen when building --//:with_compression

### DIFF
--- a/codegen/build_def.bzl
+++ b/codegen/build_def.bzl
@@ -53,5 +53,9 @@ def tflm_inference_library(
             "//tensorflow/lite/micro:micro_common",
             "//tensorflow/lite/micro:micro_context",
         ],
+        target_compatible_with = select({
+            "//conditions:default": [],
+            "//:with_compression_enabled": ["@platforms//:incompatible"],
+        }),
         visibility = visibility,
     )


### PR DESCRIPTION
The codegen prototype code is not compatible with the changes which
implement model compression made to the core TFLM components. For now,
disable codegen targets when building with compression enabled.

BUG=#2636