### PR TITLE
Provide default values for uninitialized variable

### DIFF
--- a/tensorflow/lite/micro/kernels/decode_state_lut.cc
+++ b/tensorflow/lite/micro/kernels/decode_state_lut.cc
@@ -443,6 +443,10 @@ void DecodeStateLut::DecompressToBufferWidthAny(T* buffer) {
           case 7:
             index = GetNextTableIndexWidth7(current_offset);
             break;
+          default:
+            // Added to suppress -Wmaybe-uninitialized. Should never be reached.
+            index = 0;
+            break;
         }
         current_offset++;
         *buffer++ = value_table[index];
@@ -482,6 +486,10 @@ void DecodeStateLut::DecompressToBufferWidthAny(T* buffer) {
             break;
           case 7:
             index = GetNextTableIndexWidth7(current_offset);
+            break;
+          default:
+            // Added to suppress -Wmaybe-uninitialized. Should never be reached.
+            index = 0;
             break;
         }
         current_offset++;


### PR DESCRIPTION
Switch-cases in decode_state_lut.cc don't assign a default value to a local variables. On one version of ARM GCC (building for ARM cortex m33, this results in a compiler error [-Werror=maybe-uninitialized].

BUG=451462435