### PR TITLE
Support TfLite schema buffer and custom options offsets

### DIFF
--- a/tensorflow/lite/micro/micro_allocator.h
+++ b/tensorflow/lite/micro/micro_allocator.h
@@ -47,7 +47,7 @@ TfLiteStatus InitializeTfLiteTensorFromFlatbuffer(
     INonPersistentBufferAllocator* non_persistent_buffer_allocator,
     bool allocate_temp, const tflite::Tensor& flatbuffer_tensor,
     const flatbuffers::Vector<flatbuffers::Offset<Buffer>>* buffers,
-    TfLiteTensor* result);
+    TfLiteTensor* result, const uint8_t* flatbuffer_start);
 
 // Holds placeholder information for a scratch buffer request from a kernel.
 // This struct is only used during the model prepare stage. Each request from a

--- a/tensorflow/lite/micro/micro_allocator_test.cc
+++ b/tensorflow/lite/micro/micro_allocator_test.cc
@@ -178,7 +178,7 @@ TF_LITE_MICRO_TEST(TestInitializeRuntimeTensor) {
       kTfLiteOk,
       tflite::internal::InitializeTfLiteTensorFromFlatbuffer(
           simple_allocator, simple_allocator, /*allocate_temp=*/false, *tensor,
-          buffers, &allocated_tensor));
+          buffers, &allocated_tensor, nullptr));
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteInt32, allocated_tensor.type);
   TF_LITE_MICRO_EXPECT_EQ(1, allocated_tensor.dims->size);
   TF_LITE_MICRO_EXPECT_EQ(100, allocated_tensor.dims->data[0]);
@@ -206,7 +206,7 @@ TF_LITE_MICRO_TEST(TestInitializeTempRuntimeTensor) {
   TF_LITE_MICRO_EXPECT_EQ(
       kTfLiteOk, tflite::internal::InitializeTfLiteTensorFromFlatbuffer(
                      simple_allocator, simple_allocator, /*allocate_temp=*/true,
-                     *tensor, buffers, &allocated_temp_tensor));
+                     *tensor, buffers, &allocated_temp_tensor, nullptr));
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteInt32, allocated_temp_tensor.type);
   TF_LITE_MICRO_EXPECT_EQ(1, allocated_temp_tensor.dims->size);
   TF_LITE_MICRO_EXPECT_EQ(100, allocated_temp_tensor.dims->data[0]);
@@ -235,7 +235,7 @@ TF_LITE_MICRO_TEST(TestInitializeQuantizedTensor) {
       kTfLiteOk,
       tflite::internal::InitializeTfLiteTensorFromFlatbuffer(
           simple_allocator, simple_allocator, /*allocate_temp=*/false, *tensor,
-          buffers, &allocated_tensor));
+          buffers, &allocated_tensor, nullptr));
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteInt32, allocated_tensor.type);
   TF_LITE_MICRO_EXPECT_EQ(1, allocated_tensor.dims->size);
   TF_LITE_MICRO_EXPECT_EQ(100, allocated_tensor.dims->data[0]);
@@ -262,7 +262,7 @@ TF_LITE_MICRO_TEST(TestMissingQuantization) {
       kTfLiteOk,
       tflite::internal::InitializeTfLiteTensorFromFlatbuffer(
           simple_allocator, simple_allocator, /*allocate_temp=*/false, *tensor,
-          buffers, &allocated_tensor));
+          buffers, &allocated_tensor, nullptr));
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteInt32, allocated_tensor.type);
   TF_LITE_MICRO_EXPECT_EQ(1, allocated_tensor.dims->size);
   TF_LITE_MICRO_EXPECT_EQ(100, allocated_tensor.dims->data[0]);
@@ -770,6 +770,58 @@ TF_LITE_MICRO_TEST(OfflinePlannerBasic) {
                                   start);
 }
 
+TF_LITE_MICRO_TEST(OfflinePlannerBasicUsingBufferOffset) {
+  constexpr int number_tensors = 4;
+  tflite::testing::TestingOpResolver op_resolver;
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk,
+                          tflite::testing::GetTestingOpResolver(op_resolver));
+  const int32_t metadata_buffer[tflite::testing::kOfflinePlannerHeaderSize +
+                                number_tensors] = {1,         0, number_tensors,
+                                                   /*t0=*/0,
+                                                   /*t1=*/48,
+                                                   /*t2=*/0,
+                                                   /*t3=*/48};
+  constexpr int number_connections = 3;
+  tflite::testing::NodeConnection node_list[number_connections] = {
+      {/*input=*/{tflite::testing::t0},
+       /*output=*/{tflite::testing::t1}},
+      {/*input=*/{tflite::testing::t1},
+       /*output=*/{tflite::testing::t2}},
+      {/*input=*/{tflite::testing::t2},
+       /*output=*/{tflite::testing::t3}}};
+
+  const tflite::Model* model = tflite::testing::GetModelWithOfflinePlanning(
+      number_tensors, metadata_buffer, node_list, number_connections, 0, true);
+
+  tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
+  constexpr size_t arena_size = 4096;
+  uint8_t arena[arena_size];
+  tflite::MicroAllocator* allocator =
+      tflite::MicroAllocator::Create(arena, arena_size);
+
+  tflite::SubgraphAllocations* subgraph_allocations =
+      allocator->StartModelAllocation(model);
+  TF_LITE_MICRO_EXPECT(nullptr != subgraph_allocations);
+  TF_LITE_MICRO_EXPECT_EQ(
+      kTfLiteOk, allocator->FinishModelAllocation(model, subgraph_allocations,
+                                                  &scratch_buffer_handles));
+
+  int8_t* start =
+      tflite::micro::GetTensorData<int8_t>(&subgraph_allocations[0].tensors[0]);
+  TF_LITE_MICRO_EXPECT_EQ(0, tflite::micro::GetTensorData<int8_t>(
+                                 &subgraph_allocations[0].tensors[0]) -
+                                 start);
+  TF_LITE_MICRO_EXPECT_EQ(48, tflite::micro::GetTensorData<int8_t>(
+                                  &subgraph_allocations[0].tensors[1]) -
+                                  start);
+  TF_LITE_MICRO_EXPECT_EQ(0, tflite::micro::GetTensorData<int8_t>(
+                                 &subgraph_allocations[0].tensors[2]) -
+                                 start);
+  TF_LITE_MICRO_EXPECT_EQ(48, tflite::micro::GetTensorData<int8_t>(
+                                  &subgraph_allocations[0].tensors[3]) -
+                                  start);
+}
+
 TF_LITE_MICRO_TEST(OfflinePlannerOverlappingAllocation) {
   constexpr int number_tensors = 4;
   tflite::testing::TestingOpResolver op_resolver;
@@ -939,17 +991,51 @@ TF_LITE_MICRO_TEST(TestFailAllocatePersistentTfLiteTensor) {
 }
 
 TF_LITE_MICRO_TEST(TestAllocateSingleTempTfLiteTensor) {
-  const tflite::Model* model = tflite::testing::GetSimpleMockModel();
-  constexpr size_t arena_size = 1024;
-  uint8_t arena[arena_size];
+  const tflite::Model* model =
+      tflite::testing::GetNoOpModelWithTensorData({42}, false);
+  constexpr size_t kArenaSize = 1024;
+  uint8_t arena[kArenaSize];
   tflite::MicroAllocator* allocator =
-      tflite::MicroAllocator::Create(arena, arena_size);
-  TF_LITE_MICRO_EXPECT(allocator != nullptr);
+      tflite::MicroAllocator::Create(arena, kArenaSize);
 
-  TfLiteTensor* tensor1 = allocator->AllocateTempTfLiteTensor(
-      model, /*subgraph_allocations=*/nullptr, /*tensor_index=*/1,
-      /*subgraph_index=*/0);
-  TF_LITE_MICRO_EXPECT(tensor1 != nullptr);
+  TF_LITE_MICRO_EXPECT(allocator != nullptr);
+  if (allocator != nullptr) {
+    TfLiteTensor* tensor0 = allocator->AllocateTempTfLiteTensor(
+        model, /*subgraph_allocations=*/nullptr, /*tensor_index=*/0,
+        /*subgraph_index=*/0);
+    TF_LITE_MICRO_EXPECT(tensor0 != nullptr);
+    if (tensor0 != nullptr) {
+      const int8_t* data_pointer = tflite::GetTensorData<int8_t>(tensor0);
+      TF_LITE_MICRO_EXPECT(data_pointer != nullptr);
+      if (data_pointer != nullptr) {
+        TF_LITE_MICRO_EXPECT_EQ(data_pointer[0], 42);
+      }
+    }
+  }
+}
+
+TF_LITE_MICRO_TEST(TestAllocateSingleTempTfLiteTensorUsingBufferOffset) {
+  const tflite::Model* model =
+      tflite::testing::GetNoOpModelWithTensorData({0x42}, true);
+  constexpr size_t kArenaSize = 1024;
+  uint8_t arena[kArenaSize];
+  tflite::MicroAllocator* allocator =
+      tflite::MicroAllocator::Create(arena, kArenaSize);
+
+  TF_LITE_MICRO_EXPECT(allocator != nullptr);
+  if (allocator != nullptr) {
+    TfLiteTensor* tensor0 = allocator->AllocateTempTfLiteTensor(
+        model, /*subgraph_allocations=*/nullptr, /*tensor_index=*/0,
+        /*subgraph_index=*/0);
+    TF_LITE_MICRO_EXPECT(tensor0 != nullptr);
+    if (tensor0 != nullptr) {
+      const int8_t* data_pointer = tflite::GetTensorData<int8_t>(tensor0);
+      TF_LITE_MICRO_EXPECT(data_pointer != nullptr);
+      if (data_pointer != nullptr) {
+        TF_LITE_MICRO_EXPECT_EQ(data_pointer[0], 0x42);
+      }
+    }
+  }
 }
 
 TF_LITE_MICRO_TEST(TestAllocateChainOfTfLiteTensor) {

--- a/tensorflow/lite/micro/micro_interpreter.h
+++ b/tensorflow/lite/micro/micro_interpreter.h
@@ -131,12 +131,6 @@ class MicroInterpreter {
 
   TfLiteStatus initialization_status() const { return initialization_status_; }
 
-  // Populates node and registration pointers representing the inference graph
-  // of the model from values inside the flatbuffer (loaded from the TfLiteModel
-  // instance). Persistent data (e.g. operator data) is allocated from the
-  // arena.
-  TfLiteStatus PrepareNodeAndRegistrationDataFromFlatbuffer();
-
   // For debugging only.
   // Returns the actual used arena in bytes. This method gives the optimal arena
   // size. It's only available after `AllocateTensors` has been called.
@@ -179,6 +173,12 @@ class MicroInterpreter {
   // TODO(b/158263161): Consider switching to Create() function to enable better
   // error reporting during initialization.
   void Init(MicroProfilerInterface* profiler);
+
+  // Populates node and registration pointers representing the inference graph
+  // of the model from values inside the flatbuffer (loaded from the TfLiteModel
+  // instance). Persistent data (e.g. operator data) is allocated from the
+  // arena.
+  TfLiteStatus PrepareNodeAndRegistrationDataFromFlatbuffer();
 
   // Gets the current subgraph index used from within context methods.
   int get_subgraph_index() { return graph_.GetCurrentSubgraphIndex(); }

--- a/tensorflow/lite/micro/recording_micro_allocator_test.cc
+++ b/tensorflow/lite/micro/recording_micro_allocator_test.cc
@@ -322,7 +322,8 @@ TF_LITE_MICRO_TEST(TestMultiSubgraphModel) {
 TF_LITE_MICRO_TEST(TestCompressedModel) {
   tflite::ScratchBufferHandle* scratch_buffer_handles = nullptr;
   tflite::testing::TestingOpResolver ops_resolver;
-  const tflite::Model* model = tflite::testing::GetSimpleMockModelCompressed();
+  const tflite::Model* model =
+      tflite::testing::GetSimpleMockModelCompressed(false);
   const int arena_size = 2048;
 
   uint8_t arena[arena_size];

--- a/tensorflow/lite/micro/test_helpers.h
+++ b/tensorflow/lite/micro/test_helpers.h
@@ -125,7 +125,7 @@ const Model* GetSimpleMockModel();
 // Returns a simple example flatbuffer TensorFlow Lite model. Contains 1 input,
 // 1 layer of weights, 1 output Tensor, and 1 operator (BroadcastAddOp).  The
 // weights tensor is compressed.
-const Model* GetSimpleMockModelCompressed();
+const Model* GetSimpleMockModelCompressed(bool use_buffer_offset);
 
 #endif  // USE_TFLM_COMPRESSION
 
@@ -158,11 +158,11 @@ const Model* GetSimpleMultipleInputsModel();
 //                                        are in the subgraph input list. There
 //                                        must be at least 1 input tensor in the
 //                                        subgraph input list.
-const Model* GetModelWithOfflinePlanning(int num_tensors,
-                                         const int32_t* metadata_buffer,
-                                         NodeConnection* node_conn,
-                                         int num_conns,
-                                         int num_subgraph_inputs = 0);
+// @param[in]       use_buffer_offset     Buffer objects use <offset> and <size>
+//                                        to locate their data.
+const Model* GetModelWithOfflinePlanning(
+    int num_tensors, const int32_t* metadata_buffer, NodeConnection* node_conn,
+    int num_conns, int num_subgraph_inputs = 0, bool use_buffer_offset = false);
 
 // Returns a flatbuffer with a single operator, two inputs (one unused) and one
 // output.
@@ -195,6 +195,20 @@ const Model* GetSimpleModelWithNullInputsAndOutputs();
 // of which has the supplied shape.
 const Model* GetNoOpModelWithTensorShape(
     const std::initializer_list<int32_t>& shape);
+
+// Returns a flatbuffer model with no inputs and one output, the output
+// containing the supplied data.
+const Model* GetNoOpModelWithTensorData(
+    const std::initializer_list<int8_t>& datum, bool use_buffer_offset);
+
+// Returns a flatbuffer model with two inputs and one output.
+// The model can have optional custom option data, if supplied.
+// The second input tensor will be assigned the supplied data.
+// The output is the sum of the two inputs, and if the custom option data
+// is supplied it will also be added to the sum.
+const Model* GetModelWithTensorDataAndCustomOptions(
+    const std::initializer_list<int8_t>& datum,
+    const std::initializer_list<uint8_t>& options_data, bool use_buffer_offset);
 
 // Builds a one-dimensional flatbuffer tensor of the given size.
 const Tensor* Create1dFlatbufferTensor(int size, bool is_variable = false);


### PR DESCRIPTION
@tensorflow/micro

Allow for models >2Gb (and less than 4Gb) in size, as generated by the TfLite converter. Parse TfLite schema Buffer tables where the offset and size fields are active. Parse TfLite schema Operator tables where the large_custom_options_offset and large_custom_options_size fields are active. Correctly process the Offline Memory Planner metadata buffer. Correctly process the compression metadata buffer. Add unit tests for all of the above.

bug=fixes #3196