### PR TITLE
 build: pin actions/github-script to commit SHA in pull_request_target workflow

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: check-scope
         id: check-scope
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.TFLM_BOT_REPO_TOKEN }}
           script: |


### PR DESCRIPTION
 Pin `actions/github-script` to full commit SHA instead of mutable `v8` tag
  in the `pr_test.yml` workflow.

  This workflow uses `pull_request_target` trigger with access to
  `secrets.TFLM_BOT_REPO_TOKEN`. Pinning to SHA ensures immutability
  and prevents supply chain attacks via tag manipulation.

  Ref: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions