### PR TITLE
feat(compression): check metadata schema version

### DIFF
--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -409,6 +409,14 @@ const tflite::micro::compression::Metadata* GetCompressionMetadata(
         MicroPrintf("Compression: verification failure");
         return nullptr;
       } else {
+        tflite::micro::compression::MetadataT schema;
+        if (compression_metadata->schema_version() > schema.schema_version) {
+          MicroPrintf("Compression: schema version mismatch (using %d got %d)",
+                      schema.schema_version,
+                      compression_metadata->schema_version());
+          return nullptr;
+        }
+
         return compression_metadata;
       }
     }


### PR DESCRIPTION
Add a check in `micro_allocator.cc` to verify the compression
metadata schema version. If the schema version in the metadata is
greater than the expected version, log a schema version mismatch
error and return a `nullptr`. This prevents potential issues
arising from using a newer, unsupported schema version.

BUG=part of #2636

