### PR TITLE
[CMSIS-NN] Removed batch_size assert in depthwise_conv

### DIFF
--- a/tensorflow/lite/micro/kernels/cmsis_nn/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/cmsis_nn/depthwise_conv.cc
@@ -147,7 +147,6 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 
     const int batch_size = MatchingDim(input_shape, 0, output_shape, 0);
     const int output_depth = MatchingDim(output_shape, 3, filter_shape, 3);
-    TFLITE_DCHECK_EQ(batch_size, 1); /* Only batch = 1 is supported */
 
     cmsis_nn_dims input_dims;
     input_dims.n = batch_size;


### PR DESCRIPTION
Since CMSIS-NN actually supports batch sizes > 1 natively (it loops over input_batches internally), this assertion seems to be outdated or unnecessarily restrictive. Therefore, I removed the batch_size == 1 check.

BUG=N/A
