### PR TITLE
fix: prevent EXP negative dimension size_t cast out of bounds access

### DIFF
--- a/tensorflow/lite/micro/kernels/exp.cc
+++ b/tensorflow/lite/micro/kernels/exp.cc
@@ -58,6 +58,7 @@ TfLiteStatus ExpEval(TfLiteContext* context, TfLiteNode* node) {
       tflite::micro::GetEvalOutput(context, node, kOutputTensor);
   int flat_size = MatchingFlatSize(tflite::micro::GetTensorShape(input),
                                    tflite::micro::GetTensorShape(output));
+  TF_LITE_ENSURE(context, flat_size >= 0);
 
   if (input->type == kTfLiteFloat32) {
     reference_ops::Exp(tflite::micro::GetTensorData<float>(input),

--- a/tensorflow/lite/micro/kernels/exp_test.cc
+++ b/tensorflow/lite/micro/kernels/exp_test.cc
@@ -71,4 +71,32 @@ TEST(ExpTest, SingleDim) {
   tflite::testing::TestExp(input_dims, input_values, golden, output_data);
 }
 
+TEST(ExpTest, NegativeDimensionShallFail) {
+  int dims_data[] = {1, -1};
+  TfLiteIntArray* dims = tflite::testing::IntArrayFromInts(dims_data);
+  float input_data[1] = {0.0f};
+  float output_data[1] = {0.0f};
+
+  TfLiteTensor tensors[2] = {
+      tflite::testing::CreateTensor(input_data, dims),
+      tflite::testing::CreateTensor(output_data, dims),
+  };
+
+  int inputs_array_data[] = {1, 0};
+  TfLiteIntArray* inputs_array =
+      tflite::testing::IntArrayFromInts(inputs_array_data);
+  int outputs_array_data[] = {1, 1};
+  TfLiteIntArray* outputs_array =
+      tflite::testing::IntArrayFromInts(outputs_array_data);
+
+  const TFLMRegistration registration = tflite::Register_EXP();
+  tflite::micro::KernelRunner runner(registration, tensors,
+                                     /*tensors_size=*/2, inputs_array,
+                                     outputs_array,
+                                     /*builtin_data=*/nullptr);
+
+  EXPECT_EQ(kTfLiteOk, runner.InitAndPrepare());
+  EXPECT_EQ(kTfLiteError, runner.Invoke());
+}
+
 TF_LITE_MICRO_TESTS_MAIN


### PR DESCRIPTION
## Vulnerability
This PR fixes an out of bounds memory access in the EXP kernel caused by converting a negative `flat_size` into `size_t` without validation.

A malformed tensor shape such as `[-1]` can make `MatchingFlatSize` return a negative value. `ExpEval` then casts that signed value to `size_t`, which expands it into a huge unsigned element count. `reference_ops::Exp` trusts that count and iterates far beyond the real input and output buffers, which can cause out of bounds read and write, process crash, and memory corruption.

## Root cause
- `MatchingFlatSize` can return a negative value for malformed tensor dimensions
- `ExpEval` did not reject negative `flat_size`
- the unchecked signed to unsigned conversion turned an invalid shape into a huge iteration bound
- the EXP reference kernel then used that corrupted bound for memory access

## Fix
- add `TF_LITE_ENSURE(context, flat_size >= 0)` in `ExpEval`
- reject malformed negative flat sizes before the `size_t` cast
- keep the patch minimal and localized to the vulnerable path
- add one regression test that verifies a negative dimension now returns `kTfLiteError` instead of crashing

## Why the fix is correct
The bug exists at the conversion boundary between signed and unsigned length handling. Rejecting negative `flat_size` values prevents the dangerous cast and stops malformed tensor shapes from reaching the out of bounds loop in `reference_ops::Exp`.

## Local verification
- `bazel test //tensorflow/lite/micro/kernels:exp_test`
- `xcrun clang-format --dry-run -Werror tensorflow/lite/micro/kernels/exp.cc tensorflow/lite/micro/kernels/exp_test.cc`
- `git diff --check`
- `bash tensorflow/lite/micro/tools/ci_build/test_code_style.sh`

BUG=None
