### PR TITLE
Fix set_external_context() during state kInit

### DIFF
--- a/tensorflow/lite/micro/micro_interpreter_context.cc
+++ b/tensorflow/lite/micro/micro_interpreter_context.cc
@@ -112,7 +112,8 @@ void MicroInterpreterContext::SetScratchBufferHandles(
 
 TfLiteStatus MicroInterpreterContext::set_external_context(
     void* external_context_payload) {
-  TFLITE_DCHECK(state_ == InterpreterState::kPrepare ||
+  TFLITE_DCHECK(state_ == InterpreterState::kInit ||
+                state_ == InterpreterState::kPrepare ||
                 state_ == InterpreterState::kInvoke);
   if (external_context_payload == nullptr ||
       external_context_payload_ != nullptr) {


### PR DESCRIPTION
@tensorflow/micro

Fixes MicroInterpreterContext::set_external_context so that it can be called during InterpreterState::kInit.

Add unit test for kInit state.
Cleanup other external context tests.

bug=fixes #3101