### PR TITLE
Fix non-unique /tmp filenames in external library download scripts

### DIFF
--- a/tensorflow/lite/micro/tools/make/ext_libs/cmsis_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/cmsis_download.sh
@@ -48,28 +48,39 @@ if [ -d ${DOWNLOADED_CMSIS_PATH} ]; then
   echo >&2 "${DOWNLOADED_CMSIS_PATH} already exists, skipping the download."
 else
 
+  # Create unique temporary directory name with username for better isolation
+  USERNAME=$(whoami 2>/dev/null || echo "unknown")
+  TEMP_DIR="/tmp/cmsis_dld_${USERNAME}_$(date +%s)_$$"
+  if ! mkdir -p "${TEMP_DIR}"; then
+      echo "ERROR: Failed to create temporary directory ${TEMP_DIR}" >&2
+      exit 1
+  fi
+
+  # Set up cleanup trap for all exit conditions
+  trap 'rm -rf "${TEMP_DIR}"' EXIT INT TERM
+
   ZIP_PREFIX="5782d6f8057906d360f4b95ec08a2354afe5c9b9"
   CMSIS_URL="http://github.com/ARM-software/CMSIS_6/archive/${ZIP_PREFIX}.zip"
   CMSIS_MD5="563e7c6465f63bdc034359e9b536b366"
 
   # wget is much faster than git clone of the entire repo. So we wget a specific
   # version and can then apply a patch, as needed.
-  wget ${CMSIS_URL} -O /tmp/${ZIP_PREFIX}.zip >&2
-  check_md5 /tmp/${ZIP_PREFIX}.zip ${CMSIS_MD5}
+  wget ${CMSIS_URL} -O ${TEMP_DIR}/${ZIP_PREFIX}.zip >&2
+  check_md5 ${TEMP_DIR}/${ZIP_PREFIX}.zip ${CMSIS_MD5}
 
-  unzip -qo /tmp/${ZIP_PREFIX}.zip -d /tmp >&2
-  mv /tmp/CMSIS_6-${ZIP_PREFIX} ${DOWNLOADED_CMSIS_PATH}
+  unzip -qo ${TEMP_DIR}/${ZIP_PREFIX}.zip -d ${TEMP_DIR} >&2
+  mv ${TEMP_DIR}/CMSIS_6-${ZIP_PREFIX} ${DOWNLOADED_CMSIS_PATH}
 
   # Also pull the related CMSIS Cortex_DFP component for generic Arm Cortex-M device support
   ZIP_PREFIX="c2c70a97a20fb355815e2ead3d4a40e35a4a3cdf"
   CMSIS_DFP_URL="http://github.com/ARM-software/Cortex_DFP/archive/${ZIP_PREFIX}.zip"
   CMSIS_DFP_MD5="3cbb6955b6d093a2fe078ef2341f6b89"
 
-  wget ${CMSIS_DFP_URL} -O /tmp/${ZIP_PREFIX}.zip >&2
-  check_md5 /tmp/${ZIP_PREFIX}.zip ${CMSIS_DFP_MD5}
+  wget ${CMSIS_DFP_URL} -O ${TEMP_DIR}/${ZIP_PREFIX}.zip >&2
+  check_md5 ${TEMP_DIR}/${ZIP_PREFIX}.zip ${CMSIS_DFP_MD5}
 
-  unzip -qo /tmp/${ZIP_PREFIX}.zip -d /tmp >&2
-  mv /tmp/Cortex_DFP-${ZIP_PREFIX} ${DOWNLOADED_CORTEX_DFP_PATH}
+  unzip -qo ${TEMP_DIR}/${ZIP_PREFIX}.zip -d ${TEMP_DIR} >&2
+  mv ${TEMP_DIR}/Cortex_DFP-${ZIP_PREFIX} ${DOWNLOADED_CORTEX_DFP_PATH}
 
 fi
 

--- a/tensorflow/lite/micro/tools/make/ext_libs/cmsis_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/cmsis_download.sh
@@ -48,13 +48,8 @@ if [ -d ${DOWNLOADED_CMSIS_PATH} ]; then
   echo >&2 "${DOWNLOADED_CMSIS_PATH} already exists, skipping the download."
 else
 
-  # Create unique temporary directory name with username for better isolation
-  USERNAME=$(whoami 2>/dev/null || echo "unknown")
-  TEMP_DIR="/tmp/cmsis_dld_${USERNAME}_$(date +%s)_$$"
-  if ! mkdir -p "${TEMP_DIR}"; then
-      echo "ERROR: Failed to create temporary directory ${TEMP_DIR}" >&2
-      exit 1
-  fi
+  # Create a temporary directory with the unique name for better isolation
+  TEMP_DIR=$(mktemp -d /tmp/$(basename $0 .sh).XXXXXX)
 
   # Set up cleanup trap for all exit conditions
   trap 'rm -rf "${TEMP_DIR}"' EXIT INT TERM

--- a/tensorflow/lite/micro/tools/make/ext_libs/cmsis_nn_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/cmsis_nn_download.sh
@@ -52,13 +52,25 @@ elif [ ! -d ${DOWNLOADS_DIR} ]; then
 elif [ -d ${DOWNLOADED_CMSIS_NN_PATH} ]; then
   echo >&2 "${DOWNLOADED_CMSIS_NN_PATH} already exists, skipping the download."
 else
+
+  # Create unique temporary directory name with username for better isolation
+  USERNAME=$(whoami 2>/dev/null || echo "unknown")
+  TEMP_DIR="/tmp/cmsis_nn_dld_${USERNAME}_$(date +%s)_$$"
+  if ! mkdir -p "${TEMP_DIR}"; then
+      echo "ERROR: Failed to create temporary directory ${TEMP_DIR}" >&2
+      exit 1
+  fi
+
+  # Set up cleanup trap for all exit conditions
+  trap 'rm -rf "${TEMP_DIR}"' EXIT INT TERM
+
   # wget is much faster than git clone of the entire repo. So we wget a specific
   # version and can then apply a patch, as needed.
-  wget ${CMSIS_NN_URL} -O /tmp/${ZIP_PREFIX_NN}.zip >&2
-  check_md5 /tmp/${ZIP_PREFIX_NN}.zip ${CMSIS_NN_MD5}
+  wget ${CMSIS_NN_URL} -O ${TEMP_DIR}/${ZIP_PREFIX_NN}.zip >&2
+  check_md5 ${TEMP_DIR}/${ZIP_PREFIX_NN}.zip ${CMSIS_NN_MD5}
 
-  unzip -qo /tmp/${ZIP_PREFIX_NN}.zip -d /tmp >&2
-  mv /tmp/CMSIS-NN-${ZIP_PREFIX_NN} ${DOWNLOADED_CMSIS_NN_PATH}
+  unzip -qo ${TEMP_DIR}/${ZIP_PREFIX_NN}.zip -d ${TEMP_DIR} >&2
+  mv ${TEMP_DIR}/CMSIS-NN-${ZIP_PREFIX_NN} ${DOWNLOADED_CMSIS_NN_PATH}
 fi
 
 echo "SUCCESS"

--- a/tensorflow/lite/micro/tools/make/ext_libs/cmsis_nn_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/cmsis_nn_download.sh
@@ -53,13 +53,8 @@ elif [ -d ${DOWNLOADED_CMSIS_NN_PATH} ]; then
   echo >&2 "${DOWNLOADED_CMSIS_NN_PATH} already exists, skipping the download."
 else
 
-  # Create unique temporary directory name with username for better isolation
-  USERNAME=$(whoami 2>/dev/null || echo "unknown")
-  TEMP_DIR="/tmp/cmsis_nn_dld_${USERNAME}_$(date +%s)_$$"
-  if ! mkdir -p "${TEMP_DIR}"; then
-      echo "ERROR: Failed to create temporary directory ${TEMP_DIR}" >&2
-      exit 1
-  fi
+  # Create a temporary directory with the unique name for better isolation
+  TEMP_DIR=$(mktemp -d /tmp/$(basename $0 .sh).XXXXXX)
 
   # Set up cleanup trap for all exit conditions
   trap 'rm -rf "${TEMP_DIR}"' EXIT INT TERM

--- a/tensorflow/lite/micro/tools/make/ext_libs/eyalroz_printf_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/eyalroz_printf_download.sh
@@ -47,17 +47,28 @@ if [ -d ${DOWNLOADED_PRINTF_PATH} ]; then
   echo >&2 "${DOWNLOADED_PRINTF_PATH} already exists, skipping the download."
 else
 
+  # Create unique temporary directory name with username for better isolation
+  USERNAME=$(whoami 2>/dev/null || echo "unknown")
+  TEMP_DIR="/tmp/eyalroz_dld_${USERNAME}_$(date +%s)_$$"
+  if ! mkdir -p "${TEMP_DIR}"; then
+      echo "ERROR: Failed to create temporary directory ${TEMP_DIR}" >&2
+      exit 1
+  fi
+
+  # Set up cleanup trap for all exit conditions
+  trap 'rm -rf "${TEMP_DIR}"' EXIT INT TERM
+
   ZIP_PREFIX="f8ed5a9bd9fa8384430973465e94aa14c925872d"
   PRINTF_URL="https://github.com/eyalroz/printf/archive/${ZIP_PREFIX}.zip"
   PRINTF_MD5="5772534c1d6f718301bca1fefaba28f3"
 
   # wget is much faster than git clone of the entire repo. So we wget a specific
   # version and can then apply a patch, as needed.
-  wget ${PRINTF_URL} -O /tmp/${ZIP_PREFIX}.zip >&2
-  check_md5 /tmp/${ZIP_PREFIX}.zip ${PRINTF_MD5}
+  wget ${PRINTF_URL} -O ${TEMP_DIR}/${ZIP_PREFIX}.zip >&2
+  check_md5 ${TEMP_DIR}/${ZIP_PREFIX}.zip ${PRINTF_MD5}
 
-  unzip -qo /tmp/${ZIP_PREFIX}.zip -d /tmp >&2
-  mv /tmp/printf-${ZIP_PREFIX} ${DOWNLOADED_PRINTF_PATH}
+  unzip -qo ${TEMP_DIR}/${ZIP_PREFIX}.zip -d ${TEMP_DIR} >&2
+  mv ${TEMP_DIR}/printf-${ZIP_PREFIX} ${DOWNLOADED_PRINTF_PATH}
 fi
 
 echo "SUCCESS"

--- a/tensorflow/lite/micro/tools/make/ext_libs/eyalroz_printf_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/eyalroz_printf_download.sh
@@ -47,13 +47,8 @@ if [ -d ${DOWNLOADED_PRINTF_PATH} ]; then
   echo >&2 "${DOWNLOADED_PRINTF_PATH} already exists, skipping the download."
 else
 
-  # Create unique temporary directory name with username for better isolation
-  USERNAME=$(whoami 2>/dev/null || echo "unknown")
-  TEMP_DIR="/tmp/eyalroz_dld_${USERNAME}_$(date +%s)_$$"
-  if ! mkdir -p "${TEMP_DIR}"; then
-      echo "ERROR: Failed to create temporary directory ${TEMP_DIR}" >&2
-      exit 1
-  fi
+  # Create a temporary directory with the unique name for better isolation
+  TEMP_DIR=$(mktemp -d /tmp/$(basename $0 .sh).XXXXXX)
 
   # Set up cleanup trap for all exit conditions
   trap 'rm -rf "${TEMP_DIR}"' EXIT INT TERM


### PR DESCRIPTION
Description:
bug=fixes https://github.com/tensorflow/tflite-micro/issues/3042

## Problem
Multiple users or processes compiling tflite-micro simultaneously encounter permission conflicts due to fixed temporary filenames in `/tmp`.

## Solution
- Create unique temporary directories using username, PID, and timestamp
- Implement automatic cleanup on all exit conditions

## Files Modified
- tensorflow/lite/micro/tools/make/ext_libs/cmsis_download.sh
- tensorflow/lite/micro/tools/make/ext_libs/cmsis_nn_download.sh
- tensorflow/lite/micro/tools/make/ext_libs/eyalroz_printf_download.sh

## Testing
Tested with multiple concurrent users - no more /tmp conflicts.