### PR TITLE
ci: declare workflow-level `contents: read` on 3 workflows

### DIFF
--- a/.github/workflows/merge_group.yml
+++ b/.github/workflows/merge_group.yml
@@ -5,6 +5,9 @@ name: Merge Queue
 on:
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   call-core:
     uses: ./.github/workflows/suite_core.yml

--- a/.github/workflows/pypi_build.yml
+++ b/.github/workflows/pypi_build.yml
@@ -25,6 +25,9 @@ on:
 env:
   TWINE_PASSWORD: ${{ secrets.PYPI_API_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   pypi-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_hosted.yml
+++ b/.github/workflows/test_hosted.yml
@@ -7,7 +7,10 @@ on:
         description: 'SHA to test (optional)'
         required: false
         type: string
-  
+
+permissions:
+  contents: read
+
 jobs:
   explore-linux:
     runs-on: linux-x86-n2-16


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `check_bug_id.yml`, `log_binary_size_pr.yml`, `pr_test.yml`, `sync.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.