### PR TITLE
unchecked pointer fix

### DIFF
--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -1,4 +1,4 @@
-/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2025 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -871,6 +871,11 @@ TfLiteTensor* MicroAllocator::AllocateTempTfLiteTensor(
   TfLiteTensor* tensor = reinterpret_cast<TfLiteTensor*>(
       non_persistent_buffer_allocator_->AllocateTemp(sizeof(TfLiteTensor),
                                                      alignof(TfLiteTensor)));
+  if (tensor == nullptr) {
+    MicroPrintf("Failed to allocate temp. memory for tensor %d, subgraph %d",
+                tensor_index, subgraph_index);
+    return nullptr;
+  }
 
   // Populate any fields from the flatbuffer, since this TfLiteTensor struct is
   // allocated in the temp section of the arena, ensure that additional


### PR DESCRIPTION
@tensorflow/micro 

Handle the failure to allocate temporary memory for a TfLiteTensor in a more graceful way.  This allows most kernels in the Prepare phase to not crash due to a DCHECK on memory allocation failure.

bug=fixes #3057