### PR TITLE
feat(python): add compression module to tflite_micro Python package

### DIFF
--- a/python/tflite_micro/BUILD
+++ b/python/tflite_micro/BUILD
@@ -130,6 +130,7 @@ py_package(
     # in the tflm tree.
     packages = [
         "python.tflite_micro",
+        "tensorflow.lite.micro.compression",
         "tensorflow.lite.micro.tools.generate_test_for_model",
         "tensorflow.lite.python",
         "tensorflow.lite.tools.flatbuffer_utils",
@@ -138,6 +139,7 @@ py_package(
         ":postinstall_check",
         ":runtime",
         ":version",
+        "//tensorflow/lite/micro/compression",
     ],
 )
 
@@ -223,8 +225,10 @@ py_wheel(
         ":local": "py3",
     }),
     requires = [
+        "bitarray",
         "flatbuffers",
         "numpy",
+        "pyyaml",
         "tensorflow",
     ],
     stamp = 1,  # 1 == always stamp

--- a/python/tflite_micro/__init__.py
+++ b/python/tflite_micro/__init__.py
@@ -24,5 +24,8 @@ from tflite_micro.python.tflite_micro import runtime
 # Unambiguously identify the source used to build the package.
 from tflite_micro.python.tflite_micro._version import __version__
 
-# Ordered after `runtime` to avoid a circular dependency
+# Provide a convenient alias for the compression module
+from tflite_micro.tensorflow.lite.micro import compression
+
+# Ordered after `runtime` and `compression` to avoid circular dependencies
 from tflite_micro.python.tflite_micro import postinstall_check

--- a/python/tflite_micro/postinstall_check.py
+++ b/python/tflite_micro/postinstall_check.py
@@ -19,13 +19,17 @@
 # in the Python installation environment rather than to locations in the tflm
 # source tree.
 from tflite_micro import runtime
+from tflite_micro import compression
 
 import numpy as np
 import pkg_resources
 import sys
+import tempfile
+import os
 
 
-def passed():
+def runtime_test():
+  """Test the runtime interpreter functionality."""
   # Create an interpreter with a sine model
   model = pkg_resources.resource_filename(__name__, "sine_float.tflite")
   interpreter = runtime.Interpreter.from_file(model)
@@ -47,6 +51,24 @@ def passed():
   goldens = np.sin(inputs)
 
   return np.allclose(outputs, goldens, atol=0.05)
+
+
+def compression_test():
+  """Test that the compression module is available and functional."""
+
+  # Test that compress function is available
+  # We don't actually compress here as it requires a properly structured model
+  # with compressible tensors, but we verify the function is importable
+  assert callable(compression.compress)
+
+  return True
+
+
+def passed():
+  """Run all postinstall checks."""
+  runtime_passed = runtime_test()
+  compression_passed = compression_test()
+  return runtime_passed and compression_passed
 
 
 if __name__ == "__main__":

--- a/tensorflow/lite/micro/compression/BUILD
+++ b/tensorflow/lite/micro/compression/BUILD
@@ -8,12 +8,21 @@ load(
     "flatbuffer_cc_library",
     "flatbuffer_py_library",
 )
-load("@rules_python//python:defs.bzl", "py_test")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@tflm_pip_deps//:requirements.bzl", "requirement")
 
 package(
     default_visibility = [
         "//visibility:public",
+    ],
+)
+
+py_library(
+    name = "compression",
+    srcs = ["__init__.py"],
+    deps = [
+        ":compress_lib",
+        ":spec",
     ],
 )
 
@@ -96,8 +105,8 @@ py_test(
     ],
 )
 
-py_binary(
-    name = "compress",
+py_library(
+    name = "compress_lib",
     srcs = [
         "compress.py",
     ],
@@ -110,6 +119,16 @@ py_binary(
         "@flatbuffers//:runtime_py",
         requirement("bitarray"),
         requirement("numpy"),
+    ],
+)
+
+py_binary(
+    name = "compress",
+    srcs = [
+        "compress.py",
+    ],
+    deps = [
+        ":compress_lib",
     ],
 )
 

--- a/tensorflow/lite/micro/compression/__init__.py
+++ b/tensorflow/lite/micro/compression/__init__.py
@@ -1,0 +1,26 @@
+# Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""TensorFlow Lite for Microcontrollers compression module."""
+
+# This __init__.py file exists to make compression features available as part
+# of the tflite_micro Python package.
+#
+# Usage example:
+#   from tflite_micro import compression
+#   ...
+
+from .compress import compress
+from .spec import parse_yaml
+
+__all__ = ["compress", "parse_yaml"]


### PR DESCRIPTION
feat(python): add compression module to tflite_micro Python package

Integrate the TFLM compression tools into the tflite_micro Python
package, allowing users to compress models directly from Python code
that imports the package.

Usage:
  from tflite_micro import compression

Details:
- Add compress_lib py_library target in compression BUILD
- Create compression package with __init__.py exposing public API
- Include compression module in Python package dependencies
- Add compression dependencies to wheel requirements

BUG=see description