### PR TITLE
Add 16bit xtensa depthwise conv kernel support

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
@@ -52,14 +52,14 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TfLiteTensor* input =
       micro_context->AllocateTempInputTensor(node, kConvInputTensor);
   TF_LITE_ENSURE(context, input != nullptr);
-  #ifndef HIFI5
+#ifndef HIFI5
   // Int16 input is only supported by HIFI5 for now.
   // So there is no need to prepare the Hifi/Vision kernel for other targets.
   if (input->type == kTfLiteInt16) {
     micro_context->DeallocateTempTfLiteTensor(input);
     return kTfLiteOk;
   }
-  #endif
+#endif
   micro_context->DeallocateTempTfLiteTensor(input);
 
 #if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
@@ -112,7 +112,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
         case kTfLiteInt8: {
 #if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
           DepthwiseConvEvalHifiInt8(context, node, params, op_data, input,
-                                &filter_int8, bias, output);
+                                    &filter_int8, bias, output);
 #elif defined(VISION_P6)
           DepthwiseConvEvalVision(context, node, params, op_data, input,
                                   &filter_int8, bias, output);
@@ -154,7 +154,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
         case kTfLiteInt8: {
 #if defined(HIFI5)
           DepthwiseConvEvalHifiInt16(context, node, params, op_data, input,
-                                filter, bias, output);
+                                     filter, bias, output);
 #else
           reference_integer_ops::DepthwiseConvPerChannel(
               DepthwiseConvParamsQuantized(params, op_data.reference_op_data),

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
@@ -49,7 +49,7 @@ TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
   TfLiteTensor* filter =
       micro_context->AllocateTempInputTensor(node, kConvWeightsTensor);
   TF_LITE_ENSURE(context, filter != nullptr);
-  
+
   const RuntimeShape& input_shape = GetTensorShape(input);
   const RuntimeShape& filter_shape = GetTensorShape(filter);
   const RuntimeShape& output_shape = GetTensorShape(output);
@@ -89,12 +89,12 @@ TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
 }
 
 TfLiteStatus DepthwiseConvEvalHifiInt8(TfLiteContext* context, TfLiteNode* node,
-                                   const TfLiteDepthwiseConvParams& params,
-                                   const XtensaDepthwiseConvOpData& data,
-                                   const TfLiteEvalTensor* input,
-                                   const TfLiteEvalTensor* filter,
-                                   const TfLiteEvalTensor* bias,
-                                   TfLiteEvalTensor* output) {
+                                       const TfLiteDepthwiseConvParams& params,
+                                       const XtensaDepthwiseConvOpData& data,
+                                       const TfLiteEvalTensor* input,
+                                       const TfLiteEvalTensor* filter,
+                                       const TfLiteEvalTensor* bias,
+                                       TfLiteEvalTensor* output) {
 #ifdef USE_TFLM_COMPRESSION
 
   MicroContext* micro_context = GetMicroContext(context);
@@ -216,13 +216,14 @@ TfLiteStatus DepthwiseConvEvalHifiInt8(TfLiteContext* context, TfLiteNode* node,
   return kTfLiteOk;
 }
 
-TfLiteStatus DepthwiseConvEvalHifiInt16(TfLiteContext* context, TfLiteNode* node,
-                                   const TfLiteDepthwiseConvParams& params,
-                                   const XtensaDepthwiseConvOpData& data,
-                                   const TfLiteEvalTensor* input,
-                                   const TfLiteEvalTensor* filter,
-                                   const TfLiteEvalTensor* bias,
-                                   TfLiteEvalTensor* output) {
+TfLiteStatus DepthwiseConvEvalHifiInt16(TfLiteContext* context,
+                                        TfLiteNode* node,
+                                        const TfLiteDepthwiseConvParams& params,
+                                        const XtensaDepthwiseConvOpData& data,
+                                        const TfLiteEvalTensor* input,
+                                        const TfLiteEvalTensor* filter,
+                                        const TfLiteEvalTensor* bias,
+                                        TfLiteEvalTensor* output) {
 #ifdef USE_TFLM_COMPRESSION
 
   MicroContext* micro_context = GetMicroContext(context);
@@ -291,22 +292,21 @@ TfLiteStatus DepthwiseConvEvalHifiInt16(TfLiteContext* context, TfLiteNode* node
         context->GetScratchBuffer(context, data.scratch_tensor_index));
 
     for (int i = 0; i < batches; i++) {
-
-        TF_LITE_ENSURE_EQ(
+      TF_LITE_ENSURE_EQ(
           context,
           xa_nn_conv2d_depthwise_per_chan_sym8sxsym16s(
-            &output_data[i * output_height * output_width * output_depth],
-            filter_data,
-            &input_data[i * input_height * input_width * input_depth],
-            bias_data, input_height, input_width, input_depth, filter_height,
-            filter_width, depth_multiplier, stride_width, stride_height,
-            pad_width, pad_height, output_height, output_width,
-            -data.reference_op_data.input_zero_point,
-            data.reference_op_data.per_channel_output_multiplier,
-            data.reference_op_data.per_channel_output_shift,
-            data.reference_op_data.output_zero_point, input_data_format,
-            output_data_format, p_scratch),
-        0);
+              &output_data[i * output_height * output_width * output_depth],
+              filter_data,
+              &input_data[i * input_height * input_width * input_depth],
+              bias_data, input_height, input_width, input_depth, filter_height,
+              filter_width, depth_multiplier, stride_width, stride_height,
+              pad_width, pad_height, output_height, output_width,
+              -data.reference_op_data.input_zero_point,
+              data.reference_op_data.per_channel_output_multiplier,
+              data.reference_op_data.per_channel_output_shift,
+              data.reference_op_data.output_zero_point, input_data_format,
+              output_data_format, p_scratch),
+          0);
     }
 
     int out_length = batches * output_height * output_width * output_depth;

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h
@@ -43,20 +43,21 @@ struct XtensaDepthwiseConvOpData {
 TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context, TfLiteNode* node);
 
 TfLiteStatus DepthwiseConvEvalHifiInt8(TfLiteContext* context, TfLiteNode* node,
-                                   const TfLiteDepthwiseConvParams& params,
-                                   const XtensaDepthwiseConvOpData& data,
-                                   const TfLiteEvalTensor* input,
-                                   const TfLiteEvalTensor* filter,
-                                   const TfLiteEvalTensor* bias,
-                                   TfLiteEvalTensor* output);
+                                       const TfLiteDepthwiseConvParams& params,
+                                       const XtensaDepthwiseConvOpData& data,
+                                       const TfLiteEvalTensor* input,
+                                       const TfLiteEvalTensor* filter,
+                                       const TfLiteEvalTensor* bias,
+                                       TfLiteEvalTensor* output);
 
-TfLiteStatus DepthwiseConvEvalHifiInt16(TfLiteContext* context, TfLiteNode* node,
-                                   const TfLiteDepthwiseConvParams& params,
-                                   const XtensaDepthwiseConvOpData& data,
-                                   const TfLiteEvalTensor* input,
-                                   const TfLiteEvalTensor* filter,
-                                   const TfLiteEvalTensor* bias,
-                                   TfLiteEvalTensor* output);
+TfLiteStatus DepthwiseConvEvalHifiInt16(TfLiteContext* context,
+                                        TfLiteNode* node,
+                                        const TfLiteDepthwiseConvParams& params,
+                                        const XtensaDepthwiseConvOpData& data,
+                                        const TfLiteEvalTensor* input,
+                                        const TfLiteEvalTensor* filter,
+                                        const TfLiteEvalTensor* bias,
+                                        TfLiteEvalTensor* output);
 
 TfLiteStatus DepthwiseConvReferenceEvalInt8(TfLiteContext* context,
                                             TfLiteNode* node);


### PR DESCRIPTION
This PR adds support for the optimized Xtensa depthwise convolution kernel when using 16-bit activations and 8-bit weights. Previously, this configuration would fall back to the reference implementation.

Changes:
* Removed hardcoded if-else logic in the Prepare function that restricted inputs to int8 activations only
* Removed TF_LITE_ENSURE_EQ assertion enforcing int8-only inputs
* Renamed the existing int8 evaluation function for clarity
* Added a new evaluation function to support int16 activations with int8 weights

bug=fixes [#3484](https://github.com/tensorflow/tflite-micro/issues/3484)