### PR TITLE
Added checks to ensure input, output quantization params are same.

### DIFF
--- a/tensorflow/lite/micro/kernels/pooling_common.cc
+++ b/tensorflow/lite/micro/kernels/pooling_common.cc
@@ -68,11 +68,11 @@ TfLiteStatus PoolingPrepare(TfLiteContext* context, TfLiteNode* node) {
 
   // check if input, output quantization params are same.
   if (input->type == kTfLiteInt8 || input->type == kTfLiteInt16) {
-    const double scale_diff = static_cast<double>
-      (std::abs(input->params.scale - output->params.scale));
+    const double scale_diff = static_cast<double>(
+        std::abs(input->params.scale - output->params.scale));
     TF_LITE_ENSURE(context, scale_diff <= 1.0e-6);
-    TF_LITE_ENSURE(context, input->params.zero_point ==
-                   output->params.zero_point);
+    TF_LITE_ENSURE(context, 
+                   input->params.zero_point == output->params.zero_point);
   }
 
 

--- a/tensorflow/lite/micro/kernels/pooling_common.cc
+++ b/tensorflow/lite/micro/kernels/pooling_common.cc
@@ -66,6 +66,16 @@ TfLiteStatus PoolingPrepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_STATUS(
       CalculateOpDataPooling(context, params, input, output, data));
 
+  // check if input, output quantization params are same.
+  if (input->type == kTfLiteInt8 || input->type == kTfLiteInt16) {
+    const double scale_diff = static_cast<double>
+      (std::abs(input->params.scale - output->params.scale));
+    TF_LITE_ENSURE(context, scale_diff <= 1.0e-6);
+    TF_LITE_ENSURE(context, input->params.zero_point ==
+                   output->params.zero_point);
+  }
+
+
   if (input->type == kTfLiteFloat32) {
     CalculateActivationRange(params->activation, &data->activation_min_f32,
                              &data->activation_max_f32);

--- a/tensorflow/lite/micro/kernels/pooling_common.cc
+++ b/tensorflow/lite/micro/kernels/pooling_common.cc
@@ -71,10 +71,9 @@ TfLiteStatus PoolingPrepare(TfLiteContext* context, TfLiteNode* node) {
     const double scale_diff = static_cast<double>(
         std::abs(input->params.scale - output->params.scale));
     TF_LITE_ENSURE(context, scale_diff <= 1.0e-6);
-    TF_LITE_ENSURE(context, 
+    TF_LITE_ENSURE(context,
                    input->params.zero_point == output->params.zero_point);
   }
-
 
   if (input->type == kTfLiteFloat32) {
     CalculateActivationRange(params->activation, &data->activation_min_f32,


### PR DESCRIPTION
Added checks to ensure input, output quantization parameters are same.
Without this check, pooling ops would silently ignore even if the IO quantization parameters are different.

bug=fixes
