### PR TITLE
test(memory_arena_threshold): don't expect exact allocation values

### DIFF
--- a/tensorflow/lite/micro/memory_arena_threshold_test.cc
+++ b/tensorflow/lite/micro/memory_arena_threshold_test.cc
@@ -136,10 +136,6 @@ void EnsureAllocatedSizeThreshold(const char* allocation_type, size_t actual,
     // 64-bit systems should check floor and ceiling to catch memory savings:
     TF_LITE_MICRO_EXPECT_NEAR(actual, expected,
                               expected * kAllocationThreshold);
-    if (actual != expected) {
-      MicroPrintf("%s threshold failed: %d != %d", allocation_type, actual,
-                  expected);
-    }
   } else {
     // Non-64 bit systems should just expect allocation does not exceed the
     // ceiling:


### PR DESCRIPTION
Remove the check for allocation sizes to exactly match expected values.
This check immediately followed--and thus rendered pointless---a check
that sizes are within a certain percentage, which seems to be the true
intent of the test.

BUG=see description