### PR TITLE
fix: explicitly give type parameter to help some compilers

### DIFF
--- a/tensorflow/lite/micro/compression/metadata_test.cc
+++ b/tensorflow/lite/micro/compression/metadata_test.cc
@@ -81,9 +81,9 @@ metadata->subgraphs.push_back(std::move(subgraph0));
 flatbuffers::FlatBufferBuilder builder;
 auto root = Metadata::Pack(builder, metadata.get());
 builder.Finish(root);
-auto flatbuffer =
-    tflite::Span{reinterpret_cast<const std::byte*>(builder.GetBufferPointer()),
-                 builder.GetSize()};
+auto flatbuffer = tflite::Span<const std::byte>{
+    reinterpret_cast<const std::byte*>(builder.GetBufferPointer()),
+    builder.GetSize()};
 
 TF_LITE_MICRO_TEST(ReadbackEqualsWrite) {
   const Metadata* read_metadata =


### PR DESCRIPTION
Explicitly give a type to an instantiation of tflite::Span<T>
rather than let the compiler infer it. The inference breaks on
some internal compilers.

BUG=see description