### PR TITLE
Fix generate_cc_array treating empty CSV as single-element array

### DIFF
--- a/tensorflow/lite/micro/tools/generate_cc_arrays.py
+++ b/tensorflow/lite/micro/tools/generate_cc_arrays.py
@@ -86,6 +86,8 @@ def generate_array(input_fname):
     with open(input_fname, 'r') as input_file:
       # Assume one array per csv file.
       elements = input_file.readline()
+      if elements.strip() == "":
+        return [0, ""]
       return [len(elements.split(',')), elements]
   elif input_fname.endswith('.npy'):
     data = np.float32(np.load(input_fname, allow_pickle=False))


### PR DESCRIPTION
Previously, an empty .csv file was incorrectly interpreted as a single-element array due to the behavior of str.split(',') on empty strings returning [''] (length 1). This patch explicitly checks for empty or whitespace-only lines and correctly returns a size of 0 and an empty array definition.