### PR TITLE
Validate buffer index before accessing buffers vector

### DIFF
--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -203,7 +203,11 @@ void* GetFlatbufferTensorBuffer(
   // First see if there's any buffer information in the serialized tensor.
   // TODO(b/170379532): Add better unit tests to validate flatbuffer values.
   void* out_buffer = nullptr;
-  if (auto* buffer = (*buffers)[flatbuffer_tensor.buffer()]) {
+  uint32_t buffer_index = flatbuffer_tensor.buffer();
+  if (buffer_index >= buffers->size()) {
+    return out_buffer;
+  }
+  if (auto* buffer = (*buffers)[buffer_index]) {
     // If we've found a buffer, does it have any data?
     if (auto* array = buffer->data()) {
       // If it has any data, is the data size larger than zero?


### PR DESCRIPTION
Check that the tensor buffer index is within the bounds of the model buffers vector before accessing it, matching the validation already present in the compression code path.

BUG=b/general