### PR TITLE
Updated Leaky RELU CREF code to allow negative values of alpha.

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/leaky_relu.h
+++ b/tensorflow/lite/kernels/internal/reference/leaky_relu.h
@@ -23,6 +23,68 @@ limitations under the License.
 namespace tflite {
 namespace reference_ops {
 
+// Single-rounding MultiplyByQuantizedMultiplier
+#if TFLITE_SINGLE_ROUNDING
+/* Commented the condition check for quantized_multiplier to allow -ve values */
+inline int32_t MultiplyByQuantizedMultiplier_v2(int32_t x, int32_t quantized_multiplier,
+                                      int shift) {
+  //TFLITE_DCHECK(quantized_multiplier >= 0);
+  TFLITE_DCHECK(shift >= -31 && shift <= 30);
+
+  const int64_t total_shift = 31 - shift;
+  const int64_t round = static_cast<int64_t>(1) << (total_shift - 1);
+  int64_t result = x * static_cast<int64_t>(quantized_multiplier) + round;
+  result = result >> total_shift;
+
+  TFLITE_DCHECK(result >= std::numeric_limits<int32_t>::min() &&
+                result <= std::numeric_limits<int32_t>::max());
+  return static_cast<int32_t>(result);
+}
+
+/* Commented the condition check for quantized_multiplier to allow -ve values */
+inline int32_t MultiplyByQuantizedMultiplier_v2(int64_t x, int32_t quantized_multiplier,
+                                      int shift) {
+  // Inputs:
+  // - quantized_multiplier has fixed point at bit 31
+  // - shift is -31 to +7 (negative for right shift)
+  //
+  // Assumptions: The following input ranges are assumed
+  // - quantize_scale>=0  (the usual range is (1<<30) to (1>>31)-1)
+  // - scaling is chosen so final scaled result fits in int32_t
+  // - input x is in the range -(1<<47) <= x < (1<<47)
+  //TFLITE_DCHECK(quantized_multiplier >= 0);
+  TFLITE_DCHECK(shift >= -31 && shift < 8);
+  TFLITE_DCHECK(x >= -(static_cast<int64_t>(1) << 47) &&
+                x < (static_cast<int64_t>(1) << 47));
+
+  const int32_t reduced_multiplier =
+      (quantized_multiplier < 0x7FFF0000)
+          ? ((quantized_multiplier + (1 << 15)) >> 16)
+          : 0x7FFF;
+  const int64_t total_shift = 15 - shift;
+  const int64_t round = static_cast<int64_t>(1) << (total_shift - 1);
+  int64_t result = x * static_cast<int64_t>(reduced_multiplier) + round;
+  result = result >> total_shift;
+
+  TFLITE_DCHECK(result >= std::numeric_limits<int32_t>::min() &&
+                result <= std::numeric_limits<int32_t>::max());
+  return static_cast<int32_t>(result);
+}
+// Double-rounding MultiplyByQuantizedMultiplier
+#else
+/* Call original function as the check on quantized_multiplier is relaxed */
+inline int32_t MultiplyByQuantizedMultiplier_v2(int32_t x, int32_t quantized_multiplier,
+                                      int shift) {
+  return MultiplyByQuantizedMultiplier(x, quantized_multiplier, shift);
+}
+
+/* Call original function as the check on quantized_multiplier is relaxed */
+inline int32_t MultiplyByQuantizedMultiplier_v2(int64_t x, int32_t quantized_multiplier,
+                                      int shift) {
+  return MultiplyByQuantizedMultiplier(x, quantized_multiplier, shift);
+}
+#endif  // TFLITE_SINGLE_ROUNDING
+
 inline void LeakyRelu(const tflite::LeakyReluParams& params,
                       const RuntimeShape& input_shape, const float* input_data,
                       const RuntimeShape& output_shape, float* output_data) {
@@ -48,12 +110,12 @@ inline void QuantizeLeakyRelu(const LeakyReluParams& params,
     int32_t unclamped_output;
     if (input_value >= 0) {
       unclamped_output = params.output_offset +
-                         MultiplyByQuantizedMultiplier(
+                         MultiplyByQuantizedMultiplier_v2(
                              input_value, params.output_multiplier_identity,
                              params.output_shift_identity);
     } else {
       unclamped_output = params.output_offset +
-                         MultiplyByQuantizedMultiplier(
+                         MultiplyByQuantizedMultiplier_v2(
                              input_value, params.output_multiplier_alpha,
                              params.output_shift_alpha);
     }


### PR DESCRIPTION
Relaxed the condition check in MultiplyByQuantizedMultiplier for Single-Step-Round by declaring MultiplyByQuantizedMultiplier_v2 locally in leaky_relu.h
The _v2 function has the quantized_multiplier condition check commented out.