### PR TITLE
Fix StackAllocator memory corruption due to alignment

### DIFF
--- a/tensorflow/lite/micro/test_helpers.cc
+++ b/tensorflow/lite/micro/test_helpers.cc
@@ -48,40 +48,32 @@ namespace {
 
 class StackAllocator : public flatbuffers::Allocator {
  public:
-  StackAllocator(size_t alignment) : data_size_(0) {
-    data_ = AlignPointerUp(data_backing_, alignment);
-    data_size_ = data_ - data_backing_;
-  }
+  StackAllocator() : offset_(0) {}
 
   uint8_t* allocate(size_t size) override {
-    if ((data_size_ + size) > sizeof(data_backing_)) {
-      MicroPrintf("allocate(size=%u) full: data_size_=%u", size, data_size_);
+    if (offset_ + size > kBufferSize) {
+      MicroPrintf("allocate(size=%u) full: offset_=%u", size, offset_);
       TFLITE_ABORT;
       return nullptr;
     }
-    uint8_t* result = data_;
-    data_ += size;
-    data_size_ += size;
+
+    uint8_t* result = &buffer_[offset_];
+    offset_ += size;
     return result;
   }
 
   void deallocate(uint8_t* p, size_t) override {}
 
-  static StackAllocator& instance(size_t alignment = 1) {
-    // Avoid using true dynamic memory allocation to be portable to bare metal.
-    static char inst_memory[sizeof(StackAllocator)];
-    static StackAllocator* inst = new (inst_memory) StackAllocator(alignment);
-    return *inst;
+  static StackAllocator& instance() {
+    static StackAllocator inst;
+    return inst;
   }
 
-  static constexpr size_t kStackAllocatorSize = 16384;
+  static constexpr size_t kBufferSize = 16384;
 
  private:
-  static constexpr size_t kStackAllocatorBackingSize =
-      kStackAllocatorSize + MicroArenaBufferAlignment();
-  uint8_t data_backing_[kStackAllocatorBackingSize];
-  uint8_t* data_;
-  int data_size_;
+  alignas(MicroArenaBufferAlignment()) uint8_t buffer_[kBufferSize];
+  size_t offset_;
 
   TF_LITE_REMOVE_VIRTUAL_DELETE
 };
@@ -90,8 +82,7 @@ flatbuffers::FlatBufferBuilder* BuilderInstance() {
   static char inst_memory[sizeof(flatbuffers::FlatBufferBuilder)];
   static flatbuffers::FlatBufferBuilder* inst =
       new (inst_memory) flatbuffers::FlatBufferBuilder(
-          StackAllocator::kStackAllocatorSize,
-          &StackAllocator::instance(MicroArenaBufferAlignment()));
+          StackAllocator::kBufferSize, &StackAllocator::instance());
   return inst;
 }
 


### PR DESCRIPTION
Fixes a memory corruption in `tensorflow/lite/micro/test_helpers.cc`. StackAllocator's alignment offset caused `FlatBufferBuilder` to receive a pointer range extending beyond the backing store. Since `FlatBufferBuilder` writes from the end of the buffer, this caused immediate out-of-bounds writes into `StackAllocator`'s member variables.

The fix increases `data_backing_` size to accommodate alignment, initializes `data_size_` to the offset, and checks bounds against the physical backing size. This ensures the memory provided to `FlatBufferBuilder` is always valid.

In addition to that, I doubled the size of the StackAllocator internal buffer to resolve allocation failures in compression tests.

```
[ RUN      ] MicroInterpreterTest.TestInterpreterCompressionAltMemory
allocate(size=12368) full: data_size_=8200
```

🎂 & 🎁

BUG=n/a