### PR TITLE
ci(Make): add test jobs for compression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,6 +341,27 @@ jobs:
           cd ../
           tflite-micro/tensorflow/lite/micro/tools/ci_build/test_x86_default.sh tflite-micro/
 
+  x86_default_with_compression:
+    runs-on: ubuntu-latest
+
+    name: Makefile x86 with Compression (presubmit)
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.trigger-sha }}
+      - name: Install dependencies
+        run: |
+          pip3 install Pillow
+          pip3 install numpy
+      - name: Test
+        run: |
+          tensorflow/lite/micro/tools/ci_build/test_makefile.sh
+          cd ../
+          tflite-micro/tensorflow/lite/micro/tools/ci_build/test_x86_default_with_compression.sh tflite-micro/
+
   x86_out_of_tree:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/xtensa_presubmit.yml
+++ b/.github/workflows/xtensa_presubmit.yml
@@ -51,6 +51,21 @@ jobs:
           /bin/bash -c \
           "cd /opt && tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi5.sh tflite-micro/"
 
+  hifi5_unit_tests_with_compression:
+    runs-on: ubuntu-latest
+
+    name: Hifi5 Unit Tests with Compression (presubmit)
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.trigger-sha }}
+      - run: |
+          rm -rf .git
+          echo ${{ secrets.tflm-bot-token }} | docker login ghcr.io -u tflm-bot --password-stdin
+          docker run --env XTENSA_TOOLS_VERSION=RI-2022.9-linux --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa_xplorer_hifi5:0.2 \
+          /bin/bash -c \
+          "cd /opt && tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi5_with_compression.sh tflite-micro/"
+
   hifi_3z_unit_tests:
     runs-on: ubuntu-latest
 
@@ -65,3 +80,18 @@ jobs:
           docker run --env XTENSA_TOOLS_VERSION=RI-2020.4-linux --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa_xplorer_13:0.3 \
           /bin/bash -c \
           "cd /opt && tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi3z.sh EXTERNAL tflite-micro/"
+
+  hifi_3z_unit_tests_with_compression:
+    runs-on: ubuntu-latest
+
+    name: Hifi3z Unit Tests with Compression (presubmit)
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.trigger-sha }}
+      - run: |
+          rm -rf .git
+          echo ${{ secrets.tflm-bot-token }} | docker login ghcr.io -u tflm-bot --password-stdin
+          docker run --env XTENSA_TOOLS_VERSION=RI-2020.4-linux --rm -v `pwd`:/opt/tflite-micro ghcr.io/tflm-bot/xtensa_xplorer_13:0.3 \
+          /bin/bash -c \
+          "cd /opt && tflite-micro/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi3z_with_compression.sh EXTERNAL tflite-micro/"

--- a/tensorflow/lite/micro/tools/ci_build/test_x86_default_with_compression.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_x86_default_with_compression.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Called with following arguments:
+# 1 - (optional) TENSORFLOW_ROOT: path to root of the TFLM tree (relative to directory from where the script is called).
+# 2 - (optional) EXTERNAL_DIR: Path to the external directory that contains external code
+
+# CI test with compression enabled for x86
+
+set -e
+set -x
+
+export TENSORFLOW_ROOT=${1}
+export EXTERNAL_DIR=${2}
+export USE_TFLM_COMPRESSION=yes
+export GENERIC_BENCHMARK_MODEL_PATH=${TENSORFLOW_ROOT}tensorflow/lite/micro/models/person_detect.tflite
+MAKEFILE=${TENSORFLOW_ROOT}tensorflow/lite/micro/tools/make/Makefile 
+
+make -f ${MAKEFILE} third_party_downloads  # TODO(b/143715361): first to allow parallel builds.
+make -f ${MAKEFILE} -j$(nproc) build
+make -f ${MAKEFILE} -j$(nproc) test
+make -f ${MAKEFILE} -j$(nproc) integration_tests
+make -f ${MAKEFILE} -j$(nproc) run_tflm_benchmark

--- a/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi3z_with_compression.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi3z_with_compression.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Called with following arguments:
+# 1 - EXTERNAL or INTERNAL to signal how to run the script
+# 2 - (optional) TENSORFLOW_ROOT: path to root of the TFLM tree (relative to directory from where the script is called).
+# 3 - (optional) EXTERNAL_DIR: Path to the external directory that contains external code
+
+# CI test with compression enabled for hifi3z
+
+set -e
+set -x
+pwd
+
+export TENSORFLOW_ROOT=${2}
+export EXTERNAL_DIR=${3}
+export TARGET=xtensa 
+export TARGET_ARCH=hifi3 
+export OPTIMIZED_KERNEL_DIR=xtensa
+export XTENSA_CORE=HIFI_190304_swupgrade
+export GENERIC_BENCHMARK_MODEL_PATH=${TENSORFLOW_ROOT}tensorflow/lite/micro/models/person_detect.tflite
+export USE_TFLM_COMPRESSION=yes
+MAKEFILE=${TENSORFLOW_ROOT}tensorflow/lite/micro/tools/make/Makefile 
+
+make -f ${MAKEFILE} third_party_downloads  # TODO(b/143904317): first to allow parallel builds
+make -f ${MAKEFILE} -j$(nproc) build
+make -f ${MAKEFILE} -j$(nproc) test
+make -f ${MAKEFILE} -j$(nproc) run_tflm_benchmark

--- a/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi5_with_compression.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi5_with_compression.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Called with following arguments:
+# 1 - EXTERNAL or INTERNAL to signal how to run the script
+# 2 - (optional) TENSORFLOW_ROOT: path to root of the TFLM tree (relative to directory from where the script is called).
+# 3 - (optional) EXTERNAL_DIR: Path to the external directory that contains external code
+
+# CI test with compression enabled for hifi5
+
+set -e
+set -x
+pwd
+
+export TENSORFLOW_ROOT=${2}
+export EXTERNAL_DIR=${3}
+export TARGET=xtensa 
+export TARGET_ARCH=hifi5
+export OPTIMIZED_KERNEL_DIR=xtensa
+export XTENSA_CORE=PRD_H5_RDO_07_01_2022
+export GENERIC_BENCHMARK_MODEL_PATH=${TENSORFLOW_ROOT}tensorflow/lite/micro/models/person_detect.tflite
+export USE_TFLM_COMPRESSION=yes
+MAKEFILE=${TENSORFLOW_ROOT}tensorflow/lite/micro/tools/make/Makefile 
+
+make -f ${MAKEFILE} third_party_downloads  # TODO(b/143904317): first to allow parallel builds
+make -f ${MAKEFILE} -j$(nproc) build
+make -f ${MAKEFILE} -j$(nproc) test
+make -f ${MAKEFILE} -j$(nproc) run_tflm_benchmark


### PR DESCRIPTION
Add GitHub CI jobs that run `make test`, etc. with compression
enabled. Add as new jobs, as opposed to additional steps within
the existing jobs, so they can run in parallel, and so they begin
with a fresh, un-built working directory.

BUG=part of #2636