### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/log_binary_size_pr.yml
+++ b/.github/workflows/log_binary_size_pr.yml
@@ -49,7 +49,7 @@ jobs:
         git checkout $LOG_BRANCH -- data/continuous_builds/size_profiling/ 
     - name: Create Logs PR Request
       id: create-pr
-      uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8
+      uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725  # v8
       with:
          branch: binary_size_profiling_update
          delete-branch: true

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Create Pull Request
         id: create-pr
-        uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8
+        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725  # v8
         with:
           branch: sync-from-upstream-tf
           delete-branch: true


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `peter-evans/create-pull-request` | [`052fc72`](https://github.com/peter-evans/create-pull-request/commit/052fc72b4198ba9fbc81b818c6e1859f747d49a8) | [`98357b1`](https://github.com/peter-evans/create-pull-request/commit/98357b18bf14b5342f975ff684046ec3b2a07725) | [Release](https://github.com/peter-evans/create-pull-request/releases/tag/v8) | log_binary_size_pr.yml, sync.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
