### PR TITLE
fix: use base branch SHA for check_tflite_files to prevent code execution from fork PRs

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -66,7 +66,7 @@ jobs:
   call-check-tflite-files:
     uses: ./.github/workflows/check_tflite_files.yml
     with:
-      trigger-sha: ${{ github.event.pull_request.head.sha }}
+      trigger-sha: ${{ github.sha }}
       pr-number: ${{ github.event.pull_request.number }}
       pr-body: ${{ github.event.pull_request.body }}
 


### PR DESCRIPTION
## Security Fix

The `call-check-tflite-files` job in `pr_test.yml` runs without the `approval-gate` dependency. It passes `github.event.pull_request.head.sha` as `trigger-sha`, causing `check_tflite_files.yml` to checkout the PR author's code and execute `check_tflite_files.sh` from it.

A fork PR can modify `check_tflite_files.sh` to run arbitrary commands on the runner. The other build jobs (call-core, call-cortex-m, etc.) are protected by the approval gate, but `call-check-tflite-files` is not.

### Fix

Change `trigger-sha` to `github.sha` (base branch SHA) for the `call-check-tflite-files` job. The `check_tflite_files.sh` script only needs `ci/tflite_files.txt` from the base branch and queries the GitHub API for the PR file list. It does not need the PR's source code.

### References

- [Keeping your GitHub Actions and workflows secure: Preventing pwn requests](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)