### PR TITLE
Replace mlplatform links for ethos-u with updated gitlab links (#3148)

### DIFF
--- a/tensorflow/lite/micro/cortex_m_corstone_300/README.md
+++ b/tensorflow/lite/micro/cortex_m_corstone_300/README.md
@@ -10,7 +10,7 @@ https://developer.arm.com/ip-products/subsystem/corstone/corstone-300)
 
 Building the Corstone-300 based target has the following dependencies:
 
--   [Arm Ethos-U Core Platform](https://review.mlplatform.org/admin/repos/ml/ethos-u/ethos-u-core-platform)
+-   [Arm Ethos-U Core Platform](https://gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-core-platform)
     -   Arm Ethos-U Core Platform provides the linker file as well as UART and retarget functions.
 -   [CMSIS](https://github.com/ARM-software/CMSIS_6) + [CMSIS-Cortex_DFP](https://github.com/ARM-software/Cortex_DFP)
     -   CMSIS provides startup functionality, e.g. for setting up interrupt handlers and clock speed.

--- a/tensorflow/lite/micro/kernels/ethos_u/README.md
+++ b/tensorflow/lite/micro/kernels/ethos_u/README.md
@@ -4,7 +4,7 @@
 Arm(R) Ethos(TM)-U is a new class of machine learning processors, called a
 microNPU, specifically designed to accelerate ML inference in area-constrained
 embedded and IoT devices. This readme briefly describes how to integrate Ethos-U
-related hardware and software into TFLM. See also [Ethos-U ML Evaluation kit examples](https://review.mlplatform.org/plugins/gitiles/ml/ethos-u/ml-embedded-evaluation-kit).
+related hardware and software into TFLM. See also [Ethos-U ML Evaluation kit examples](https://gitlab.arm.com/artificial-intelligence/ethos-u/ml-embedded-evaluation-kit).
 
 To enable the Ethos-U software stack, add `CO_PROCESSOR=ethos_u` to the make
 command. Use ETHOSU_ARCH to specify the architecture. See examples below.
@@ -18,7 +18,7 @@ The TFLM runtime will dispatch workloads to Ethos-U when it encounters an
 Ethos-U custom op in the tflite file. See an ASCII art example below.
 The Ethos-U custom op is added by a tool called Ethos-U Vela and contains
 information the Ethos-U hardware need to execute the workload. More info in the
-[Vela repository](https://review.mlplatform.org/plugins/gitiles/ml/ethos-u/ethos-u-vela).
+[Vela repository](https://gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-vela).
 
 ```
      | tensor0
@@ -44,9 +44,9 @@ information the Ethos-U hardware need to execute the workload. More info in the
 ```
 
 Note that the `ethousu_init()` API of the Ethos-U driver need to be called at
-startup, before calling the TFLM API. More info in the [Ethos-U driver repo](https://review.mlplatform.org/plugins/gitiles/ml/ethos-u/ethos-u-core-driver).
+startup, before calling the TFLM API. More info in the [Ethos-U driver repo](https://gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-core-driver).
 
-For even more info regarding Vela and Ethos-U, checkout [Ethos-U landing page](https://review.mlplatform.org/plugins/gitiles/ml/ethos-u/ethos-u/+/refs/heads/master).
+For even more info regarding Vela and Ethos-U, checkout [Ethos-U landing page](https://gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u/-/tree/main).
 
 # Some examples of compiling a binary and running a network with Ethos-U support.
 In order to run a test with Ethos-U55 enabled, a platform with corresponding

--- a/tensorflow/lite/micro/tools/make/ethos_u_core_driver_download.sh
+++ b/tensorflow/lite/micro/tools/make/ethos_u_core_driver_download.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2025 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ else
     exit 1
   fi
 
-  git clone "https://review.mlplatform.org/ml/ethos-u/ethos-u-core-driver" \
+  git clone "https://gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-core-driver" \
       ${DOWNLOADED_ETHOS_U_CORE_DRIVER_PATH} >&2
   pushd ${DOWNLOADED_ETHOS_U_CORE_DRIVER_PATH} > /dev/null
   git -c advice.detachedHead=false checkout 9622608a5cc318c0933bcce720b59737d03bfb6f

--- a/tensorflow/lite/micro/tools/make/ethos_u_core_platform_download.sh
+++ b/tensorflow/lite/micro/tools/make/ethos_u_core_platform_download.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2025 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ else
     exit 1
   fi
 
-  git clone "https://review.mlplatform.org/ml/ethos-u/ethos-u-core-platform" ${DOWNLOADED_ETHOS_U_CORE_PLATFORM_PATH} >&2
+  git clone "https://gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-core-platform" ${DOWNLOADED_ETHOS_U_CORE_PLATFORM_PATH} >&2
   pushd ${DOWNLOADED_ETHOS_U_CORE_PLATFORM_PATH} > /dev/null
   git checkout e25a89dec1cf990f3168dbd6c565e3b0d51cb151 >&2
   rm -rf .git


### PR DESCRIPTION
BUG=#3148
 * Updates all references from mlplatform  to gitlab when referring to ethos-u dependencies