### PR TITLE
Disable renaming of expftblf in NDSP libraries for hifi5 and hifi4

### DIFF
--- a/tensorflow/lite/micro/tools/make/ext_libs/ndsplib-hifi4.patch
+++ b/tensorflow/lite/micro/tools/make/ext_libs/ndsplib-hifi4.patch
@@ -25,6 +25,19 @@ index 0069361..c0f411f 100644
    #define onchip
    #define NASSERT(x) {(void)__builtin_expect((x)!=0,1);}
  #else
+diff --git a/library/include_private/__renaming__.h b/library/include_private/__renaming__.h
+index 25a4d34..8e12d59 100644
+--- a/library/include_private/__renaming__.h
++++ b/library/include_private/__renaming__.h
+@@ -562,7 +562,7 @@
+ #define 	fft_16x16_stage_first_scl2_DFT3	NatureDSP_Signal_579
+ #define 	fft_16	NatureDSP_Signal_580
+ #define 	fft_128	NatureDSP_Signal_581
+-#define 	expftblf	NatureDSP_Signal_582
++//#define 	expftblf	NatureDSP_Signal_582
+ #define 	dct4_twd	NatureDSP_Signal_583
+ #define 	dct4_twd_512	NatureDSP_Signal_584
+ #define 	dct4_twd_32	NatureDSP_Signal_585
 diff --git a/library/include_private/common.h b/library/include_private/common.h
 index d647af4..25d0ca8 100644
 --- a/library/include_private/common.h

--- a/tensorflow/lite/micro/tools/make/ext_libs/ndsplib-hifi5.patch
+++ b/tensorflow/lite/micro/tools/make/ext_libs/ndsplib-hifi5.patch
@@ -12,6 +12,19 @@ index 82e16c7..ce7fb75 100644
    #define onchip
    #define NASSERT(x) {(void)__builtin_expect((x)!=0,1);}
  #else
+diff --git a/library/include_private/__renaming__.h b/library/include_private/__renaming__.h
+index af48b03..5c3092a 100644
+--- a/library/include_private/__renaming__.h
++++ b/library/include_private/__renaming__.h
+@@ -561,7 +561,7 @@
+ #define 	fft_16x16_stage_first_scl2_DFT3	NatureDSP_Signal_579
+ #define 	fft_16	NatureDSP_Signal_580
+ #define 	fft_128	NatureDSP_Signal_581
+-#define 	expftblf	NatureDSP_Signal_582
++// #define 	expftblf	NatureDSP_Signal_582
+ #define 	dct4_twd	NatureDSP_Signal_583
+ #define 	dct4_twd_512	NatureDSP_Signal_584
+ #define 	dct4_twd_32	NatureDSP_Signal_585
 diff --git a/library/include_private/common.h b/library/include_private/common.h
 index 2eaf70f..9df811c 100644
 --- a/library/include_private/common.h


### PR DESCRIPTION
__renaming__.h re-#defines expftblf, which is already #defined in the NN library for the same cores. To avoid the compiler throwing a re-definition error, renaming of just this one function is disabled. This only disables renaming. The function is still compiled into the library.

BUG=478153404