### PR TITLE
feat(python): throw error when loading compressed models without support

### DIFF
--- a/python/tflite_micro/BUILD
+++ b/python/tflite_micro/BUILD
@@ -49,6 +49,7 @@ pybind_extension(
     # target = _runtime.so because pybind_extension() appends suffix
     srcs = [
         "_runtime.cc",
+        "compression_utils.h",
         "interpreter_wrapper.cc",
         "interpreter_wrapper.h",
         "numpy_utils.cc",
@@ -95,6 +96,27 @@ py_test(
         requirement("tensorflow"),
         "//tensorflow/lite/micro/examples/recipes:add_four_numbers",
         "//tensorflow/lite/micro/testing:generate_test_models_lib",
+    ],
+)
+
+py_test(
+    name = "test_compression_unsupported",
+    srcs = ["test_compression_unsupported.py"],
+    tags = [
+        "noasan",
+        "nomsan",  # Python doesn't like these symbols in _runtime.so
+        "noubsan",
+    ],
+    # Only compatible when compression is NOT enabled
+    target_compatible_with = select({
+        "//:with_compression_enabled": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":runtime",
+        requirement("numpy"),
+        requirement("tensorflow"),
+        "//tensorflow/lite/micro/compression",
     ],
 )
 

--- a/python/tflite_micro/compression_utils.h
+++ b/python/tflite_micro/compression_utils.h
@@ -1,0 +1,56 @@
+/* Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_LITE_MICRO_PYTHON_COMPRESSION_UTILS_H_
+#define TENSORFLOW_LITE_MICRO_PYTHON_COMPRESSION_UTILS_H_
+
+#include <cstring>
+
+#include "tensorflow/lite/schema/schema_generated.h"
+
+namespace tflite {
+
+// Returns true if interpreter was built with compression support.
+// When USE_TFLM_COMPRESSION is defined, this always returns true and
+// the compiler can optimize away any if (!IsCompressionSupported()) branches.
+inline constexpr bool IsCompressionSupported() {
+#ifdef USE_TFLM_COMPRESSION
+  return true;
+#else
+  return false;
+#endif
+}
+
+// Helper to check if model has compression metadata.
+// This is always compiled in, but when used with IsCompressionSupported()
+// the entire check can be optimized away.
+inline bool HasCompressionMetadata(const Model& model) {
+  if (!model.metadata()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < model.metadata()->size(); ++i) {
+    const auto* metadata = model.metadata()->Get(i);
+    if (metadata && metadata->name() &&
+        strcmp(metadata->name()->c_str(), "COMPRESSION_METADATA") == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace tflite
+
+#endif  // TENSORFLOW_LITE_MICRO_PYTHON_COMPRESSION_UTILS_H_

--- a/python/tflite_micro/test_compression_unsupported.py
+++ b/python/tflite_micro/test_compression_unsupported.py
@@ -1,0 +1,95 @@
+# Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Test compression metadata detection when compression is disabled."""
+
+import os
+import numpy as np
+import tensorflow as tf
+from tflite_micro.python.tflite_micro import runtime
+from tflite_micro.tensorflow.lite.micro import compression
+
+
+class CompressionDetectionTest(tf.test.TestCase):
+  """Test compression metadata detection when compression is disabled."""
+
+  def _create_test_model(self):
+    """Create a simple quantized model for testing."""
+    model = tf.keras.Sequential([
+        tf.keras.layers.Dense(10, input_shape=(5, ), activation='relu'),
+        tf.keras.layers.Dense(5, activation='softmax')
+    ])
+    model.compile(optimizer='adam', loss='sparse_categorical_crossentropy')
+
+    # Convert to quantized TFLite
+    converter = tf.lite.TFLiteConverter.from_keras_model(model)
+    converter.optimizations = [tf.lite.Optimize.DEFAULT]
+
+    def representative_dataset():
+      for _ in range(10):
+        yield [np.random.randn(1, 5).astype(np.float32)]
+
+    converter.representative_dataset = representative_dataset
+    converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
+    converter.inference_input_type = tf.uint8
+    converter.inference_output_type = tf.uint8
+
+    tflite_model = converter.convert()
+    return bytes(tflite_model) if isinstance(tflite_model,
+                                             bytearray) else tflite_model
+
+  def test_regular_model_loads_successfully(self):
+    """Non-compressed models should load without issues."""
+    model_data = self._create_test_model()
+    interpreter = runtime.Interpreter.from_bytes(model_data)
+    self.assertIsNotNone(interpreter)
+
+  def test_compressed_model_raises_runtime_error(self):
+    """Compressed models should raise RuntimeError when compression is disabled."""
+    # Create and compress a model
+    model_data = self._create_test_model()
+
+    spec = (compression.SpecBuilder().add_tensor(
+        subgraph=0, tensor=1).with_lut(index_bitwidth=4).build())
+
+    compressed_model = compression.compress(model_data, spec)
+    if isinstance(compressed_model, bytearray):
+      compressed_model = bytes(compressed_model)
+
+    # Should raise RuntimeError
+    with self.assertRaises(RuntimeError):
+      runtime.Interpreter.from_bytes(compressed_model)
+
+  def test_can_load_regular_after_compressed_failure(self):
+    """Verify we can still load regular models after compressed model fails."""
+    model_data = self._create_test_model()
+
+    # First try compressed model (should fail)
+    spec = (compression.SpecBuilder().add_tensor(
+        subgraph=0, tensor=1).with_lut(index_bitwidth=4).build())
+    compressed_model = compression.compress(model_data, spec)
+
+    with self.assertRaises(RuntimeError):
+      runtime.Interpreter.from_bytes(bytes(compressed_model))
+
+    # Then load regular model (should succeed)
+    interpreter = runtime.Interpreter.from_bytes(model_data)
+    self.assertIsNotNone(interpreter)
+
+
+if __name__ == '__main__':
+  # Set TF environment variables to suppress warnings
+  os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
+  os.environ['TF_ENABLE_ONEDNN_OPTS'] = '0'
+  tf.test.main()


### PR DESCRIPTION
When a model contains COMPRESSION_METADATA but the interpreter was built
without compression support, throw a RuntimeError with a helpful message
directing users to build with --//:with_compression=true.

The implementation uses inline functions in compression_utils.h
that are optimized away when compression is disabled, ensuring
all code paths remain compile-checked, and readable without
preprocessor clutter.

Includes test_compression_unsupported.py to verify the error detection,
which only runs when compression is disabled.

BUG=#3125