### PR TITLE
Revert TF_LITE_STATIC_MEMORY and small BUILD fixes.

### DIFF
--- a/tensorflow/lite/micro/BUILD
+++ b/tensorflow/lite/micro/BUILD
@@ -1,7 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(
     "//tensorflow/lite/micro:build_def.bzl",
-    "tflm_cc_binary",
     "tflm_cc_library",
     "tflm_cc_test",
     "tflm_copts",
@@ -414,6 +413,7 @@ tflm_cc_library(
         "hexdump.h",
     ],
     deps = [
+        ":debug_log",
         ":span",
         ":static_vector",
     ],

--- a/tensorflow/lite/micro/build_def.bzl
+++ b/tensorflow/lite/micro/build_def.bzl
@@ -1,3 +1,5 @@
+"""TfLite Micro BUILD options."""
+
 def tflm_copts():
     """Returns the default copts for targets in TFLM.
 

--- a/tensorflow/lite/micro/build_def.bzl
+++ b/tensorflow/lite/micro/build_def.bzl
@@ -9,7 +9,6 @@ def tflm_copts():
     """
     return [
         "-fno-asynchronous-unwind-tables",
-        "-fno-exceptions",
         "-Wall",
         "-Wno-unused-parameter",
         "-Wnon-virtual-dtor",
@@ -32,20 +31,13 @@ def tflm_defines():
     this function directly; however, it may be useful when additively
     overriding the defaults for a particular target.
     """
-    defines = [
-        # Exclude dynamic memory use in shared TFLite code.
-        "TF_LITE_STATIC_MEMORY=1",
-    ]
-
-    defines += select({
+    return select({
         # Include code for the compression feature.
         "//:with_compression_enabled": ["USE_TFLM_COMPRESSION=1"],
 
         # By default, don't include code for the compression feature.
         "//conditions:default": [],
     })
-
-    return defines
 
 def tflm_cc_binary(copts = tflm_copts(), defines = tflm_defines(), **kwargs):
     native.cc_binary(


### PR DESCRIPTION
Fixes unused import and a required dep for hexdump. Also adds docstring for .bzl file. These changes are needed for some internal checks.

Additionally, temporarily reverts #2945, to help with internal fix.

BUG=quick fix