### PR TITLE
ci: gate call-check-tflite-files behind approval-gate

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -64,6 +64,8 @@ jobs:
         run: echo "CI Authorized."
 
   call-check-tflite-files:
+    needs: [gatekeeper, approval-gate]
+    if: needs.gatekeeper.outputs.scope != 'none'
     uses: ./.github/workflows/check_tflite_files.yml
     with:
       trigger-sha: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Summary

The `call-check-tflite-files` job in `pr_test.yml` was the only CI job that did not require `[gatekeeper, approval-gate]`. All other `call-*` jobs are gated, but this one ran unconditionally on every `pull_request_target` event.

## Root Cause

`check_tflite_files.yml` checks out the PR's `head.sha` (i.e. fork code) and executes `tensorflow/lite/micro/tools/ci_build/check_tflite_files.sh` from that checkout — running untrusted contributor code in the base repository's workflow context with `GITHUB_TOKEN` exposed via the `TFLM_BOT_TOKEN` environment variable.

## Fix

Add `needs: [gatekeeper, approval-gate]` to `call-check-tflite-files` to match all other CI jobs in this workflow.

## Alternative (stronger fix)

`check_tflite_files.yml` does not need to execute any contributor-provided code at all. The PR file list can be fetched entirely via the GitHub API using the base repository's token, without checking out fork code. Consider refactoring to:
1. Checkout only the base branch (no `ref:` override)
2. Use `curl -H "Authorization: Bearer $TFLM_BOT_TOKEN" .../pulls/$PR_NUMBER/files` with the base repo's token

This would make the check safe to run ungated.


BUG=N/A
