### PR TITLE
build: add -fno-asynchronous-unwind-tables to reduce binary size

### DIFF
--- a/tensorflow/lite/micro/build_def.bzl
+++ b/tensorflow/lite/micro/build_def.bzl
@@ -6,6 +6,7 @@ def tflm_copts():
     be useful when additively overriding the defaults for a particular target.
     """
     return [
+        "-fno-asynchronous-unwind-tables",
         "-fno-exceptions",
         "-Wall",
         "-Wno-unused-parameter",

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -167,6 +167,7 @@ endif
 COMMON_FLAGS := \
   -Werror \
   -fno-unwind-tables \
+  -fno-asynchronous-unwind-tables \
   -ffunction-sections \
   -fdata-sections \
   -fmessage-length=0 \


### PR DESCRIPTION
Add -fno-asynchronous-unwind-tables to reduce binary size. Bloaty
showed the stack unwinding metadata to be taking up space even
when we don't use exceptions.

BUG=part of #2636

