### PR TITLE
ci: add missing approval-gate dependency to call-check-tflite-files

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -64,6 +64,8 @@ jobs:
         run: echo "CI Authorized."
 
   call-check-tflite-files:
+    needs: [gatekeeper, approval-gate]
+    if: needs.gatekeeper.outputs.scope != 'none'
     uses: ./.github/workflows/check_tflite_files.yml
     with:
       trigger-sha: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
BUG=N/A

### Description

The `call-check-tflite-files` job in `.github/workflows/pr_test.yml` is the only test job missing the `needs: [gatekeeper, approval-gate]` dependency and the matching `if: needs.gatekeeper.outputs.scope != 'none'` condition.

All other test jobs (`call-core`, `call-windows`, `call-cortex-m`, `call-xtensa`, `call-hexagon`, `call-riscv`) include this dependency, which was added when the gatekeeper/approval-gate system was introduced in #3426. This PR aligns `call-check-tflite-files` with the rest.

### Why this matters

The called workflow `check_tflite_files.yml` checks out the PR head SHA and then runs `tensorflow/lite/micro/tools/ci_build/check_tflite_files.sh`:

```yaml
- uses: actions/checkout@v6
  with:
    ref: ${{ inputs.trigger-sha }}

- name: Check Files
  run: tensorflow/lite/micro/tools/ci_build/check_tflite_files.sh
```

Since `pr_test.yml` is triggered by `pull_request_target`, this script runs in a privileged context with access to repository secrets. Without the approval gate, it executes against any fork PR's HEAD before maintainer approval, which is the same risk the gate was added to address for the other jobs.

You can see this happening in recent run history — `call-check-tflite-files` completes during the window when `approval-gate` is still `waiting`, e.g.:
- https://github.com/tensorflow/tflite-micro/actions/runs/23304254651

### Change

```diff
   call-check-tflite-files:
+    needs: [gatekeeper, approval-gate]
+    if: needs.gatekeeper.outputs.scope != 'none'
     uses: ./.github/workflows/check_tflite_files.yml
     with:
       trigger-sha: ${{ github.event.pull_request.head.sha }}
       pr-number: ${{ github.event.pull_request.number }}
       pr-body: ${{ github.event.pull_request.body }}
```

Two-line change, matches the pattern used by every other test job in the file.