### PR TITLE
ci: gate call-check-tflite-files behind approval-gate

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -64,6 +64,8 @@ jobs:
         run: echo "CI Authorized."
 
   call-check-tflite-files:
+    needs: [gatekeeper, approval-gate]
+    if: needs.gatekeeper.outputs.scope != 'none'
     uses: ./.github/workflows/check_tflite_files.yml
     with:
       trigger-sha: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
BUG=N/A (CI consistency fix; no functional change)

The Feb 10 security hardening (PRs #3425, #3426, #3432) added `needs: [gatekeeper, approval-gate]` plus the matching `if:` guard to all six other test jobs in `pr_test.yml` — `call-core`, `call-windows`, `call-cortex-m`, `call-xtensa`, `call-hexagon`, `call-riscv`.

The `call-check-tflite-files` job uses the same parent workflow trigger (`pull_request_target`) and the same checkout-by-head-sha pattern (via `check_tflite_files.yml`), but the gate dependency was not applied to it. This PR adds the same two lines for consistency:

```yaml
needs: [gatekeeper, approval-gate]
if: needs.gatekeeper.outputs.scope != 'none'
```

Behavior:
- Trusted maintainer PRs: `approval-gate` resolves to an empty environment and passes immediately, so the job runs as before.
- Untrusted fork PRs: `approval-gate` uses the `integration-test` environment and waits for team approval, matching the other six jobs.
- `tests-passed` aggregator (line 128) is unaffected — it already lists `call-check-tflite-files` in `needs:`, and skipped jobs do not produce a `failure`/`cancelled` result.

No other changes.