### PR TITLE
feat(compression): allocate resource variables in persistent buffer

### DIFF
--- a/tensorflow/lite/micro/micro_resource_variable.cc
+++ b/tensorflow/lite/micro/micro_resource_variable.cc
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -113,8 +113,8 @@ TfLiteStatus MicroResourceVariables::Allocate(int id, TfLiteContext* context,
   return kTfLiteOk;
 }
 
-TfLiteStatus MicroResourceVariables::Assign(int id,
-                                            const TfLiteEvalTensor* tensor) {
+TfLiteStatus MicroResourceVariables::Assign(int id, size_t count_bytes,
+                                            const void* input_buffer) {
   if (id < 0 || id >= num_resource_variables_) {
     MicroPrintf("Attempting to read non-existent resource variable %d", id);
     return kTfLiteError;
@@ -128,8 +128,9 @@ TfLiteStatus MicroResourceVariables::Assign(int id,
         "with a TfLiteTensor first.");
     return kTfLiteError;
   }
-  TFLITE_DCHECK(EvalTensorBytes(tensor) == variable.bytes);
-  memcpy(variable.resource_buffer, tensor->data.raw, variable.bytes);
+  TFLITE_DCHECK(count_bytes == variable.bytes);
+  TFLITE_DCHECK(input_buffer != nullptr);
+  memcpy(variable.resource_buffer, input_buffer, variable.bytes);
   return kTfLiteOk;
 }
 

--- a/tensorflow/lite/micro/micro_resource_variable.h
+++ b/tensorflow/lite/micro/micro_resource_variable.h
@@ -1,4 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -46,10 +46,10 @@ class MicroResourceVariables {
   TfLiteStatus Allocate(int id, TfLiteContext* context,
                         const TfLiteTensor* tensor);
 
-  // Copies input tensor contents to the resource buffer.
+  // Copies input_buffer contents to the resource buffer.
   // AllocateResourceVariable with a TFLite tensor must have been called first
   // in order to allocate the resource buffer.
-  TfLiteStatus Assign(int id, const TfLiteEvalTensor* tensor);
+  TfLiteStatus Assign(int id, size_t count_bytes, const void* input_buffer);
 
   // Zeros out all resource buffers.
   TfLiteStatus ResetAll();

--- a/tensorflow/lite/micro/micro_resource_variable_test.cc
+++ b/tensorflow/lite/micro/micro_resource_variable_test.cc
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/micro_resource_variable.h"
 
 #include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/micro/micro_utils.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
 
@@ -120,7 +121,9 @@ TF_LITE_MICRO_TEST(VerifyAssignAndReadResourceBuffer) {
 
       .type = kTfLiteFloat32,
   };
-  resource_variables->Assign(id, &assign_tensor);
+  resource_variables->Assign(
+      id, tflite::EvalTensorBytes(&assign_tensor),
+      tflite::micro::GetTensorData<void>(&assign_tensor));
 
   int32_t buffer[32];
   TfLiteEvalTensor read_tensor = {


### PR DESCRIPTION
Allocate resource variables in a persistent buffer when the input
tensor is compressed. Extend tests to validate operation.

BUG=part of #2636

