### PR TITLE
Missing build dep for hexdump.

### DIFF
--- a/tensorflow/lite/micro/BUILD
+++ b/tensorflow/lite/micro/BUILD
@@ -432,7 +432,7 @@ tflm_cc_library(
         "hexdump.h",
     ],
     deps = [
-        ":debug_log",
+        ":micro_log",
         ":span",
         ":static_vector",
     ],


### PR DESCRIPTION
Build fail in some cases because missing dep.

BUG=simple fix