### PR TITLE
Remove deprecated BUILD tags

### DIFF
--- a/codegen/BUILD
+++ b/codegen/BUILD
@@ -59,8 +59,6 @@ py_binary(
     srcs = [
         "code_generator.py",
     ],
-    python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         ":graph",
         ":inference_generator",

--- a/python/tflite_micro/BUILD
+++ b/python/tflite_micro/BUILD
@@ -73,7 +73,6 @@ py_library(
         "runtime.py",
     ],
     data = [":_runtime.so"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         requirement("numpy"),
@@ -85,7 +84,6 @@ py_library(
 py_test(
     name = "runtime_test",
     srcs = ["runtime_test.py"],
-    python_version = "PY3",
     tags = [
         "noasan",
         "nomsan",  # Python doesn't like these symbols in _runtime.so

--- a/python/tflite_micro/signal/BUILD
+++ b/python/tflite_micro/signal/BUILD
@@ -35,7 +35,6 @@ py_library(
         "__init__.py",
         "ops/__init__.py",
     ],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":delay_op",
@@ -66,8 +65,6 @@ py_test(
     name = "delay_op_test",
     size = "small",
     srcs = ["ops/delay_op_test.py"],
-    python_version = "PY3",
-    srcs_version = "PY3",
     tags = [
         "noasan",
         "nomsan",
@@ -99,8 +96,6 @@ py_test(
     data = [
         "//python/tflite_micro/signal/ops/testdata:energy_test1.txt",
     ],
-    python_version = "PY3",
-    srcs_version = "PY3",
     tags = [
         "noasan",
         "nomsan",
@@ -132,8 +127,6 @@ py_test(
         "//python/tflite_micro/signal/ops/testdata:fft_auto_scale_test1.txt",
         "//python/tflite_micro/signal/ops/testdata:rfft_test1.txt",
     ],
-    python_version = "PY3",
-    srcs_version = "PY3",
     tags = [
         "noasan",
         "nomsan",
@@ -171,8 +164,6 @@ py_test(
         "//python/tflite_micro/signal/ops/testdata:filter_bank_square_root_test1.txt",
         "//python/tflite_micro/signal/ops/testdata:filter_bank_test1.txt",
     ],
-    python_version = "PY3",
-    srcs_version = "PY3",
     tags = [
         "noasan",
         "nomsan",
@@ -204,8 +195,6 @@ py_test(
     data = [
         "//python/tflite_micro/signal/ops/testdata:framer_test1.txt",
     ],
-    python_version = "PY3",
-    srcs_version = "PY3",
     tags = [
         "noasan",
         "nomsan",
@@ -234,8 +223,6 @@ py_test(
     name = "overlap_add_op_test",
     size = "small",
     srcs = ["ops/overlap_add_op_test.py"],
-    python_version = "PY3",
-    srcs_version = "PY3",
     tags = [
         "noasan",
         "nomsan",
@@ -268,8 +255,6 @@ py_test(
     data = [
         "//python/tflite_micro/signal/ops/testdata:pcan_op_test1.txt",
     ],
-    python_version = "PY3",
-    srcs_version = "PY3",
     tags = [
         "noasan",
         "nomsan",
@@ -301,8 +286,6 @@ py_test(
     data = [
         "//python/tflite_micro/signal/ops/testdata:stacker_test1.txt",
     ],
-    python_version = "PY3",
-    srcs_version = "PY3",
     tags = [
         "noasan",
         "nomsan",
@@ -333,8 +316,6 @@ py_test(
     data = [
         "//python/tflite_micro/signal/ops/testdata:window_test1.txt",
     ],
-    python_version = "PY3",
-    srcs_version = "PY3",
     tags = [
         "noasan",
         "nomsan",

--- a/python/tflite_micro/signal/utils/BUILD
+++ b/python/tflite_micro/signal/utils/BUILD
@@ -16,8 +16,6 @@ py_test(
     data = [
         ":freq_to_mel_wrapper.so",
     ],
-    python_version = "PY3",
-    srcs_version = "PY3",
     tags = [
         "noasan",
         "nomsan",
@@ -69,8 +67,6 @@ py_test(
     data = [
         ":wide_dynamic_func_lut_wrapper.so",
     ],
-    python_version = "PY3",
-    srcs_version = "PY3",
     tags = [
         "noasan",
         "nomsan",

--- a/tensorflow/lite/micro/examples/hello_world/BUILD
+++ b/tensorflow/lite/micro/examples/hello_world/BUILD
@@ -47,8 +47,6 @@ py_binary(
     name = "evaluate",
     srcs = ["evaluate.py"],
     data = ["//tensorflow/lite/micro/examples/hello_world/models:hello_world_float.tflite"],
-    python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         "@absl_py//absl:app",
         "@absl_py//absl/flags",
@@ -66,8 +64,6 @@ py_binary(
         "//tensorflow/lite/micro/examples/hello_world/models:hello_world_float.tflite",
         "//tensorflow/lite/micro/examples/hello_world/models:hello_world_int8.tflite",
     ],
-    python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         ":evaluate",
     ],
@@ -76,7 +72,6 @@ py_binary(
 py_binary(
     name = "train",
     srcs = ["train.py"],
-    srcs_version = "PY3",
     deps = [
         requirement("numpy"),
         requirement("tensorflow"),

--- a/tensorflow/lite/micro/examples/hello_world/quantization/BUILD
+++ b/tensorflow/lite/micro/examples/hello_world/quantization/BUILD
@@ -5,8 +5,6 @@ py_binary(
     name = "ptq",
     srcs = ["ptq.py"],
     data = ["//tensorflow/lite/micro/examples/hello_world/models:hello_world_float.tflite"],
-    python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         "@absl_py//absl:app",
         "@absl_py//absl/flags",

--- a/tensorflow/lite/micro/examples/micro_speech/BUILD
+++ b/tensorflow/lite/micro/examples/micro_speech/BUILD
@@ -237,7 +237,6 @@ py_test(
         ":samples_1000ms",
     ],
     main = "evaluate_test.py",
-    python_version = "PY3",
     tags = [
         "noasan",
         "nomsan",  # Python doesn't like these symbols
@@ -256,7 +255,6 @@ py_test(
         ":samples_30ms",
     ],
     main = "audio_preprocessor_test.py",
-    python_version = "PY3",
     tags = [
         "noasan",
         "nomsan",  # Python doesn't like these symbols

--- a/tensorflow/lite/micro/examples/micro_speech/BUILD
+++ b/tensorflow/lite/micro/examples/micro_speech/BUILD
@@ -207,8 +207,6 @@ py_binary(
     data = [
         ":samples_30ms",
     ],
-    python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         "@absl_py//absl:app",
         "@absl_py//absl/flags",
@@ -226,8 +224,6 @@ py_binary(
     data = [
         ":models_tflite",
     ],
-    python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         ":audio_preprocessor",
     ],

--- a/tensorflow/lite/micro/examples/mnist_lstm/BUILD
+++ b/tensorflow/lite/micro/examples/mnist_lstm/BUILD
@@ -4,7 +4,6 @@ load("@tflm_pip_deps//:requirements.bzl", "requirement")
 py_binary(
     name = "train",
     srcs = ["train.py"],
-    srcs_version = "PY3",
     deps = [
         requirement("numpy"),
         requirement("tensorflow"),
@@ -14,7 +13,6 @@ py_binary(
 py_binary(
     name = "evaluate",
     srcs = ["evaluate.py"],
-    srcs_version = "PY3",
     deps = [
         "//python/tflite_micro:runtime",
         "@absl_py//absl:app",

--- a/tensorflow/lite/micro/examples/mnist_lstm/BUILD
+++ b/tensorflow/lite/micro/examples/mnist_lstm/BUILD
@@ -34,7 +34,6 @@ py_test(
         ":sample_images",
     ],
     main = "evaluate_test.py",
-    python_version = "PY3",
     tags = [
         "noasan",
         "nomsan",  # Python doesn't like these symbols

--- a/tensorflow/lite/micro/examples/person_detection/utils/BUILD
+++ b/tensorflow/lite/micro/examples/person_detection/utils/BUILD
@@ -9,8 +9,6 @@ package(
 py_binary(
     name = "raw_to_bitmap",
     srcs = ["raw_to_bitmap.py"],
-    python_version = "PY3",
-    srcs_version = "PY3ONLY",
     deps = [
         requirement("numpy"),
     ],
@@ -19,7 +17,6 @@ py_binary(
 py_library(
     name = "raw_to_bitmap_lib",
     srcs = ["raw_to_bitmap.py"],
-    srcs_version = "PY3",
     deps = [
         requirement("numpy"),
     ],
@@ -29,7 +26,6 @@ py_test(
     name = "raw_to_bitmap_test",
     srcs = ["raw_to_bitmap_test.py"],
     data = glob(["testdata/**"]),
-    python_version = "PY3",
     tags = [
         "nomicro_static",  # TF dep incompatible w/ TF_LITE_STATIC_MEMORY.
         "notap",  # TODO(b/186679612)

--- a/tensorflow/lite/micro/examples/recipes/BUILD
+++ b/tensorflow/lite/micro/examples/recipes/BUILD
@@ -8,7 +8,6 @@ package(
 py_library(
     name = "add_four_numbers",
     srcs = ["add_four_numbers.py"],
-    srcs_version = "PY3",
     visibility = ["//:__subpackages__"],
     deps = [
         requirement("numpy"),
@@ -19,7 +18,6 @@ py_library(
 py_library(
     name = "resource_variables_lib",
     srcs = ["resource_variables_lib.py"],
-    srcs_version = "PY3",
     visibility = ["//:__subpackages__"],
     deps = [
         requirement("numpy"),
@@ -30,7 +28,6 @@ py_library(
 py_test(
     name = "resource_variables_test",
     srcs = ["resource_variables_test.py"],
-    srcs_version = "PY3",
     tags = [
         "noasan",
         "nomsan",  # Python doesn't like these symbols

--- a/tensorflow/lite/micro/integration_tests/BUILD
+++ b/tensorflow/lite/micro/integration_tests/BUILD
@@ -12,8 +12,6 @@ py_binary(
         "templates/BUILD.mako",
         "templates/integration_tests_cc.mako",
     ],
-    python_version = "PY3",
-    srcs_version = "PY3",
     visibility = ["//:__subpackages__"],
     deps = [
         "@absl_py//absl:app",

--- a/tensorflow/lite/micro/kernels/testdata/BUILD
+++ b/tensorflow/lite/micro/kernels/testdata/BUILD
@@ -45,7 +45,6 @@ py_binary(
         "lstm_test_data_generator.py",
         "lstm_test_data_utils.py",
     ],
-    srcs_version = "PY3",
     deps = [
         "@absl_py//absl:app",
         requirement("numpy"),

--- a/tensorflow/lite/micro/kernels/testdata/BUILD
+++ b/tensorflow/lite/micro/kernels/testdata/BUILD
@@ -56,7 +56,6 @@ py_test(
     name = "lstm_test_data_generator_test",
     srcs = ["lstm_test_data_generator_test.py"],
     main = "lstm_test_data_generator_test.py",
-    python_version = "PY3",
     tags = [
         "noasan",
         "nomsan",  # Python doesn't like these symbols

--- a/tensorflow/lite/micro/python/tflite_size/src/BUILD
+++ b/tensorflow/lite/micro/python/tflite_size/src/BUILD
@@ -46,7 +46,6 @@ py_library(
     data = [
         ":flatbuffer_size_wrapper_pybind.so",
     ],
-    srcs_version = "PY3",
 )
 
 py_binary(
@@ -54,7 +53,6 @@ py_binary(
     srcs = [
         "flatbuffer_size.py",
     ],
-    srcs_version = "PY3",
     deps = [
         ":flatbuffer_size_lib",
     ],

--- a/tensorflow/lite/micro/python/tflite_size/tests/BUILD
+++ b/tensorflow/lite/micro/python/tflite_size/tests/BUILD
@@ -19,7 +19,6 @@ py_test(
         ":test_resources",
     ],
     main = "flatbuffer_size_test.py",
-    python_version = "PY3",
     tags = [
         "noasan",
         "nomsan",  # Python doesn't like these symbols from flatbuffer_size_wrapper_pybind.so

--- a/tensorflow/lite/micro/testing/BUILD
+++ b/tensorflow/lite/micro/testing/BUILD
@@ -89,8 +89,6 @@ py_library(
 py_binary(
     name = "generate_test_models",
     srcs = ["generate_test_models.py"],
-    python_version = "PY3",
-    srcs_version = "PY3ONLY",
     tags = [
         "nomicro_static",  # TF dep incompatible w/ TF_LITE_STATIC_MEMORY.
         "noubsan",  # TODO(b/144512025): Fix raw_to_bitmap_test to fix ubsan failure.

--- a/tensorflow/lite/micro/tools/BUILD
+++ b/tensorflow/lite/micro/tools/BUILD
@@ -31,7 +31,6 @@ py_library(
 py_library(
     name = "generate_test_for_model",
     srcs = ["generate_test_for_model.py"],
-    srcs_version = "PY3",
     visibility = ["//:__subpackages__"],
     deps = [
         "//tensorflow/lite/python:schema_py",
@@ -53,7 +52,6 @@ py_binary(
         "requantize_flatbuffer.py",
         "requantize_flatbuffer_utils.py",
     ],
-    srcs_version = "PY3",
     deps = [
         "//tensorflow/lite/python:schema_py",
         "//tensorflow/lite/tools:flatbuffer_utils",
@@ -65,7 +63,6 @@ py_test(
     name = "requantize_flatbuffer_test",
     srcs = ["requantize_flatbuffer_test.py"],
     main = "requantize_flatbuffer_test.py",
-    python_version = "PY3",
     tags = [
         "noasan",
         "nomsan",  # Python doesn't like these symbols
@@ -109,7 +106,6 @@ py_library(
     data = [
         ":tflite_flatbuffer_align_wrapper.so",
     ],
-    srcs_version = "PY3",
     visibility = [
         ":application_friends",
         ":tflm_tools",
@@ -126,7 +122,6 @@ py_library(
     data = [
         ":tflite_flatbuffer_align",
     ],
-    srcs_version = "PY3",
     visibility = [
         ":application_friends",
         ":tflm_tools",
@@ -167,8 +162,6 @@ cc_binary(
 py_binary(
     name = "tflm_model_transforms",
     srcs = ["tflm_model_transforms.py"],
-    python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         ":tflm_model_transforms_lib",
         "@absl_py//absl:app",
@@ -184,7 +177,6 @@ py_test(
         "//tensorflow/lite/micro/models",
     ],
     main = "tflm_model_transforms_test.py",
-    python_version = "PY3",
     tags = [
         "noasan",
         "nomsan",
@@ -201,8 +193,6 @@ py_test(
 py_binary(
     name = "layer_by_layer_debugger",
     srcs = ["layer_by_layer_debugger.py"],
-    python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         ":layer_by_layer_schema_py",
         ":model_transforms_utils",

--- a/tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver/BUILD
+++ b/tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver/BUILD
@@ -14,8 +14,6 @@ py_binary(
     data = [
         "templates/micro_mutable_op_resolver.h.mako",
     ],
-    python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         "@absl_py//absl:app",
         "@absl_py//absl/flags",
@@ -37,8 +35,6 @@ py_binary(
         "templates/micro_mutable_op_resolver.h.mako",
         "templates/micro_mutable_op_resolver_test.cc.mako",
     ],
-    python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         "@absl_py//absl:app",
         "@absl_py//absl/flags",

--- a/tensorflow/lite/python/BUILD
+++ b/tensorflow/lite/python/BUILD
@@ -16,7 +16,6 @@ flatbuffer_py_library(
 py_library(
     name = "schema_util",
     srcs = ["schema_util.py"],
-    srcs_version = "PY3",
     visibility = ["//:__subpackages__"],
     deps = [
         requirement("flatbuffers"),

--- a/tensorflow/lite/tools/BUILD
+++ b/tensorflow/lite/tools/BUILD
@@ -3,7 +3,6 @@ load("@tflm_pip_deps//:requirements.bzl", "requirement")
 py_library(
     name = "flatbuffer_utils",
     srcs = ["flatbuffer_utils.py"],
-    srcs_version = "PY3",
     visibility = ["//:__subpackages__"],
     deps = [
         "@flatbuffers//:runtime_py",
@@ -16,7 +15,6 @@ py_library(
 py_library(
     name = "test_utils",
     srcs = ["test_utils.py"],
-    srcs_version = "PY3",
     deps = [
         "@flatbuffers//:runtime_py",
         requirement("tensorflow"),
@@ -27,8 +25,6 @@ py_library(
 py_binary(
     name = "strip_strings",
     srcs = ["strip_strings.py"],
-    python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         ":flatbuffer_utils",
         "@absl_py//absl:app",
@@ -39,8 +35,6 @@ py_binary(
 py_binary(
     name = "visualize",
     srcs = ["visualize.py"],
-    python_version = "PY3",
-    srcs_version = "PY3",
     visibility = ["//:__subpackages__"],
     deps = [
         "//tensorflow/lite/python:schema_py",
@@ -51,8 +45,6 @@ py_binary(
 py_test(
     name = "flatbuffer_utils_test",
     srcs = ["flatbuffer_utils_test.py"],
-    python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         ":flatbuffer_utils",
         ":test_utils",
@@ -63,8 +55,6 @@ py_test(
 py_test(
     name = "visualize_test",
     srcs = ["visualize_test.py"],
-    python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         ":test_utils",
         ":visualize",


### PR DESCRIPTION
These tags have been deprecated and are unused now. Syncing with upstream and removing them from the BUILD files.

BUG=remove deprecated tags