### PR TITLE
fix: add approval gate to call-check-tflite-files job

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -64,6 +64,8 @@ jobs:
         run: echo "CI Authorized."
 
   call-check-tflite-files:
+    needs: [gatekeeper, approval-gate]
+    if: needs.gatekeeper.outputs.scope != 'none'
     uses: ./.github/workflows/check_tflite_files.yml
     with:
       trigger-sha: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Summary

`call-check-tflite-files` in `pr_test.yml` is missing `needs: [gatekeeper, approval-gate]`. All other jobs (`call-core`, `call-windows`, `call-cortex-m`, etc.) have this dependency, but `call-check-tflite-files` runs immediately on any fork PR — checking out and executing fork-controlled `check_tflite_files.sh` without waiting for approval.

## Fix

Add `needs: [gatekeeper, approval-gate]` and the `if: needs.gatekeeper.outputs.scope != 'none'` condition, matching every other job in the workflow.

BUG=n/a