### PR TITLE
fix(ci): properly pass variables to Make

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_x86_default_with_compression.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_x86_default_with_compression.sh
@@ -23,14 +23,40 @@
 set -e
 set -x
 
-export TENSORFLOW_ROOT=${1}
-export EXTERNAL_DIR=${2}
-export USE_TFLM_COMPRESSION=yes
-export GENERIC_BENCHMARK_MODEL_PATH=${TENSORFLOW_ROOT}tensorflow/lite/micro/models/person_detect.tflite
+TENSORFLOW_ROOT=${1}
+EXTERNAL_DIR=${2}
 MAKEFILE=${TENSORFLOW_ROOT}tensorflow/lite/micro/tools/make/Makefile 
 
-make -f ${MAKEFILE} third_party_downloads  # TODO(b/143715361): first to allow parallel builds.
-make -f ${MAKEFILE} -j$(nproc) build
-make -f ${MAKEFILE} -j$(nproc) test
-make -f ${MAKEFILE} -j$(nproc) integration_tests
-make -f ${MAKEFILE} -j$(nproc) run_tflm_benchmark
+make -f ${MAKEFILE} \
+    TENSORFLOW_ROOT=${TENSORFLOW_ROOT} \
+    EXTERNAL_DIR=${EXTERNAL_DIR} \
+    third_party_downloads  # TODO(b/143715361): download first to allow parallel builds.
+
+make -f ${MAKEFILE} \
+    -j$(nproc) \
+    TENSORFLOW_ROOT=${TENSORFLOW_ROOT} \
+    EXTERNAL_DIR=${EXTERNAL_DIR} \
+    USE_TFLM_COMPRESSION=yes \
+    build
+
+make -f ${MAKEFILE} \
+    -j$(nproc) \
+    TENSORFLOW_ROOT=${TENSORFLOW_ROOT} \
+    EXTERNAL_DIR=${EXTERNAL_DIR} \
+    USE_TFLM_COMPRESSION=yes \
+    test
+
+make -f ${MAKEFILE} \
+    -j$(nproc) \
+    TENSORFLOW_ROOT=${TENSORFLOW_ROOT} \
+    EXTERNAL_DIR=${EXTERNAL_DIR} \
+    USE_TFLM_COMPRESSION=yes \
+    integration_tests
+
+make -f ${MAKEFILE} \
+    -j$(nproc) \
+    TENSORFLOW_ROOT=${TENSORFLOW_ROOT} \
+    EXTERNAL_DIR=${EXTERNAL_DIR} \
+    GENERIC_BENCHMARK_MODEL_PATH=${TENSORFLOW_ROOT}tensorflow/lite/micro/models/person_detect.tflite \
+    USE_TFLM_COMPRESSION=yes \
+    run_tflm_benchmark

--- a/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi3z_with_compression.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi3z_with_compression.sh
@@ -24,17 +24,54 @@ set -e
 set -x
 pwd
 
-export TENSORFLOW_ROOT=${2}
-export EXTERNAL_DIR=${3}
-export TARGET=xtensa 
-export TARGET_ARCH=hifi3 
-export OPTIMIZED_KERNEL_DIR=xtensa
-export XTENSA_CORE=HIFI_190304_swupgrade
-export GENERIC_BENCHMARK_MODEL_PATH=${TENSORFLOW_ROOT}tensorflow/lite/micro/models/person_detect.tflite
-export USE_TFLM_COMPRESSION=yes
+TENSORFLOW_ROOT=${2}
+EXTERNAL_DIR=${3}
 MAKEFILE=${TENSORFLOW_ROOT}tensorflow/lite/micro/tools/make/Makefile 
 
-make -f ${MAKEFILE} third_party_downloads  # TODO(b/143904317): first to allow parallel builds
-make -f ${MAKEFILE} -j$(nproc) build
-make -f ${MAKEFILE} -j$(nproc) test
-make -f ${MAKEFILE} -j$(nproc) run_tflm_benchmark
+TARGET=xtensa 
+TARGET_ARCH=hifi3 
+OPTIMIZED_KERNEL_DIR=xtensa
+XTENSA_CORE=HIFI_190304_swupgrade
+
+make -f ${MAKEFILE} \
+    TENSORFLOW_ROOT=${TENSORFLOW_ROOT} \
+    EXTERNAL_DIR=${EXTERNAL_DIR} \
+    TARGET=${TARGET} \
+    TARGET_ARCH=${TARGET_ARCH} \
+    OPTIMIZED_KERNEL_DIR=${OPTIMIZED_KERNEL_DIR} \
+    XTENSA_CORE=${XTENSA_CORE} \
+    third_party_downloads  # TODO(b/143904317): first to allow parallel builds
+
+make -f ${MAKEFILE} \
+    -j$(nproc) \
+    TENSORFLOW_ROOT=${TENSORFLOW_ROOT} \
+    EXTERNAL_DIR=${EXTERNAL_DIR} \
+    TARGET=${TARGET} \
+    TARGET_ARCH=${TARGET_ARCH} \
+    OPTIMIZED_KERNEL_DIR=${OPTIMIZED_KERNEL_DIR} \
+    XTENSA_CORE=${XTENSA_CORE} \
+    USE_TFLM_COMPRESSION=yes \
+    build
+
+make -f ${MAKEFILE} \
+    -j$(nproc) \
+    TENSORFLOW_ROOT=${TENSORFLOW_ROOT} \
+    EXTERNAL_DIR=${EXTERNAL_DIR} \
+    TARGET=${TARGET} \
+    TARGET_ARCH=${TARGET_ARCH} \
+    OPTIMIZED_KERNEL_DIR=${OPTIMIZED_KERNEL_DIR} \
+    XTENSA_CORE=${XTENSA_CORE} \
+    USE_TFLM_COMPRESSION=yes \
+    test
+
+make -f ${MAKEFILE} \
+    -j$(nproc) \
+    TENSORFLOW_ROOT=${TENSORFLOW_ROOT} \
+    EXTERNAL_DIR=${EXTERNAL_DIR} \
+    TARGET=${TARGET} \
+    TARGET_ARCH=${TARGET_ARCH} \
+    OPTIMIZED_KERNEL_DIR=${OPTIMIZED_KERNEL_DIR} \
+    XTENSA_CORE=${XTENSA_CORE} \
+    GENERIC_BENCHMARK_MODEL_PATH=${TENSORFLOW_ROOT}tensorflow/lite/micro/models/person_detect.tflite \
+    USE_TFLM_COMPRESSION=yes \
+    run_tflm_benchmark

--- a/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi5_with_compression.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi5_with_compression.sh
@@ -24,17 +24,54 @@ set -e
 set -x
 pwd
 
-export TENSORFLOW_ROOT=${2}
-export EXTERNAL_DIR=${3}
-export TARGET=xtensa 
-export TARGET_ARCH=hifi5
-export OPTIMIZED_KERNEL_DIR=xtensa
-export XTENSA_CORE=PRD_H5_RDO_07_01_2022
-export GENERIC_BENCHMARK_MODEL_PATH=${TENSORFLOW_ROOT}tensorflow/lite/micro/models/person_detect.tflite
-export USE_TFLM_COMPRESSION=yes
+TENSORFLOW_ROOT=${2}
+EXTERNAL_DIR=${3}
 MAKEFILE=${TENSORFLOW_ROOT}tensorflow/lite/micro/tools/make/Makefile 
 
-make -f ${MAKEFILE} third_party_downloads  # TODO(b/143904317): first to allow parallel builds
-make -f ${MAKEFILE} -j$(nproc) build
-make -f ${MAKEFILE} -j$(nproc) test
-make -f ${MAKEFILE} -j$(nproc) run_tflm_benchmark
+TARGET=xtensa 
+TARGET_ARCH=hifi5 
+OPTIMIZED_KERNEL_DIR=xtensa
+XTENSA_CORE=PRD_H5_RDO_07_01_2022
+
+make -f ${MAKEFILE} \
+    TENSORFLOW_ROOT=${TENSORFLOW_ROOT} \
+    EXTERNAL_DIR=${EXTERNAL_DIR} \
+    TARGET=${TARGET} \
+    TARGET_ARCH=${TARGET_ARCH} \
+    OPTIMIZED_KERNEL_DIR=${OPTIMIZED_KERNEL_DIR} \
+    XTENSA_CORE=${XTENSA_CORE} \
+    third_party_downloads  # TODO(b/143904317): first to allow parallel builds
+
+make -f ${MAKEFILE} \
+    -j$(nproc) \
+    TENSORFLOW_ROOT=${TENSORFLOW_ROOT} \
+    EXTERNAL_DIR=${EXTERNAL_DIR} \
+    TARGET=${TARGET} \
+    TARGET_ARCH=${TARGET_ARCH} \
+    OPTIMIZED_KERNEL_DIR=${OPTIMIZED_KERNEL_DIR} \
+    XTENSA_CORE=${XTENSA_CORE} \
+    USE_TFLM_COMPRESSION=yes \
+    build
+
+make -f ${MAKEFILE} \
+    -j$(nproc) \
+    TENSORFLOW_ROOT=${TENSORFLOW_ROOT} \
+    EXTERNAL_DIR=${EXTERNAL_DIR} \
+    TARGET=${TARGET} \
+    TARGET_ARCH=${TARGET_ARCH} \
+    OPTIMIZED_KERNEL_DIR=${OPTIMIZED_KERNEL_DIR} \
+    XTENSA_CORE=${XTENSA_CORE} \
+    USE_TFLM_COMPRESSION=yes \
+    test
+
+make -f ${MAKEFILE} \
+    -j$(nproc) \
+    TENSORFLOW_ROOT=${TENSORFLOW_ROOT} \
+    EXTERNAL_DIR=${EXTERNAL_DIR} \
+    TARGET=${TARGET} \
+    TARGET_ARCH=${TARGET_ARCH} \
+    OPTIMIZED_KERNEL_DIR=${OPTIMIZED_KERNEL_DIR} \
+    XTENSA_CORE=${XTENSA_CORE} \
+    GENERIC_BENCHMARK_MODEL_PATH=${TENSORFLOW_ROOT}tensorflow/lite/micro/models/person_detect.tflite \
+    USE_TFLM_COMPRESSION=yes \
+    run_tflm_benchmark

--- a/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi5_with_compression.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_xtensa_hifi5_with_compression.sh
@@ -24,8 +24,8 @@ set -e
 set -x
 pwd
 
-TENSORFLOW_ROOT=${2}
-EXTERNAL_DIR=${3}
+TENSORFLOW_ROOT=${1}
+EXTERNAL_DIR=${2}
 MAKEFILE=${TENSORFLOW_ROOT}tensorflow/lite/micro/tools/make/Makefile 
 
 TARGET=xtensa 


### PR DESCRIPTION
Fix the broken CI scripts, new in 23d626d, by passing variable
values to Make as command line options rather than through the
environment. Variables set in the environment are overridden by
assignments in the Makefile, whereas variables set as command
line options override assignments in the Makefile.

BUG=fixes #2989 and fixes #2990