### PR TITLE
Exclude Cadence NNlib function xa_nn_norm3D_16 from build

### DIFF
--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -116,7 +116,8 @@ else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi3 hifi4))
   
   ifeq ($(TARGET_ARCH), hifi4)
     EXCLUDED_NNLIB_SRCS += \
-      $(NNLIB_PATH)/algo/kernels/activations/hifi4/xa_nn_activations_asym8_asym8.c
+      $(NNLIB_PATH)/algo/kernels/activations/hifi4/xa_nn_activations_asym8_asym8.c \
+      $(NNLIB_PATH)/algo/kernels/norm/hifi4/xa_nn_norm3D_16.c
   endif
 
   THIRD_PARTY_KERNEL_CC_SRCS := $(filter-out $(EXCLUDED_NNLIB_SRCS), $(THIRD_PARTY_KERNEL_CC_SRCS))


### PR DESCRIPTION
The function causes an internal compiler error on some hifi4 cores. The function isn't currently used by any kernels.

BUG=478153404