### PR TITLE
build(Make): include compression when USE_TFLM_COMPRESSION is set

### DIFF
--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -264,6 +264,17 @@ endif
 # runtime that can be linked in to other programs.
 MICROLITE_LIB_NAME := libtensorflow-microlite.a
 
+# TFLM optional compression support (default disabled)
+ENABLE_COMPRESSION := no
+ifneq ($(USE_TFLM_COMPRESSION),)
+  # currently only Linux (x86), Xtensa targets supported
+  ifeq ($(TARGET), $(filter $(TARGET), linux xtensa))
+    CXXFLAGS += -DUSE_TFLM_COMPRESSION
+    CCFLAGS += -DUSE_TFLM_COMPRESSION
+    ENABLE_COMPRESSION := yes
+  endif
+endif
+
 # Where compiled objects are stored.
 BASE_GENDIR := gen
 GENDIR := $(BASE_GENDIR)/$(TARGET)_$(TARGET_ARCH)_$(BUILD_TYPE)
@@ -272,6 +283,9 @@ ifneq ($(OPTIMIZED_KERNEL_DIR),)
 endif
 ifneq ($(CO_PROCESSOR),)
   GENDIR := $(GENDIR)_$(CO_PROCESSOR)
+endif
+ifeq ($(ENABLE_COMPRESSION), yes)
+  GENDIR := $(GENDIR)_compression
 endif
 GENDIR := $(GENDIR)_$(TOOLCHAIN)/
 


### PR DESCRIPTION
Conditionally include support for compressed tensors when the
environment variable USE_TFLM_COMPRESSION is set, which may be
set in the environment or on the command line.

BUG=part of #2636

