### PR TITLE
Updated CREF to handle bias=null for FC,Conv 8x16 CREF code

### DIFF
--- a/tensorflow/lite/micro/kernels/conv.cc
+++ b/tensorflow/lite/micro/kernels/conv.cc
@@ -80,7 +80,7 @@ TfLiteStatus ConvEval(TfLiteContext* context, TfLiteNode* node) {
       break;
     }
     case kTfLiteInt16: {
-      if (bias == nullptr || bias->type == kTfLiteInt32) {
+      if (bias != nullptr && bias->type == kTfLiteInt32) {
         reference_integer_ops::ConvPerChannel(
             ConvParamsQuantized(params, data),
             data.per_channel_output_multiplier, data.per_channel_output_shift,
@@ -92,16 +92,16 @@ TfLiteStatus ConvEval(TfLiteContext* context, TfLiteNode* node) {
                                                  weights_comp_td,
                                                  data.weights_scratch_index),
             tflite::micro::GetTensorShape(bias),
-            tflite::micro::GetOptionalTensorData<int32_t>(
+            tflite::micro::GetTensorData<int32_t>(
                 micro_context, bias, bias_comp_td, data.bias_scratch_index),
 #else   // USE_TFLM_COMPRESSION
             tflite::micro::GetTensorData<int8_t>(filter),
             tflite::micro::GetTensorShape(bias),
-            tflite::micro::GetOptionalTensorData<std::int32_t>(bias),
+            tflite::micro::GetTensorData<std::int32_t>(bias),
 #endif  // USE_TFLM_COMPRESSION
             tflite::micro::GetTensorShape(output),
             tflite::micro::GetTensorData<int16_t>(output));
-      } else if (bias->type == kTfLiteInt64) {
+      } else if (bias == nullptr || bias->type == kTfLiteInt64) {
         reference_integer_ops::ConvPerChannel(
             ConvParamsQuantized(params, data),
             data.per_channel_output_multiplier, data.per_channel_output_shift,
@@ -113,12 +113,12 @@ TfLiteStatus ConvEval(TfLiteContext* context, TfLiteNode* node) {
                                                  weights_comp_td,
                                                  data.weights_scratch_index),
             tflite::micro::GetTensorShape(bias),
-            tflite::micro::GetTensorData<int64_t>(
+            tflite::micro::GetOptionalTensorData<int64_t>(
                 micro_context, bias, bias_comp_td, data.bias_scratch_index),
 #else   // USE_TFLM_COMPRESSION
             tflite::micro::GetTensorData<int8_t>(filter),
             tflite::micro::GetTensorShape(bias),
-            tflite::micro::GetTensorData<std::int64_t>(bias),
+            tflite::micro::GetOptionalTensorData<std::int64_t>(bias),
 #endif  // USE_TFLM_COMPRESSION
             tflite::micro::GetTensorShape(output),
             tflite::micro::GetTensorData<int16_t>(output));

--- a/tensorflow/lite/micro/kernels/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/fully_connected.cc
@@ -54,7 +54,7 @@ TfLiteStatus FullyConnectedPrepare(TfLiteContext* context, TfLiteNode* node) {
   TfLiteTensor* output = micro_context->AllocateTempOutputTensor(
       node, kFullyConnectedOutputTensor);
   TF_LITE_ENSURE(context, output != nullptr);
-  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
+  //TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
 
   if ((input->type == kTfLiteFloat32 && filter->type != kTfLiteFloat32) ||
       (input->type == kTfLiteInt8 &&

--- a/tensorflow/lite/micro/kernels/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/fully_connected.cc
@@ -54,7 +54,7 @@ TfLiteStatus FullyConnectedPrepare(TfLiteContext* context, TfLiteNode* node) {
   TfLiteTensor* output = micro_context->AllocateTempOutputTensor(
       node, kFullyConnectedOutputTensor);
   TF_LITE_ENSURE(context, output != nullptr);
-  //TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
 
   if ((input->type == kTfLiteFloat32 && filter->type != kTfLiteFloat32) ||
       (input->type == kTfLiteInt8 &&

--- a/tensorflow/lite/micro/kernels/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/fully_connected.cc
@@ -54,7 +54,7 @@ TfLiteStatus FullyConnectedPrepare(TfLiteContext* context, TfLiteNode* node) {
   TfLiteTensor* output = micro_context->AllocateTempOutputTensor(
       node, kFullyConnectedOutputTensor);
   TF_LITE_ENSURE(context, output != nullptr);
-  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
+  //TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
 
   if ((input->type == kTfLiteFloat32 && filter->type != kTfLiteFloat32) ||
       (input->type == kTfLiteInt8 &&
@@ -238,7 +238,7 @@ TfLiteStatus FullyConnectedEval(TfLiteContext* context, TfLiteNode* node) {
     case kTfLiteInt16: {
       switch (filter->type) {
         case kTfLiteInt8: {
-          if (bias == nullptr || bias->type == kTfLiteInt32) {
+          if (bias != nullptr && bias->type == kTfLiteInt32) {
             data.is_per_channel
                 ? tflite::reference_integer_ops::FullyConnectedPerChannel(
                       FullyConnectedParamsQuantized(data),
@@ -253,13 +253,13 @@ TfLiteStatus FullyConnectedEval(TfLiteContext* context, TfLiteNode* node) {
                           micro_context, filter, weights_comp_td,
                           data.weights_scratch_index),
                       tflite::micro::GetTensorShape(bias),
-                      tflite::micro::GetOptionalTensorData<int32_t>(
+                      tflite::micro::GetTensorData<int32_t>(
                           micro_context, bias, bias_comp_td,
                           data.bias_scratch_index),
 #else   // USE_TFLM_COMPRESSION
                       tflite::micro::GetTensorData<int8_t>(filter),
                       tflite::micro::GetTensorShape(bias),
-                      tflite::micro::GetOptionalTensorData<int32_t>(bias),
+                      tflite::micro::GetTensorData<int32_t>(bias),
 #endif  // USE_TFLM_COMPRESSION
                       tflite::micro::GetTensorShape(output),
                       tflite::micro::GetTensorData<int16_t>(output))
@@ -273,17 +273,17 @@ TfLiteStatus FullyConnectedEval(TfLiteContext* context, TfLiteNode* node) {
                           micro_context, filter, weights_comp_td,
                           data.weights_scratch_index),
                       tflite::micro::GetTensorShape(bias),
-                      tflite::micro::GetOptionalTensorData<int32_t>(
+                      tflite::micro::GetTensorData<int32_t>(
                           micro_context, bias, bias_comp_td,
                           data.bias_scratch_index),
 #else   // USE_TFLM_COMPRESSION
                       tflite::micro::GetTensorData<int8_t>(filter),
                       tflite::micro::GetTensorShape(bias),
-                      tflite::micro::GetOptionalTensorData<int32_t>(bias),
+                      tflite::micro::GetTensorData<int32_t>(bias),
 #endif  // USE_TFLM_COMPRESSION
                       tflite::micro::GetTensorShape(output),
                       tflite::micro::GetTensorData<int16_t>(output));
-          } else if (bias->type == kTfLiteInt64) {
+          } else if (bias == nullptr || bias->type == kTfLiteInt64) {
             data.is_per_channel
                 ? tflite::reference_integer_ops::FullyConnectedPerChannel(
                       FullyConnectedParamsQuantized(data),

--- a/tensorflow/lite/micro/kernels/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/fully_connected.cc
@@ -54,7 +54,7 @@ TfLiteStatus FullyConnectedPrepare(TfLiteContext* context, TfLiteNode* node) {
   TfLiteTensor* output = micro_context->AllocateTempOutputTensor(
       node, kFullyConnectedOutputTensor);
   TF_LITE_ENSURE(context, output != nullptr);
-  //TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
+  // TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
 
   if ((input->type == kTfLiteFloat32 && filter->type != kTfLiteFloat32) ||
       (input->type == kTfLiteInt8 &&

--- a/tensorflow/lite/micro/kernels/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/fully_connected.cc
@@ -54,7 +54,7 @@ TfLiteStatus FullyConnectedPrepare(TfLiteContext* context, TfLiteNode* node) {
   TfLiteTensor* output = micro_context->AllocateTempOutputTensor(
       node, kFullyConnectedOutputTensor);
   TF_LITE_ENSURE(context, output != nullptr);
-  // TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
 
   if ((input->type == kTfLiteFloat32 && filter->type != kTfLiteFloat32) ||
       (input->type == kTfLiteInt8 &&


### PR DESCRIPTION
This change enhances the CREF kernels for Fully Connected and Convolutional layers to use higher precision accumulation when no bias term is present. Previously, the implementation would default to int32 accumulation when bias=NULL or INT32. This change is applicable only for the Int16x8 kernel type.

Adding @vp-cad and @joshih-cad as watchers.

BUG=3498