### PR TITLE
[CMSIS-NN] Fix stateful execution and batch-major striding for CMSIS-NN LSTM

### DIFF
--- a/tensorflow/lite/micro/kernels/cmsis_nn/unidirectional_sequence_lstm.cc
+++ b/tensorflow/lite/micro/kernels/cmsis_nn/unidirectional_sequence_lstm.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include <limits>
 
 #include "Include/arm_nnfunctions.h"
+#include "Include/arm_nnsupportfunctions.h"
 #include "tensorflow/lite/kernels/internal/quantization_util.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/fully_connected.h"
@@ -270,7 +271,7 @@ TfLiteStatus CMSIS_NN_PortOpData(TfLiteContext* context, OpDataLSTM* params_ref,
 }
 
 TfLiteStatus CMSIS_NN_EvalInteger8x8_16Lstm(
-    const OpData& op_data, const LSTMKernelContents& kernel_content,
+    const OpData& op_data, LSTMKernelContents& kernel_content,
     const LSTMBuffers<int16_t>& buffers) {
   TFLITE_DCHECK(
       kernel_content.GetInternalTensor(tflite::kLstmInputTensor)->dims->size >=
@@ -282,21 +283,74 @@ TfLiteStatus CMSIS_NN_EvalInteger8x8_16Lstm(
       kernel_content.GetInternalTensor(tflite::kLstmInputTensor));
   int8_t* output =
       tflite::micro::GetTensorData<int8_t>(kernel_content.output_tensor);
+  int8_t* hidden_state =
+      tflite::micro::GetTensorData<int8_t>(kernel_content.HiddenStateTensor());
+  int16_t* cell_state =
+      tflite::micro::GetTensorData<int16_t>(kernel_content.CellStateTensor());
 
   // Create lstm buffer struct
   cmsis_nn_lstm_context cmsis_buffers;
   cmsis_buffers.temp1 = reinterpret_cast<int16_t*>(buffers.buffer0);
   cmsis_buffers.temp2 = reinterpret_cast<int16_t*>(buffers.buffer1);
-  cmsis_buffers.cell_state = reinterpret_cast<int16_t*>(buffers.buffer2);
+  cmsis_buffers.cell_state = cell_state;
 
-  arm_lstm_unidirectional_s8(input, output, &op_data.params_cmsis_nn,
-                             &cmsis_buffers);
+  const auto& params = op_data.params_cmsis_nn;
+
+#ifdef CMSIS_NN_STATEFUL_LSTM
+  cmsis_buffers.hidden_state = hidden_state;
+  arm_cmsis_nn_status status =
+      arm_lstm_unidirectional_s8(input, output, &params, &cmsis_buffers);
+  if (status != ARM_CMSIS_NN_SUCCESS) return kTfLiteError;
+#else
+  if (params.time_major) {
+    int8_t* step_hidden_in = hidden_state;
+    for (int t = 0; t < params.time_steps; t++) {
+      const int8_t* data_in =
+          input + (t * params.batch_size * params.input_size);
+      int8_t* hidden_out =
+          output + (t * params.batch_size * params.hidden_size);
+
+      arm_cmsis_nn_status status = arm_nn_lstm_step_s8(
+          data_in, step_hidden_in, hidden_out, &params, &cmsis_buffers, 1);
+      if (status != ARM_CMSIS_NN_SUCCESS) return kTfLiteError;
+      step_hidden_in = hidden_out;
+    }
+    if (params.time_steps > 0) {
+      std::copy_n(step_hidden_in, params.batch_size * params.hidden_size,
+                  hidden_state);
+    }
+  } else {
+    cmsis_nn_lstm_params step_params = params;
+    step_params.batch_size = 1;
+    for (int b = 0; b < params.batch_size; b++) {
+      int8_t* step_hidden_in = hidden_state + b * params.hidden_size;
+      cmsis_buffers.cell_state = cell_state + b * params.hidden_size;
+
+      for (int t = 0; t < params.time_steps; t++) {
+        const int8_t* data_in =
+            input + (b * params.time_steps + t) * params.input_size;
+        int8_t* hidden_out =
+            output + (b * params.time_steps + t) * params.hidden_size;
+
+        arm_cmsis_nn_status status =
+            arm_nn_lstm_step_s8(data_in, step_hidden_in, hidden_out,
+                                &step_params, &cmsis_buffers, 1);
+        if (status != ARM_CMSIS_NN_SUCCESS) return kTfLiteError;
+        step_hidden_in = hidden_out;
+      }
+      if (params.time_steps > 0) {
+        std::copy_n(step_hidden_in, params.hidden_size,
+                    hidden_state + b * params.hidden_size);
+      }
+    }
+  }
+#endif
 
   return kTfLiteOk;
 }
 
 TfLiteStatus CMSIS_NN_EvalInteger16x8_16Lstm(
-    const OpData& op_data, const LSTMKernelContents& kernel_content,
+    const OpData& op_data, LSTMKernelContents& kernel_content,
     const LSTMBuffers<int16_t>& buffers) {
   TFLITE_DCHECK(
       kernel_content.GetInternalTensor(tflite::kLstmInputTensor)->dims->size >=
@@ -308,15 +362,63 @@ TfLiteStatus CMSIS_NN_EvalInteger16x8_16Lstm(
       kernel_content.GetInternalTensor(tflite::kLstmInputTensor));
   int16_t* output =
       tflite::micro::GetTensorData<int16_t>(kernel_content.output_tensor);
+  int16_t* hidden_state =
+      tflite::micro::GetTensorData<int16_t>(kernel_content.HiddenStateTensor());
+  int16_t* cell_state =
+      tflite::micro::GetTensorData<int16_t>(kernel_content.CellStateTensor());
 
   // Create lstm buffer struct
   cmsis_nn_lstm_context cmsis_buffers;
   cmsis_buffers.temp1 = reinterpret_cast<int16_t*>(buffers.buffer0);
   cmsis_buffers.temp2 = reinterpret_cast<int16_t*>(buffers.buffer1);
-  cmsis_buffers.cell_state = reinterpret_cast<int16_t*>(buffers.buffer2);
+  cmsis_buffers.cell_state = cell_state;
 
-  arm_lstm_unidirectional_s16(input, output, &op_data.params_cmsis_nn,
-                              &cmsis_buffers);
+  const auto& params = op_data.params_cmsis_nn;
+
+#ifdef CMSIS_NN_STATEFUL_LSTM
+  cmsis_buffers.hidden_state = hidden_state;
+  arm_cmsis_nn_status status =
+      arm_lstm_unidirectional_s16(input, output, &params, &cmsis_buffers);
+  if (status != ARM_CMSIS_NN_SUCCESS) return kTfLiteError;
+#else
+  if (params.time_major) {
+    for (int t = 0; t < params.time_steps; t++) {
+      const int16_t* data_in =
+          input + (t * params.batch_size * params.input_size);
+      int16_t* hidden_out =
+          output + (t * params.batch_size * params.hidden_size);
+
+      arm_cmsis_nn_status status = arm_nn_lstm_step_s16(
+          data_in, hidden_state, hidden_out, &params, &cmsis_buffers, 1);
+      if (status != ARM_CMSIS_NN_SUCCESS) return kTfLiteError;
+
+      // Update hidden state for next step
+      std::copy_n(hidden_out, params.batch_size * params.hidden_size,
+                  hidden_state);
+    }
+  } else {
+    cmsis_nn_lstm_params step_params = params;
+    step_params.batch_size = 1;
+    for (int b = 0; b < params.batch_size; b++) {
+      for (int t = 0; t < params.time_steps; t++) {
+        const int16_t* data_in =
+            input + (b * params.time_steps + t) * params.input_size;
+        int16_t* hidden_out =
+            output + (b * params.time_steps + t) * params.hidden_size;
+        int16_t* current_hidden = hidden_state + b * params.hidden_size;
+        cmsis_buffers.cell_state = cell_state + b * params.hidden_size;
+
+        arm_cmsis_nn_status status =
+            arm_nn_lstm_step_s16(data_in, current_hidden, hidden_out,
+                                 &step_params, &cmsis_buffers, 1);
+        if (status != ARM_CMSIS_NN_SUCCESS) return kTfLiteError;
+
+        // Update hidden state for next step
+        std::copy_n(hidden_out, params.hidden_size, current_hidden);
+      }
+    }
+  }
+#endif
 
   return kTfLiteOk;
 }


### PR DESCRIPTION
### Problem

The current CMSIS-NN LSTM wrapper uses arm_lstm_unidirectional_s8 and arm_lstm_unidirectional_s16. These CMSIS-NN functions are designed for stateless sequence evaluation: they explicitly wipe the cell state at t=0 and ignore any initial hidden state, returning only the sequence outputs.

This breaks TFLM's streaming/embedded ML workloads which rely on stateful LSTMs where the CellStateTensor and HiddenStateTensor persist as variable tensors across Invoke() calls.

Furthermore, CMSIS-NN's internal implementation for batch-major tensors (time_major=false with batch_size > 1) incorrectly jumps memory by time_steps, causing an out-of-bounds read on the contiguous hidden_state buffer.

### Solution

1. Fallback to explicit looping: Implemented a manual time/batch loop within CMSIS_NN_EvalInteger8x8_16Lstm and CMSIS_NN_EvalInteger16x8_16Lstm that bypasses the stateless sequence evaluator and instead iteratively calls the single-step CMSIS-NN kernels (arm_nn_lstm_step_s8 and arm_nn_lstm_step_s16).
1. State Persistence: The fallback loop properly preserves the CellStateTensor and HiddenStateTensor across timesteps and invocations.
1. Stride Bug Bypass: For time_major=false, the loop evaluates one batch at a time (batch_size=1 passed to the kernel), which guarantees cache-friendly contiguous memory reads and avoids CMSIS-NN's batch striding bug entirely.
1. Future-proofing: Introduced #ifdef CMSIS_NN_STATEFUL_LSTM. Once ARM merges a fix upstream to support the optional hidden_state context pointer, this flag will seamlessly switch back to using the native CMSIS-NN sequence evaluator. (https://github.com/ARM-software/CMSIS-NN/pull/219)

BUG=N/A