### PR TITLE
Fix mergify batch merge issue

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,3 +1,6 @@
+merge_queue:
+  max_parallel_checks: 1
+
 queue_rules:
   - name: default
     checks_timeout: 2 h


### PR DESCRIPTION
Mergify recently added ability for batch merge, but that doesn't play well with our setup.
Setting max_parallel_check to 1 should resolve the issue and go back to how it was working before.

BUG=mergify fix