### PR TITLE
[CI] Enable manual triggering of the main CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@
 name: CI
 
 on:
+  # Allow manually triggering of the workflow.
+  workflow_dispatch: {}
+
   workflow_call:
     inputs:
       trigger-sha:


### PR DESCRIPTION
Currently, the CI workflow is only triggered automatically on a new PR event. Adding a manual trigger will be useful for testing changes to the CI workflow itself without having to create a new PR.

Reference: https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow
BUG=CI