### PR TITLE
Revert "[CI] Replaced tensorflow with tensorflow-cpu"

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -101,7 +101,7 @@ py_pkg_cc_deps(
     name = "tensorflow_cc_deps",
     includes = ["tensorflow/include"],
     libs = ["tensorflow/libtensorflow_framework.so.2"],
-    pkg = requirement("tensorflow-cpu"),
+    pkg = requirement("tensorflow"),
 )
 
 # Optimized kernel deps

--- a/python/tflite_micro/BUILD
+++ b/python/tflite_micro/BUILD
@@ -94,7 +94,7 @@ py_test(
     deps = [
         ":runtime",
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
         "//tensorflow/lite/micro/examples/recipes:add_four_numbers",
         "//tensorflow/lite/micro/testing:generate_test_models_lib",
     ],
@@ -116,7 +116,7 @@ py_test(
     deps = [
         ":runtime",
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
         "//tensorflow/lite/micro/compression",
     ],
 )

--- a/python/tflite_micro/signal/BUILD
+++ b/python/tflite_micro/signal/BUILD
@@ -74,7 +74,7 @@ py_test(
     deps = [
         ":delay_op",
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 
@@ -105,7 +105,7 @@ py_test(
     deps = [
         ":energy_op",
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 
@@ -136,7 +136,7 @@ py_test(
     deps = [
         ":fft_ops",
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 
@@ -173,7 +173,7 @@ py_test(
     deps = [
         ":filter_bank_ops",
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 
@@ -204,7 +204,7 @@ py_test(
     deps = [
         ":framer_op",
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 
@@ -233,7 +233,7 @@ py_test(
         ":overlap_add_op",
         requirement("absl_py"),
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 
@@ -264,7 +264,7 @@ py_test(
     deps = [
         ":pcan_op",
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 
@@ -295,7 +295,7 @@ py_test(
     deps = [
         ":stacker_op",
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 
@@ -325,6 +325,6 @@ py_test(
     deps = [
         ":window_op",
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )

--- a/python/tflite_micro/signal/utils/BUILD
+++ b/python/tflite_micro/signal/utils/BUILD
@@ -43,7 +43,7 @@ py_library(
     srcs = ["util.py"],
     visibility = ["//visibility:public"],
     deps = [
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
         "//python/tflite_micro:runtime",
     ],
 )

--- a/tensorflow/lite/micro/compression/BUILD
+++ b/tensorflow/lite/micro/compression/BUILD
@@ -104,7 +104,7 @@ py_test(
     deps = [
         "metadata_py",
         "@flatbuffers//:runtime_py",
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 
@@ -155,7 +155,7 @@ py_test(
         "//tensorflow/lite/python:schema_py",
         requirement("bitarray"),
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 
@@ -175,7 +175,7 @@ py_test(
     deps = [
         ":model_facade",
         ":test_models",
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 
@@ -193,7 +193,7 @@ py_test(
     srcs = ["spec_test.py"],
     deps = [
         ":spec",
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 
@@ -212,7 +212,7 @@ py_test(
     deps = [
         ":spec",
         ":spec_builder",
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 
@@ -233,7 +233,7 @@ py_test(
     deps = [
         ":test_models",
         "//tensorflow/lite/python:schema_py",
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 

--- a/tensorflow/lite/micro/examples/hello_world/BUILD
+++ b/tensorflow/lite/micro/examples/hello_world/BUILD
@@ -50,7 +50,7 @@ py_binary(
     deps = [
         requirement("absl_py"),
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
         "//python/tflite_micro:runtime",
     ],
 )
@@ -72,6 +72,6 @@ py_binary(
     srcs = ["train.py"],
     deps = [
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )

--- a/tensorflow/lite/micro/examples/hello_world/quantization/BUILD
+++ b/tensorflow/lite/micro/examples/hello_world/quantization/BUILD
@@ -8,7 +8,7 @@ py_binary(
     deps = [
         requirement("absl_py"),
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
         "//python/tflite_micro:runtime",
     ],
 )

--- a/tensorflow/lite/micro/examples/micro_speech/BUILD
+++ b/tensorflow/lite/micro/examples/micro_speech/BUILD
@@ -210,7 +210,7 @@ py_binary(
     deps = [
         requirement("absl_py"),
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
         "//python/tflite_micro:runtime",
         "//python/tflite_micro/signal:ops",
         "//python/tflite_micro/signal/utils:util",

--- a/tensorflow/lite/micro/examples/mnist_lstm/BUILD
+++ b/tensorflow/lite/micro/examples/mnist_lstm/BUILD
@@ -6,7 +6,7 @@ py_binary(
     srcs = ["train.py"],
     deps = [
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 

--- a/tensorflow/lite/micro/examples/person_detection/utils/BUILD
+++ b/tensorflow/lite/micro/examples/person_detection/utils/BUILD
@@ -33,7 +33,7 @@ py_test(
     ],
     deps = [
         ":raw_to_bitmap_lib",
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
         requirement("numpy"),
     ],
 )

--- a/tensorflow/lite/micro/examples/recipes/BUILD
+++ b/tensorflow/lite/micro/examples/recipes/BUILD
@@ -11,7 +11,7 @@ py_library(
     visibility = ["//:__subpackages__"],
     deps = [
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 
@@ -21,7 +21,7 @@ py_library(
     visibility = ["//:__subpackages__"],
     deps = [
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 

--- a/tensorflow/lite/micro/integration_tests/BUILD
+++ b/tensorflow/lite/micro/integration_tests/BUILD
@@ -16,7 +16,7 @@ py_binary(
     deps = [
         requirement("absl_py"),
         requirement("mako"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
         "//tensorflow/lite/micro/tools:generate_test_for_model",
         "//tensorflow/lite/python:schema_py",
         "//tensorflow/lite/python:schema_util",

--- a/tensorflow/lite/micro/kernels/testdata/BUILD
+++ b/tensorflow/lite/micro/kernels/testdata/BUILD
@@ -48,7 +48,7 @@ py_binary(
     deps = [
         requirement("absl_py"),
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 

--- a/tensorflow/lite/micro/python/tflite_size/tests/BUILD
+++ b/tensorflow/lite/micro/python/tflite_size/tests/BUILD
@@ -25,7 +25,7 @@ py_test(
         "noubsan",
     ],
     deps = [
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
         "//tensorflow/lite/micro/python/tflite_size/src:flatbuffer_size",
     ],
 )

--- a/tensorflow/lite/micro/testing/BUILD
+++ b/tensorflow/lite/micro/testing/BUILD
@@ -82,7 +82,7 @@ py_library(
     ],
     deps = [
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 
@@ -96,6 +96,6 @@ py_binary(
     deps = [
         requirement("absl_py"),
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )

--- a/tensorflow/lite/micro/tools/BUILD
+++ b/tensorflow/lite/micro/tools/BUILD
@@ -72,7 +72,7 @@ py_test(
     deps = [
         ":requantize_flatbuffer",
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
         "//python/tflite_micro:runtime",
     ],
 )
@@ -132,7 +132,7 @@ py_library(
         ":model_transforms_utils",
         requirement("absl_py"),
         requirement("numpy"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
         "//python/tflite_micro:runtime",
         "//tensorflow/lite/tools:flatbuffer_utils",
     ],
@@ -184,7 +184,7 @@ py_test(
     deps = [
         ":tflm_model_transforms_lib",
         requirement("absl_py"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
         "//tensorflow/lite/micro/examples/recipes:resource_variables_lib",
     ],
 )
@@ -196,7 +196,7 @@ py_binary(
         ":layer_by_layer_schema_py",
         ":model_transforms_utils",
         requirement("absl_py"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
         "//python/tflite_micro:runtime",
         "//tensorflow/lite/tools:flatbuffer_utils",
     ],

--- a/tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver/BUILD
+++ b/tensorflow/lite/micro/tools/gen_micro_mutable_op_resolver/BUILD
@@ -36,7 +36,7 @@ py_binary(
     ],
     deps = [
         requirement("absl_py"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
         requirement("mako"),
         "//tensorflow/lite/micro/tools:generate_test_for_model",
         "//tensorflow/lite/python:schema_py",

--- a/tensorflow/lite/python/BUILD
+++ b/tensorflow/lite/python/BUILD
@@ -20,6 +20,6 @@ py_library(
     visibility = ["//:__subpackages__"],
     deps = [
         requirement("flatbuffers"),
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )

--- a/tensorflow/lite/tools/BUILD
+++ b/tensorflow/lite/tools/BUILD
@@ -7,7 +7,7 @@ py_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "@flatbuffers//:runtime_py",
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
         "//tensorflow/lite/python:schema_py",
         "//tensorflow/lite/python:schema_util",
     ],
@@ -18,7 +18,7 @@ py_library(
     srcs = ["test_utils.py"],
     deps = [
         "@flatbuffers//:runtime_py",
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
         "//tensorflow/lite/python:schema_py",
     ],
 )
@@ -48,7 +48,7 @@ py_test(
     deps = [
         ":flatbuffer_utils",
         ":test_utils",
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )
 
@@ -58,6 +58,6 @@ py_test(
     deps = [
         ":test_utils",
         ":visualize",
-        requirement("tensorflow-cpu"),
+        requirement("tensorflow"),
     ],
 )

--- a/third_party/python_requirements.in
+++ b/third_party/python_requirements.in
@@ -34,6 +34,6 @@ pillow
 prettyprinter
 protobuf
 pyyaml
-tensorflow-cpu
+tensorflow
 twine
 yapf

--- a/third_party/python_requirements.txt
+++ b/third_party/python_requirements.txt
@@ -11,11 +11,11 @@ absl-py==2.3.1 \
     #   -r third_party/python_requirements.in
     #   keras
     #   tensorboard
-    #   tensorflow-cpu
+    #   tensorflow
 astunparse==1.6.3 \
     --hash=sha256:5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872 \
     --hash=sha256:c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8
-    # via tensorflow-cpu
+    # via tensorflow
 backports-tarfile==1.2.0 \
     --hash=sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34 \
     --hash=sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991
@@ -394,16 +394,16 @@ docutils==0.22.2 \
 flatbuffers==25.9.23 \
     --hash=sha256:255538574d6cb6d0a79a17ec8bc0d30985913b87513a01cce8bcdb6b4c44d0e2 \
     --hash=sha256:676f9fa62750bb50cf531b42a0a2a118ad8f7f797a511eda12881c016f093b12
-    # via tensorflow-cpu
+    # via tensorflow
 gast==0.6.0 \
     --hash=sha256:52b182313f7330389f72b069ba00f174cfe2a06411099547288839c6cbafbd54 \
     --hash=sha256:88fc5300d32c7ac6ca7b515310862f71e6fdf2c029bbec7c66c0f5dd47b6b1fb
-    # via tensorflow-cpu
+    # via tensorflow
 google-pasta==0.2.0 \
     --hash=sha256:4612951da876b1a10fe3960d7226f0c7682cf901e16ac06e473b267a5afa8954 \
     --hash=sha256:b32482794a366b5366a32c92a9a9201b107821889935a02b3e51f6b432ea84ed \
     --hash=sha256:c9f2c8dfc8f96d0d5808299920721be30c9eec37f2389f28904f454565c8a16e
-    # via tensorflow-cpu
+    # via tensorflow
 grpcio==1.75.0 \
     --hash=sha256:050760fd29c8508844a720f06c5827bb00de8f5e02f58587eb21a4444ad706e5 \
     --hash=sha256:06d22e1d8645e37bc110f4c589cb22c283fd3de76523065f821d6e81de33f5d4 \
@@ -458,7 +458,7 @@ grpcio==1.75.0 \
     --hash=sha256:ffc33e67cab6141c54e75d85acd5dec616c5095a957ff997b4330a6395aa9b51
     # via
     #   tensorboard
-    #   tensorflow-cpu
+    #   tensorflow
 h5py==3.14.0 \
     --hash=sha256:016e89d3be4c44f8d5e115fab60548e518ecd9efe9fa5c5324505a90773e6f03 \
     --hash=sha256:0cbd41f4e3761f150aa5b662df991868ca533872c95467216f2bec5fcad84882 \
@@ -488,7 +488,7 @@ h5py==3.14.0 \
     --hash=sha256:f5cc1601e78027cedfec6dd50efb4802f018551754191aeb58d948bd3ec3bd7a
     # via
     #   keras
-    #   tensorflow-cpu
+    #   tensorflow
 id==1.5.0 \
     --hash=sha256:292cb8a49eacbbdbce97244f47a97b4c62540169c976552e497fd57df0734c1d \
     --hash=sha256:f1434e1cef91f2cbb8a4ec64663d5a23b9ed43ef44c4c957d02583d61714c658
@@ -522,7 +522,7 @@ jeepney==0.9.0 \
 keras==3.11.3 \
     --hash=sha256:efda616835c31b7d916d72303ef9adec1257320bc9fd4b2b0138840fc65fb5b7 \
     --hash=sha256:f484f050e05ee400455b05ec8c36ed35edc34de94256b6073f56cfe68f65491f
-    # via tensorflow-cpu
+    # via tensorflow
 keyring==25.6.0 \
     --hash=sha256:0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66 \
     --hash=sha256:552a3f7af126ece7ed5c89753650eec89c7eaae8617d0aa4d9ad2b75111266bd
@@ -538,7 +538,7 @@ libclang==18.1.1 \
     --hash=sha256:a1214966d08d73d971287fc3ead8dfaf82eb07fb197680d8b3859dbbbbf78250 \
     --hash=sha256:c533091d8a3bbf7460a00cb6c1a71da93bffe148f172c7d03b1c31fbf8aa2a0b \
     --hash=sha256:cf4a99b05376513717ab5d82a0db832c56ccea4fd61a69dbb7bccf2dfb207dbe
-    # via tensorflow-cpu
+    # via tensorflow
 mako==1.3.10 \
     --hash=sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28 \
     --hash=sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59
@@ -658,7 +658,7 @@ ml-dtypes==0.5.3 \
     --hash=sha256:e12e29764a0e66a7a31e9b8bf1de5cc0423ea72979f45909acd4292de834ccd3
     # via
     #   keras
-    #   tensorflow-cpu
+    #   tensorflow
 more-itertools==10.8.0 \
     --hash=sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b \
     --hash=sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd
@@ -759,11 +759,11 @@ numpy==2.2.6 \
     #   keras
     #   ml-dtypes
     #   tensorboard
-    #   tensorflow-cpu
+    #   tensorflow
 opt-einsum==3.4.0 \
     --hash=sha256:69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd \
     --hash=sha256:96ca72f1b886d148241348783498194c577fa30a8faac108586b14f1ba4473ac
-    # via tensorflow-cpu
+    # via tensorflow
 optree==0.17.0 \
     --hash=sha256:039ea98c0cd94a64040d6f6d21dbe5cd9731bb380d7893f78d6898672080a232 \
     --hash=sha256:057f95213e403ff3a975f287aef6b687299d0c4512d211de24b1b98050cd4fbf \
@@ -863,7 +863,7 @@ packaging==25.0 \
     # via
     #   keras
     #   tensorboard
-    #   tensorflow-cpu
+    #   tensorflow
     #   twine
 pillow==11.3.0 \
     --hash=sha256:023f6d2d11784a465f09fd09a34b150ea4672e85fb3d05931d89f373ab14abb2 \
@@ -996,7 +996,7 @@ protobuf==6.32.1 \
     # via
     #   -r third_party/python_requirements.in
     #   tensorboard
-    #   tensorflow-cpu
+    #   tensorflow
 pycparser==2.23 \
     --hash=sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2 \
     --hash=sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934
@@ -1073,7 +1073,7 @@ requests==2.32.5 \
     # via
     #   id
     #   requests-toolbelt
-    #   tensorflow-cpu
+    #   tensorflow
     #   twine
 requests-toolbelt==1.0.0 \
     --hash=sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6 \
@@ -1099,31 +1099,41 @@ six==1.17.0 \
     # via
     #   astunparse
     #   google-pasta
-    #   tensorflow-cpu
+    #   tensorflow
 tensorboard==2.20.0 \
     --hash=sha256:9dc9f978cb84c0723acf9a345d96c184f0293d18f166bb8d59ee098e6cfaaba6
-    # via tensorflow-cpu
+    # via tensorflow
 tensorboard-data-server==0.7.2 \
     --hash=sha256:7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb \
     --hash=sha256:9fe5d24221b29625dbc7328b0436ca7fc1c23de4acf4d272f1180856e32f9f60 \
     --hash=sha256:ef687163c24185ae9754ed5650eb5bc4d84ff257aabdc33f0cc6f74d8ba54530
     # via tensorboard
-tensorflow-cpu==2.20.0 \
-    --hash=sha256:06b4d213f093a72da9c767754bd8d6605f2b1a98c7a683532fc152b0a5d8ce04 \
-    --hash=sha256:0888d26d99ca88a5154c470dbaa080154e72ea3ea48c47a16c96f73296011d67 \
-    --hash=sha256:1a3ef238410543ee884b64d222775727504407395785d3719a9ee8d016d1c583 \
-    --hash=sha256:1c91c84e604598151a9e4cd9d0683fe081408577d05f7f4e1c33d2316f0f2468 \
-    --hash=sha256:510bb97f6f15337c7c45c113c20704662a07cd87d21b820748ae270ad07c5eda \
-    --hash=sha256:90cf8009bdf60297c23e098b574e053faa5d7872857df110fe13fc58cfa8b5db \
-    --hash=sha256:c7a9224185818094ed95c4e114d3efe77241db35fbf0b75251fb2bf6222dd6a7 \
-    --hash=sha256:cf756bbe2d256e942ab5d0ad2c858fb40017581494febdb4387c149b1afde780 \
-    --hash=sha256:da6e7791e5e10ec84e6225c45e04fee05f33d7b828c9b61cc905f4146f7c64b5 \
-    --hash=sha256:f9a6ca1d334d61086e3e823c096454f843a1f9bac7b7f9bd56ce52712178428a
+tensorflow==2.20.0 \
+    --hash=sha256:02a0293d94f5c8b7125b66abf622cc4854a33ae9d618a0d41309f95e091bbaea \
+    --hash=sha256:0deb5c583dfc53b54fd158a194ce0087b406bb6518af400ca3809735e4548ec3 \
+    --hash=sha256:1590cbf87b6bcbd34d8e9ad70d0c696135e0aa71be31803b27358cf7ed63f8fc \
+    --hash=sha256:197f0b613b38c0da5c6a12a8295ad4a05c78b853835dae8e0f9dfae3ce9ce8a5 \
+    --hash=sha256:25265b0bc527e0d54b1e9cc60c44a24f44a809fe27666b905f0466471f9c52ec \
+    --hash=sha256:28bc33759249c98eabcee9debd24e74506bbe29ac139e050cf0c74aa9888ebdf \
+    --hash=sha256:2bfbfb3dd0e22bffc45fe1e922390d27753e99261fab8a882e802cf98a0e078f \
+    --hash=sha256:3e9568c8efcb05c0266be223e3269c62ebf7ad3498f156438311735f6fa5ced5 \
+    --hash=sha256:47c88e05a07f1ead4977b4894b3ecd4d8075c40191065afc4fd9355c9db3d926 \
+    --hash=sha256:481499fd0f824583de8945be61d5e827898cdaa4f5ea1bc2cc28ca2ccff8229e \
+    --hash=sha256:4a69ac2c2ce20720abf3abf917b4e86376326c0976fcec3df330e184b81e4088 \
+    --hash=sha256:52b122f0232fd7ab10f28d537ce08470d0b6dcac7fff9685432daac7f8a06c8f \
+    --hash=sha256:5f964016c5035d09b85a246a6b739be89282a7839743f3ea63640224f0c63aee \
+    --hash=sha256:5fa3729b0126f75a99882b89fb7d536515721eda8014a63e259e780ba0a37372 \
+    --hash=sha256:7551558a48c2e2f6c32a1537f06c654a9df1408a1c18e7b99c3caafbd03edfe3 \
+    --hash=sha256:7abd7f3a010e0d354dc804182372779a722d474c4d8a3db8f4a3f5baef2a591e \
+    --hash=sha256:a66cbd1b19209d3fbc45cbea80de92514ba455434013937251d65d444779783c \
+    --hash=sha256:c25edad45e8cb9e76366f7a8c835279f9169028d610f3b52ce92d332a1b05438 \
+    --hash=sha256:dd71a7e7c3270239f4185915e8f2c5d39608c5e18973d6e1d101b153993841eb \
+    --hash=sha256:e5f169f8f5130ab255bbe854c5f0ae152e93d3d1ac44f42cb1866003b81a5357
     # via -r third_party/python_requirements.in
 termcolor==3.1.0 \
     --hash=sha256:591dd26b5c2ce03b9e43f391264626557873ce1d379019786f99b0c2bee140aa \
     --hash=sha256:6a6dd7fbee581909eeec6a756cff1d7f7c376063b14e4a298dc4980309e55970
-    # via tensorflow-cpu
+    # via tensorflow
 tomli==2.2.1 \
     --hash=sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6 \
     --hash=sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd \
@@ -1169,7 +1179,7 @@ typing-extensions==4.15.0 \
     #   cryptography
     #   grpcio
     #   optree
-    #   tensorflow-cpu
+    #   tensorflow
 urllib3==2.5.0 \
     --hash=sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760 \
     --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
@@ -1266,7 +1276,7 @@ wrapt==1.17.3 \
     --hash=sha256:f9b2601381be482f70e5d1051a5965c25fb3625455a2bf520b5a077b22afb775 \
     --hash=sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10 \
     --hash=sha256:fd341868a4b6714a5962c1af0bd44f7c404ef78720c7de4892901e540417111c
-    # via tensorflow-cpu
+    # via tensorflow
 yapf==0.43.0 \
     --hash=sha256:00d3aa24bfedff9420b2e0d5d9f5ab6d9d4268e72afbf59bb3fa542781d5218e \
     --hash=sha256:224faffbc39c428cb095818cf6ef5511fdab6f7430a10783fdfb292ccf2852ca
@@ -1282,4 +1292,4 @@ setuptools==80.9.0 \
     --hash=sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c
     # via
     #   tensorboard
-    #   tensorflow-cpu
+    #   tensorflow


### PR DESCRIPTION
Reverts PR #3261. Although that PR attempted to resolve CI disk space limitations, it resulted in a regression (Issue #3262). Since PR #3288 has successfully increased the available storage, the original workaround is no longer necessary and can be safely reverted.

BUG=n/a