### PR TITLE
Solve compiler errors in decode op (Xtensa)

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/decompress.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/decompress.cc
@@ -53,6 +53,7 @@ struct DecompressionStateXtensa : DecompressionState {
 
 void DecompressionStateXtensa::DecompressToBufferWidth4_Xtensa(int8_t* buffer) {
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   ae_int8x8 d_shuffle_t = AE_MOVINT8X8_FROMINT64(0xFB73EA62D951C840LL);
   ae_int8x8 d_shuffle_value_t = AE_MOVINT8X8_FROMINT64(0x08192A3B4C5D6E7FLL);
@@ -110,6 +111,7 @@ void DecompressionStateXtensa::DecompressToBufferWidth4_Xtensa(int8_t* buffer) {
 
 void DecompressionStateXtensa::DecompressToBufferWidth3_Xtensa(int8_t* buffer) {
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   int i, j;
   ae_int8* __restrict p_out_tmp = (ae_int8*)buffer;
@@ -232,6 +234,7 @@ void DecompressionStateXtensa::DecompressToBufferWidth3_Xtensa(int8_t* buffer) {
 
 void DecompressionStateXtensa::DecompressToBufferWidth2_Xtensa(int8_t* buffer) {
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   int i, j;
   ae_int8* __restrict p_out_tmp = (ae_int8*)buffer;
@@ -350,6 +353,7 @@ void DecompressionStateXtensa::DecompressToBufferWidth2_Xtensa(int8_t* buffer) {
 void DecompressionStateXtensa::DecompressToBufferWidthAnyInt8_Xtensa(
     int8_t* buffer) {
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   const int stride = comp_data_.data.lut_data->value_table_channel_stride;
   const uint8_t* __restrict value_table =
@@ -420,6 +424,7 @@ void DecompressionStateXtensa::DecompressToBufferWidthAnyInt8_Xtensa(
 void DecompressionStateXtensa::DecompressToBufferWidthAnyInt16_Xtensa(
     int16_t* buffer) {
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   const int stride = comp_data_.data.lut_data->value_table_channel_stride;
   const uint16_t* __restrict value_table =
@@ -471,6 +476,7 @@ void DecompressionStateXtensa::DecompressToBufferWidthAnyInt16_Xtensa(
 void DecompressionStateXtensa::DecompressToBufferWidthAnyInt32_Xtensa(
     int32_t* buffer) {
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   const int stride = comp_data_.data.lut_data->value_table_channel_stride;
   const uint32_t* __restrict value_table =
@@ -522,6 +528,7 @@ void DecompressionStateXtensa::DecompressToBufferWidthAnyInt32_Xtensa(
 void DecompressionStateXtensa::DecompressToBufferWidthAnyInt64_Xtensa(
     int64_t* buffer) {
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   const int stride = comp_data_.data.lut_data->value_table_channel_stride;
   const uint64_t* __restrict value_table =

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_decode_state_huffman.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_decode_state_huffman.cc
@@ -52,6 +52,7 @@ TfLiteStatus XtensaDecodeStateHuffman::Decode(const TfLiteEvalTensor& input,
 
 void XtensaDecodeStateHuffman::Decompress16BitTable_Xtensa(int8_t* buffer) {
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   size_t remaining = count_codewords_;
   const uint16_t* huffman_tables =
@@ -83,6 +84,7 @@ void XtensaDecodeStateHuffman::Decompress16BitTable_Xtensa(int8_t* buffer) {
 template <typename T>
 void XtensaDecodeStateHuffman::Decompress32BitTable_Xtensa(T* buffer) {
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   size_t remaining = count_codewords_;
   const uint32_t* huffman_tables =

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_decode_state_lut.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_decode_state_lut.cc
@@ -29,6 +29,7 @@ namespace tflite {
 
 void XtensaDecodeStateLut::DecompressToBufferWidth4_Xtensa(int8_t* buffer) {
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   ae_int8x8 d_shuffle_t = AE_MOVINT8X8_FROMINT64(0xFB73EA62D951C840LL);
   ae_int8x8 d_shuffle_value_t = AE_MOVINT8X8_FROMINT64(0x08192A3B4C5D6E7FLL);
@@ -86,6 +87,7 @@ void XtensaDecodeStateLut::DecompressToBufferWidth4_Xtensa(int8_t* buffer) {
 
 void XtensaDecodeStateLut::DecompressToBufferWidth3_Xtensa(int8_t* buffer) {
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   int i, j;
   ae_int8* __restrict p_out_tmp = (ae_int8*)buffer;
@@ -208,6 +210,7 @@ void XtensaDecodeStateLut::DecompressToBufferWidth3_Xtensa(int8_t* buffer) {
 
 void XtensaDecodeStateLut::DecompressToBufferWidth2_Xtensa(int8_t* buffer) {
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   int i, j;
   ae_int8* __restrict p_out_tmp = (ae_int8*)buffer;
@@ -326,6 +329,7 @@ void XtensaDecodeStateLut::DecompressToBufferWidth2_Xtensa(int8_t* buffer) {
 void XtensaDecodeStateLut::DecompressToBufferWidthAnyInt8_Xtensa(
     int8_t* buffer) {
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   const int stride = value_table_channel_stride_;
   const uint8_t* __restrict value_table =
@@ -396,6 +400,7 @@ void XtensaDecodeStateLut::DecompressToBufferWidthAnyInt8_Xtensa(
 void XtensaDecodeStateLut::DecompressToBufferWidthAnyInt16_Xtensa(
     int16_t* buffer) {
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   const int stride = value_table_channel_stride_;
   const uint16_t* __restrict value_table =
@@ -447,6 +452,7 @@ void XtensaDecodeStateLut::DecompressToBufferWidthAnyInt16_Xtensa(
 void XtensaDecodeStateLut::DecompressToBufferWidthAnyInt32_Xtensa(
     int32_t* buffer) {
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   const int stride = value_table_channel_stride_;
   const uint32_t* __restrict value_table =
@@ -498,6 +504,7 @@ void XtensaDecodeStateLut::DecompressToBufferWidthAnyInt32_Xtensa(
 void XtensaDecodeStateLut::DecompressToBufferWidthAnyInt64_Xtensa(
     int64_t* buffer) {
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   const int stride = value_table_channel_stride_;
   const uint64_t* __restrict value_table =

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_decode_state_prune.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_decode_state_prune.cc
@@ -66,6 +66,7 @@ void XtensaDecodeStatePrune::DecompressToBufferInt8_Xtensa(void* buffer) {
   }
 
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   ae_int8x16* p_weights = (ae_int8x16*)value_table_;
   int* __restrict p_mask32 = (int*)compressed_indices_;
@@ -169,6 +170,7 @@ void XtensaDecodeStatePrune::DecompressToBufferPerChannelInt8_Xtensa(
   TFLITE_DCHECK(zero_points_ != nullptr);
 
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   ae_int8x16* p_weights = (ae_int8x16*)value_table_;
   short* __restrict p_stream = (short*)compressed_indices_;
@@ -283,6 +285,7 @@ void XtensaDecodeStatePrune::DecompressToBufferPerChannelAltAxisInt8_Xtensa(
   TFLITE_DCHECK(zero_points_ != nullptr);
 
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   ae_int8x16* p_weights = (ae_int8x16*)value_table_;
   short* __restrict p_stream = (short*)compressed_indices_;
@@ -387,6 +390,7 @@ void XtensaDecodeStatePrune::DecompressToBufferPerChannelAltAxisInt8_Xtensa(
 
 void XtensaDecodeStatePrune::DecompressToBufferInt16_Xtensa(void* buffer) {
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
+  (void)scoped_profiler;
 
   ae_int16x8* p_weights = (ae_int16x8*)value_table_;
   int* __restrict p_mask32 = (int*)compressed_indices_;


### PR DESCRIPTION
When building with old Xtensa toolchains, the compiler throws an unused variable warning which is treated as error (-Werror is defined by default). The cause is ScopedMicroProfile instantiation in the decoder op. Added a dummy reference to mute the warning.

Old pre C++14 Xtensa compilers don't support ticks in preprocessor constants, e.g. 0x8000'0000 Removed the ticks.

BUG=451462435