### PR TITLE
Support to use half_pixel_centers value in the resize nearest neighbor operator.

### DIFF
--- a/tensorflow/lite/micro/kernels/resize_nearest_neighbor.cc
+++ b/tensorflow/lite/micro/kernels/resize_nearest_neighbor.cc
@@ -78,7 +78,7 @@ TfLiteStatus ResizeNearestNeighborEval(TfLiteContext* context,
 
   tflite::ResizeNearestNeighborParams op_params;
   op_params.align_corners = params->align_corners;
-  op_params.half_pixel_centers = false;
+  op_params.half_pixel_centers = params->half_pixel_centers;
 
   if (output->type == kTfLiteFloat32) {
     reference_ops::ResizeNearestNeighbor(


### PR DESCRIPTION
Updated CREF code of resize nearest neighbor to use the half_pixel_centers value from the TFLite model.