### PR TITLE
Increase number of axis that could be reduced.

### DIFF
--- a/tensorflow/lite/micro/kernels/reduce_common.cc
+++ b/tensorflow/lite/micro/kernels/reduce_common.cc
@@ -29,7 +29,7 @@ limitations under the License.
 namespace tflite {
 
 const int kMaxNumberOfAxis = 5;
-const int kMaxNumberOfReducedAxis = 2;
+const int kMaxNumberOfReducedAxis = 3;
 
 namespace {
 


### PR DESCRIPTION
I'm working with a Conformer model that requires more 2 axis during reduction. Without that change Address and Memory sanitizers are reporting errors.