### PR TITLE
Refactor: Use scratch buffers for reduce kernel

### DIFF
--- a/tensorflow/lite/micro/kernels/reduce.h
+++ b/tensorflow/lite/micro/kernels/reduce.h
@@ -24,14 +24,12 @@ limitations under the License.
 
 namespace tflite {
 
-extern const int kMaxNumberOfAxis;
-extern const int kMaxNumberOfReducedAxis;
-
 struct OpDataReduce {
   int32_t multiplier;
   int shift;
-  int temp_buffer_idx;
-  int resolved_axis_idx;
+  int scratch_accumulator_idx;
+  int scratch_resolved_axis_idx;
+  int scratch_input_iter_idx;
   int input_zp;
   float input_scale;
   int output_zp;


### PR DESCRIPTION
This change refactors the reduce kernel to use scratch buffers allocated from the arena for temporary indices and resolved axes, instead of fixed-size stack arrays. This improves memory management and avoids potential stack overflows..

BUG=472486447