### PR TITLE
[CI] Fix mergify issue.

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,6 +3,7 @@ merge_queue:
 
 queue_rules:
   - name: default
+    batch_size: 1
     checks_timeout: 2 h
     branch_protection_injection_mode: queue
     merge_method: squash


### PR DESCRIPTION
Currently mergify doesn't work with this error

```
Configuration not compatible with a branch protection setting
The branch protection setting Require branches to be up to date before merging is not compatible with draft PR checks. To keep this branch protection enabled, update your Mergify configuration to enable in-place checks: set merge_queue.max_parallel_checks: 1, set every queue rule batch_size: 1, and avoid two-step CI (make merge_conditions identical to queue_conditions). Otherwise, disable this branch protection.
```

To address this, this PR added missing `batch_size: 1`

BUG=N/A