### PR TITLE
Bugfix: unchecked pointer use

### DIFF
--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -875,7 +875,8 @@ TfLiteTensor* MicroAllocator::AllocateTempTfLiteTensor(
   // Populate any fields from the flatbuffer, since this TfLiteTensor struct is
   // allocated in the temp section of the arena, ensure that additional
   // allocations also take place in that section of the arena.
-  if (PopulateTfLiteTensorFromFlatbuffer(model, tensor, tensor_index,
+  if (nullptr == tensor ||
+      PopulateTfLiteTensorFromFlatbuffer(model, tensor, tensor_index,
                                          subgraph_index,
                                          /*allocate_temp=*/true) != kTfLiteOk) {
     MicroPrintf(


### PR DESCRIPTION
**Description**
Pointer may be used unchecked.
API happens to return NULL if not enough memory but pointer is not checked and used in tensor population.
