### PR TITLE
Remove hexdump_test.cc from source list

### DIFF
--- a/tensorflow/lite/micro/hexdump.cc
+++ b/tensorflow/lite/micro/hexdump.cc
@@ -17,7 +17,7 @@
 #include <algorithm>
 #include <cctype>
 
-#include "tensorflow/lite/micro/debug_log.h"
+#include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/static_vector.h"
 
 namespace {
@@ -35,10 +35,10 @@ tflite::Span<char> output(const tflite::Span<char>& buf, const char* format,
   va_start(args, format);
 
   if (buf.data() == nullptr) {
-    DebugLog(format, args);
+    VMicroPrintf(format, args);
     result = {nullptr, 0};
   } else {
-    size_t len = DebugVsnprintf(buf.data(), buf.size(), format, args);
+    size_t len = MicroVsnprintf(buf.data(), buf.size(), format, args);
     // Returns the number of characters that would have been written if
     // there were enough room, so cap it at the size of the buffer in order to
     // know how much was actually written.

--- a/tensorflow/lite/micro/hexdump.cc
+++ b/tensorflow/lite/micro/hexdump.cc
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdarg>
 
 #include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/static_vector.h"

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -333,6 +333,7 @@ $(wildcard $(TENSORFLOW_ROOT)tensorflow/lite/micro/tools/benchmarking/*benchmark
 MICROLITE_TEST_SRCS := \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/fake_micro_context_test.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/flatbuffer_utils_test.cc \
+$(TENSORFLOW_ROOT)tensorflow/lite/micro/hexdump_test.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/memory_arena_threshold_test.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/memory_helpers_test.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/micro_allocator_test.cc \

--- a/tensorflow/lite/micro/tools/make/targets/bluepill_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/bluepill_makefile.inc
@@ -77,10 +77,14 @@ MICROLITE_CC_SRCS := $(filter-out $(EXCLUDED_SRCS), $(MICROLITE_CC_SRCS))
 # which use std::vector constructor which then invokes new.
 # Excludes memory_arena_threshold_test because the size difference of some
 # allocator classes between different architectures.
+# Excluded hexdump_test, which fails eve
 # TODO(b/158651472): Fix the memory_arena_threshold_test
+# TODO(b/b/410801324): Fix hexdump_test for Bluepill
 EXCLUDED_TESTS := \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/micro_allocator_test.cc \
-  $(TENSORFLOW_ROOT)tensorflow/lite/micro/memory_arena_threshold_test.cc
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/memory_arena_threshold_test.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/hexdump_test.cc
+
 
 # flatbuffer_utils_test is intentionaly disabled because the flexbuffer builder
 # uses dynamic memory.

--- a/tensorflow/lite/micro/tools/make/targets/bluepill_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/bluepill_makefile.inc
@@ -77,14 +77,14 @@ MICROLITE_CC_SRCS := $(filter-out $(EXCLUDED_SRCS), $(MICROLITE_CC_SRCS))
 # which use std::vector constructor which then invokes new.
 # Excludes memory_arena_threshold_test because the size difference of some
 # allocator classes between different architectures.
-# Excluded hexdump_test, which fails eve
+# Excludes hexdump_test because it fails in release model when MicroVsnprintf
+# isn't defined.
 # TODO(b/158651472): Fix the memory_arena_threshold_test
 # TODO(b/b/410801324): Fix hexdump_test for Bluepill
 EXCLUDED_TESTS := \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/micro_allocator_test.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/memory_arena_threshold_test.cc \
   $(TENSORFLOW_ROOT)tensorflow/lite/micro/hexdump_test.cc
-
 
 # flatbuffer_utils_test is intentionaly disabled because the flexbuffer builder
 # uses dynamic memory.


### PR DESCRIPTION
As a unit test, it belongs on MICROLITE_TEST_SRCS, which gets filtered out of MICROLITE_CC_SRCS. Keeping it on the source list results in it being compiled into the tflm archive, where its main() function conflicts with the application's main.
Also, since hexdump.cc calls DebugVsnprintf(), we need to define it in debug_log.cc, also when TF_LITE_STRIP_ERROR_STRINGS is #defined, else compilation fails. Move the #ifdef TF_LITE_STRIP_ERROR_STRINGS to be inside the function implementation, rather around the whole function.

BUG=384562154