### PR TITLE
Optimization in 8x16 lstm layer FCs for HiFi.

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/lstm_eval.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/lstm_eval.cc
@@ -305,16 +305,33 @@ void FullyConnected(const FullyConnectedParams& params,
   return;
 }
 
+#define ARG_CHK_ALIGN(_ptr, _align) (((unsigned int)(_ptr) & ((_align) - 1)) == 0)
+
 void FullyConnected(const FullyConnectedParams& params,
                     const int16_t* input_data, const int8_t* filter_data,
                     const int64_t* bias_data, int16_t* output_data,
                     const int num_batches, const int output_depth,
                     const int accum_depth) {
-  xa_nn_matmul_sym8sxsym16s_sym16s(
-      output_data, filter_data, input_data, bias_data, output_depth,
-      accum_depth, accum_depth, num_batches, accum_depth, output_depth, 1,
-      params.input_offset, params.output_multiplier, params.output_shift,
-      params.output_offset);
+  WORD32 err;
+  if(num_batches == 1 && ARG_CHK_ALIGN(output_data, sizeof(WORD16)*8)
+     && ARG_CHK_ALIGN(filter_data, sizeof(WORD8)*16)
+     && ARG_CHK_ALIGN(input_data, sizeof(WORD16)*8)
+     && ARG_CHK_ALIGN(bias_data, sizeof(WORD64)*2)) {
+    err = xa_nn_matXvec_v2_sym8sxsym16s_sym16s(
+          output_data, filter_data,
+          input_data, bias_data,
+          output_depth, accum_depth, accum_depth,
+          params.output_multiplier, params.output_shift,
+          -32768, 32767, NULL);
+  }
+  else{
+    err = xa_nn_matmul_sym8sxsym16s_sym16s(
+        output_data, filter_data, input_data, bias_data, output_depth,
+        accum_depth, accum_depth, num_batches, accum_depth, output_depth, 1,
+        params.input_offset, params.output_multiplier, params.output_shift,
+        params.output_offset);
+  }
+  (void)err;
   return;
 }
 


### PR DESCRIPTION
Optimization in 8x16 lstm layer FCs for HiFi by using xa_nn_matXvec_v2_sym8sxsym16s_sym16s with appropriate conditions.