### PR TITLE
Exclude `examples/mnist_lstm:train` from sanitizer builds

### DIFF
--- a/tensorflow/lite/micro/examples/mnist_lstm/BUILD
+++ b/tensorflow/lite/micro/examples/mnist_lstm/BUILD
@@ -5,7 +5,13 @@ load("//tensorflow/lite/micro:build_def.bzl", "INCOMPATIBLE_WITH_WINDOWS")
 py_binary(
     name = "train",
     srcs = ["train.py"],
+    tags = [
+        "noasan",  # Not useful for Python-only targets.
+        "nomsan",
+        "noubsan",
+    ],
     deps = [
+        requirement("absl_py"),
         requirement("numpy"),
         requirement("tensorflow"),
     ],
@@ -17,6 +23,7 @@ py_binary(
     deps = [
         "//python/tflite_micro:runtime",
         requirement("absl_py"),
+        requirement("numpy"),
         requirement("pillow"),
     ],
 )


### PR DESCRIPTION
This is a very large Python-only target, and building it with `asan`/`msan`/`ubsan` consumes a lot of resources, but does not add any value.

Also added some missing dependencies.

BUG=#3554