### PR TITLE
feat(compression): update tooling to use DECODE operators

### DIFF
--- a/python/tflite_micro/BUILD
+++ b/python/tflite_micro/BUILD
@@ -125,7 +125,7 @@ py_test(
         ":runtime",
         requirement("numpy"),
         requirement("tensorflow"),
-        "//tensorflow/lite/micro/compression",
+        "//tensorflow/lite/micro/compression:model_editor",
     ],
 )
 

--- a/python/tflite_micro/test_compression_unsupported.py
+++ b/python/tflite_micro/test_compression_unsupported.py
@@ -88,6 +88,8 @@ class LegacyCompressionDetectionTest(tf.test.TestCase):
 
 
 if __name__ == '__main__':
+  # Suppress TF C++ info/debug logs (0=DEBUG, 1=INFO, 2=WARNING, 3=ERROR)
   os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
+  # Disable oneDNN to avoid non-deterministic floating point results
   os.environ['TF_ENABLE_ONEDNN_OPTS'] = '0'
   tf.test.main()

--- a/python/tflite_micro/test_compression_unsupported.py
+++ b/python/tflite_micro/test_compression_unsupported.py
@@ -12,84 +12,82 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Test compression metadata detection when compression is disabled."""
+"""Test legacy compression metadata detection when compression is disabled."""
 
 import os
 import numpy as np
 import tensorflow as tf
 from tflite_micro.python.tflite_micro import runtime
-from tflite_micro.tensorflow.lite.micro import compression
+from tflite_micro.tensorflow.lite.micro.compression import model_editor
 
 
-class CompressionDetectionTest(tf.test.TestCase):
-  """Test compression metadata detection when compression is disabled."""
+def _create_test_model():
+  """Create a simple quantized model for testing."""
+  model = tf.keras.Sequential([
+      tf.keras.layers.Dense(10, input_shape=(5, ), activation='relu'),
+      tf.keras.layers.Dense(5, activation='softmax')
+  ])
+  model.compile(optimizer='adam', loss='sparse_categorical_crossentropy')
 
-  def _create_test_model(self):
-    """Create a simple quantized model for testing."""
-    model = tf.keras.Sequential([
-        tf.keras.layers.Dense(10, input_shape=(5, ), activation='relu'),
-        tf.keras.layers.Dense(5, activation='softmax')
-    ])
-    model.compile(optimizer='adam', loss='sparse_categorical_crossentropy')
+  converter = tf.lite.TFLiteConverter.from_keras_model(model)
+  converter.optimizations = [tf.lite.Optimize.DEFAULT]
 
-    # Convert to quantized TFLite
-    converter = tf.lite.TFLiteConverter.from_keras_model(model)
-    converter.optimizations = [tf.lite.Optimize.DEFAULT]
+  def representative_dataset():
+    for _ in range(10):
+      yield [np.random.randn(1, 5).astype(np.float32)]
 
-    def representative_dataset():
-      for _ in range(10):
-        yield [np.random.randn(1, 5).astype(np.float32)]
+  converter.representative_dataset = representative_dataset
+  converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
+  converter.inference_input_type = tf.uint8
+  converter.inference_output_type = tf.uint8
 
-    converter.representative_dataset = representative_dataset
-    converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
-    converter.inference_input_type = tf.uint8
-    converter.inference_output_type = tf.uint8
+  tflite_model = converter.convert()
+  return bytes(tflite_model) if isinstance(tflite_model,
+                                           bytearray) else tflite_model
 
-    tflite_model = converter.convert()
-    return bytes(tflite_model) if isinstance(tflite_model,
-                                             bytearray) else tflite_model
+
+def _inject_compression_metadata(model_data):
+  """Inject raw COMPRESSION_METADATA into a model's flatbuffer metadata.
+
+  This simulates a legacy-compressed model (one that uses the
+  COMPRESSION_METADATA metadata entry and kernel-level decompression) without
+  going through compress(), which now produces DECODE-based output.
+  """
+  model = model_editor.read(model_data)
+  model.metadata["COMPRESSION_METADATA"] = b"\x00"
+  return bytes(model.build())
+
+
+class LegacyCompressionDetectionTest(tf.test.TestCase):
+  """Test that legacy COMPRESSION_METADATA is rejected without the flag."""
 
   def test_regular_model_loads_successfully(self):
     """Non-compressed models should load without issues."""
-    model_data = self._create_test_model()
+    model_data = _create_test_model()
     interpreter = runtime.Interpreter.from_bytes(model_data)
     self.assertIsNotNone(interpreter)
 
-  def test_compressed_model_raises_runtime_error(self):
-    """Compressed models should raise RuntimeError when compression is disabled."""
-    # Create and compress a model
-    model_data = self._create_test_model()
-
-    spec = (compression.SpecBuilder().add_tensor(
-        subgraph=0, tensor=1).with_lut(index_bitwidth=4).build())
-
-    compressed_model = compression.compress(model_data, spec)
-    if isinstance(compressed_model, bytearray):
-      compressed_model = bytes(compressed_model)
-
-    # Should raise RuntimeError
-    with self.assertRaises(RuntimeError):
-      runtime.Interpreter.from_bytes(compressed_model)
-
-  def test_can_load_regular_after_compressed_failure(self):
-    """Verify we can still load regular models after compressed model fails."""
-    model_data = self._create_test_model()
-
-    # First try compressed model (should fail)
-    spec = (compression.SpecBuilder().add_tensor(
-        subgraph=0, tensor=1).with_lut(index_bitwidth=4).build())
-    compressed_model = compression.compress(model_data, spec)
+  def test_legacy_compressed_model_raises_runtime_error(self):
+    """Models with COMPRESSION_METADATA should raise RuntimeError."""
+    model_data = _create_test_model()
+    legacy_model = _inject_compression_metadata(model_data)
 
     with self.assertRaises(RuntimeError):
-      runtime.Interpreter.from_bytes(bytes(compressed_model))
+      runtime.Interpreter.from_bytes(legacy_model)
 
-    # Then load regular model (should succeed)
+  def test_can_load_regular_after_legacy_failure(self):
+    """Verify regular models still load after a legacy-compressed failure."""
+    model_data = _create_test_model()
+    legacy_model = _inject_compression_metadata(model_data)
+
+    with self.assertRaises(RuntimeError):
+      runtime.Interpreter.from_bytes(legacy_model)
+
     interpreter = runtime.Interpreter.from_bytes(model_data)
     self.assertIsNotNone(interpreter)
 
 
 if __name__ == '__main__':
-  # Set TF environment variables to suppress warnings
   os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
   os.environ['TF_ENABLE_ONEDNN_OPTS'] = '0'
   tf.test.main()

--- a/tensorflow/lite/micro/compression/BUILD
+++ b/tensorflow/lite/micro/compression/BUILD
@@ -123,14 +123,15 @@ py_library(
         "compress.py",
     ],
     deps = [
-        ":metadata_py",
+        ":compressor",
+        ":decode_insert",
+        ":huffman",
+        ":lut",
         ":model_editor",
+        ":pruning",
         ":spec",
         "//tensorflow/lite/micro/tools:tflite_flatbuffer_align",
         requirement("absl_py"),
-        requirement("flatbuffers"),
-        requirement("bitarray"),
-        requirement("numpy"),
     ],
 )
 
@@ -159,11 +160,11 @@ py_test(
     target_compatible_with = INCOMPATIBLE_WITH_WINDOWS,
     deps = [
         ":compress",
-        ":metadata_py",
+        ":compressor",
+        ":decode_insert",
         ":model_editor",
         ":spec",
         "//tensorflow/lite/python:schema_py",
-        requirement("bitarray"),
         requirement("numpy"),
     ],
 )

--- a/tensorflow/lite/micro/compression/BUILD
+++ b/tensorflow/lite/micro/compression/BUILD
@@ -194,6 +194,30 @@ tflm_py_test(
     ],
 )
 
+tflm_py_test(
+    name = "proprietary_integration_test",
+    size = "small",
+    srcs = ["proprietary_integration_test.py"],
+    tags = [
+        "manual",
+        "noasan",
+        "nomsan",
+        "noubsan",
+    ],
+    target_compatible_with = select({
+        "//:with_compression_enabled": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        ":compress_lib",
+        ":model_editor",
+        ":spec",
+        "//python/tflite_micro:runtime",
+        "//tensorflow/lite/python:schema_py",
+        requirement("numpy"),
+    ],
+)
+
 tflm_py_library(
     name = "spec",
     srcs = ["spec.py"],

--- a/tensorflow/lite/micro/compression/BUILD
+++ b/tensorflow/lite/micro/compression/BUILD
@@ -355,6 +355,26 @@ tflm_py_test(
     ],
 )
 
+tflm_py_test(
+    name = "decode_insert_runtime_test",
+    size = "small",
+    srcs = ["decode_insert_runtime_test.py"],
+    tags = [
+        "noasan",
+        "nomsan",
+        "noubsan",
+    ],
+    deps = [
+        ":decode_insert",
+        ":lut",
+        ":model_editor",
+        ":spec",
+        "//python/tflite_micro:runtime",
+        "//tensorflow/lite/python:schema_py",
+        requirement("numpy"),
+    ],
+)
+
 tflm_py_binary(
     name = "view",
     srcs = [

--- a/tensorflow/lite/micro/compression/BUILD
+++ b/tensorflow/lite/micro/compression/BUILD
@@ -169,6 +169,31 @@ py_test(
     ],
 )
 
+tflm_py_test(
+    name = "compression_integration_test",
+    size = "small",
+    srcs = ["compression_integration_test.py"],
+    tags = [
+        "noasan",
+        "nomsan",
+        "noubsan",
+    ],
+    # Only run when compression IS enabled
+    target_compatible_with = select({
+        "//:with_compression_enabled": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        ":compress_lib",
+        ":decode_insert",
+        ":model_editor",
+        ":spec",
+        "//python/tflite_micro:runtime",
+        "//tensorflow/lite/python:schema_py",
+        requirement("numpy"),
+    ],
+)
+
 tflm_py_library(
     name = "spec",
     srcs = ["spec.py"],

--- a/tensorflow/lite/micro/compression/BUILD
+++ b/tensorflow/lite/micro/compression/BUILD
@@ -326,6 +326,35 @@ tflm_py_library(
     ],
 )
 
+tflm_py_library(
+    name = "decode_insert",
+    srcs = ["decode_insert.py"],
+    deps = [
+        ":compressor",
+        ":model_editor",
+        "//tensorflow/lite/python:schema_py",
+    ],
+)
+
+tflm_py_test(
+    name = "decode_insert_test",
+    size = "small",
+    srcs = ["decode_insert_test.py"],
+    tags = [
+        "noasan",
+        "nomsan",
+        "noubsan",
+    ],
+    deps = [
+        ":compressor",
+        ":decode",
+        ":decode_insert",
+        ":model_editor",
+        "//tensorflow/lite/python:schema_py",
+        requirement("numpy"),
+    ],
+)
+
 tflm_py_binary(
     name = "view",
     srcs = [

--- a/tensorflow/lite/micro/compression/BUILD
+++ b/tensorflow/lite/micro/compression/BUILD
@@ -178,11 +178,7 @@ tflm_py_test(
         "nomsan",
         "noubsan",
     ],
-    # Only run when compression IS enabled
-    target_compatible_with = select({
-        "//:with_compression_enabled": [],
-        "//conditions:default": ["@platforms//:incompatible"],
-    }),
+    target_compatible_with = INCOMPATIBLE_WITH_WINDOWS,
     deps = [
         ":compress_lib",
         ":decode_insert",
@@ -204,10 +200,7 @@ tflm_py_test(
         "nomsan",
         "noubsan",
     ],
-    target_compatible_with = select({
-        "//:with_compression_enabled": [],
-        "//conditions:default": ["@platforms//:incompatible"],
-    }),
+    target_compatible_with = INCOMPATIBLE_WITH_WINDOWS,
     deps = [
         ":compress_lib",
         ":model_editor",

--- a/tensorflow/lite/micro/compression/compress.py
+++ b/tensorflow/lite/micro/compression/compress.py
@@ -132,6 +132,11 @@ def compress(model_in: ByteString, specs: Iterable[spec.Tensor]) -> bytearray:
   Returns:
     A compressed flatbuffer with DECODE operators inserted.
   """
+  specs = list(specs)
+  if not specs:
+    raise compressor.CompressionError(
+        "Compression spec is empty; no tensors to compress")
+
   model = model_editor.read(model_in)
   compression_results: dict[tuple[int, int], compressor.CompressionResult] = {}
 

--- a/tensorflow/lite/micro/compression/compress.py
+++ b/tensorflow/lite/micro/compression/compress.py
@@ -16,22 +16,22 @@
 See USAGE.
 """
 
-import bitarray
-import bitarray.util
-from dataclasses import dataclass, field
 import os
 import sys
 import tempfile
-from typing import ByteString, Iterable, Optional
+import warnings
+from typing import ByteString, Iterable, Type
 
 import absl.app
 import absl.flags
-import flatbuffers
-import numpy as np
 
+from tflite_micro.tensorflow.lite.micro.compression import compressor
+from tflite_micro.tensorflow.lite.micro.compression import decode_insert
+from tflite_micro.tensorflow.lite.micro.compression import huffman
+from tflite_micro.tensorflow.lite.micro.compression import lut
 from tflite_micro.tensorflow.lite.micro.compression import model_editor
+from tflite_micro.tensorflow.lite.micro.compression import pruning
 from tflite_micro.tensorflow.lite.micro.compression import spec
-from tflite_micro.tensorflow.lite.micro.compression import metadata_py_generated as schema
 from tflite_micro.tensorflow.lite.micro.tools import tflite_flatbuffer_align_wrapper
 
 USAGE = f"""\
@@ -49,221 +49,48 @@ key "tensors" with a list of tensors to compress as its value. E.g.:
 {spec.EXAMPLE_YAML_SPEC}
 ---
 
-The only compression method currently implemented is "lut", i.e.,
-Look-Up-Table. This method requires the tensor in the input model to have a
-small number of unique values, fewer than or equal to 2**index_bitwidth. LUT
-compression collects these values into a lookup table, and rewrites the tensor
-as bitwidth-wide integer indices into that lookup table. Presumably, the input
-model has been trained or preprocessed in a way that the tensor values
-are binned into a meaningful, limited set.
+Supported compression methods:
+
+  lut: Look-Up-Table compression. Requires the tensor to have a small number of
+       unique values, fewer than or equal to 2**index_bitwidth. LUT compression
+       collects these values into a lookup table, and rewrites the tensor as
+       bitwidth-wide integer indices into that lookup table.
+
+  huffman: Huffman compression using Xtensa-format decode tables. (Not yet
+           implemented.)
+
+  pruning: Pruning (sparsity) compression for sparse tensors. (Not yet
+           implemented.)
+
+Compressed models use DECODE operators to decompress tensors at runtime.
 """
 
-# A compressed model augments the usual .tflite flatbuffer with a flatbuffer of
-# its own containing compression metadata, stored at the buffer index stored at
-# the following key in the .tflite flatbuffer's metadata map.
-TFLITE_METADATA_KEY = "COMPRESSION_METADATA"
+# Plugin dispatch table: maps CompressionMethod subclasses to compressor instances
+_COMPRESSORS: dict[Type[spec.CompressionMethod], compressor.Compressor] = {
+    spec.LookUpTableCompression: lut.LutCompressor(),
+    spec.HuffmanCompression: huffman.HuffmanCompressor(),
+    spec.PruningCompression: pruning.PruningCompressor(),
+}
 
 
-class CompressionError(Exception):
-  """Raised when compression fails for the reason documented in the message."""
-
-  def __init__(self, message, wrapped_exception=None):
-    super().__init__(f"{message}: {str(wrapped_exception)}")
-    self.original_exception = wrapped_exception
-
-
-class _MetadataBuilder:
-  """Builder for the compression metadata flatbuffer."""
-
-  def __init__(self):
-    self._metadata = schema.MetadataT()
-    self._metadata.subgraphs = []
-
-  def compile(self) -> bytearray:
-    """Packs the metadata into a binary array and returns it.
-    """
-    builder = flatbuffers.Builder(1 * 2**10)
-    root = self._metadata.Pack(builder)
-    builder.Finish(root)
-    return builder.Output()
-
-  def subgraph(self, index: int):
-    """Return subgraph at index, adding subgraphs if necessary.
-    """
-    while len(self._metadata.subgraphs) <= index:
-      self._add_subgraph()
-    return self._metadata.subgraphs[index]
-
-  def add_lut_tensor(self, subgraph_id: int):
-    """Add LUT tensor to the given subgraph and return it.
-    """
-    tensor = schema.LutTensorT()
-    self.subgraph(subgraph_id).lutTensors.append(tensor)
-    return tensor
-
-  def _add_subgraph(self):
-    subgraph = schema.SubgraphT()
-    subgraph.lutTensors = []
-    self._metadata.subgraphs.append(subgraph)
-    return subgraph
-
-
-@dataclass
-class _LutCompressedArray:
-  compression_axis: Optional[int] = None
-  lookup_tables: list[np.ndarray] = field(default_factory=list)
-  indices: np.ndarray = field(default_factory=lambda: np.array([]))
-
-  @property
-  def index_bitwidth(self) -> int:
-    """Returns the number of bits required to encode the indices."""
-    if self.indices is None:
-      raise ValueError
-
-    max_index = int(np.max(self.indices))
-    return max_index.bit_length() or 1
-
-
-def _lut_compress_array(tensor: np.ndarray,
-                        axis: Optional[int]) -> _LutCompressedArray:
-  """Compresses the given tensor using lookup tables.
-
-  Args:
-      tensor (np.ndarray): The tensor to be compressed.
-
-      axis (Optional[int]): The axis along which to compress the tensor. If an
-          axis is given, a lookup table is created for each slice along the
-          axis. If axis is None, a single lookup table is used for the entire
-          tensor.
-
-          Compressing a tensor with a lookup table per slice along a
-          particular axis is analogous to quantizing a tensor with different
-          quantization parameters per slice along a particular axis (dimension).
-
-  Returns:
-      _LutCompressedArray: An object containing the compressed tensor data,
-      including the lookup tables and indices.
-  """
-  compressed = _LutCompressedArray()
-  compressed.compression_axis = axis
-
-  if axis is None:
-    # Compute unique values and indices for the entire tensor
-    values, indices = np.unique(tensor, return_inverse=True)
-    compressed.lookup_tables.append(values)
-    compressed.indices = indices.reshape(tensor.shape)
-  else:
-    # Iterate over slices along the compression axis
-    slice_indices = []
-    for slice in np.moveaxis(tensor, axis, 0):
-      values, indices = np.unique(slice, return_inverse=True)
-      compressed.lookup_tables.append(values)
-      indices = indices.reshape(slice.shape)
-      slice_indices.append(indices)
-
-    # Reconstruct a tensor of indices from the slices
-    stacked = np.stack(slice_indices, axis=0)
-    compressed.indices = np.moveaxis(stacked, 0, axis)
-
-  return compressed
-
-
-def _check_lut_compression(compression) -> spec.LookUpTableCompression:
-  if len(compression) != 1:
-    raise CompressionError("Each tensor must have exactly one compression")
-  if not isinstance(compression[0], spec.LookUpTableCompression):
-    raise CompressionError('Only "lut" compression may be specified')
-
-  return compression[0]
-
-
-def _identify_compression_axis(tensor: model_editor.Tensor) -> Optional[int]:
-  """Determines the axis along which to compress.
-
-  The axis along which to compress is inferred from the tensor's quantization
-  parameters.
-
-  Returns:
-    The axis along which to compress, or None to indicate one value table for
-    the entire tensor.
-
-  Raises:
-    CompressionError: If the axis cannot be determined.
-  """
-  q = tensor.quantization
-  if q is not None:
-    # model_editor wraps quantization, access scales/axis from wrapper
-    scales = q.scales if isinstance(q.scales, list) else [q.scales]
-    quantization_channels = len(scales)
-
-    if quantization_channels == 1:
-      # Use one value table for the entire tensor
-      return None
-
-    if q.axis is not None and q.axis < len(tensor.shape):
-      if quantization_channels == tensor.shape[q.axis]:
-        return q.axis
-
-  raise CompressionError(
-      f"Invalid or no quanitzation parameters from which to "
-      f"infer the axis along which tensor should be compressed.")
-
-
-def _check_bitwidth(compressed: int, specified: int, spec: spec.Tensor):
-  """Applies business logic regarding specified bitwidth.
-
-  It is an error if the bitwidth required to compress a tensor exceeds the
-  specified bitwith, and a warning if the tensor can be compressed in less than
-  the specified bitwidth. The latter is allowed, and is not an error, to permit
-  testing with larger bitwidths without re-binning a model.
-  """
-  if compressed > specified:
-    raise CompressionError(
-        f"index_bitwidth too small: {compressed} bits needed to "
-        f"enumerate unique values in tensor specified in {spec}")
-  elif compressed < specified:
-    print(
-        f"warning: index_bitwidth too large: only {compressed} "
-        f"bits needed to enumerate unique values in tensor specified in {spec}",
-        file=sys.stderr)
-
-
-def _pack_indices(indices: np.ndarray, bitwidth: int) -> bytes:
-  """Packs indices into a bytearray using bitwidth-sized fields.
-  """
-  endianness = "big"
-  bits = bitarray.bitarray(endian=endianness)
-  for i in indices.ravel():
-    bits.extend(
-        bitarray.util.int2ba(int(i), length=bitwidth, endian=endianness))
-  return bits.tobytes()
-
-
-def _pack_lookup_tables(tables: list[np.ndarray], table_len: int) -> bytearray:
-  """Packs the value tables of a LutCompressedArray.
-
-  Pack the value tables of a LutCompressedArray into a bytes object in the
-  format writable to a value_table buffer in the .tflite flatbuffer. The
-  tables are concatenated.
-  """
-  buffer = bytearray()
-  for t in tables:
-    padding_needed = table_len - len(t)
-    padded = np.pad(t, (0, padding_needed), mode='constant', constant_values=0)
-    buffer.extend(padded.tobytes())
-
-  return buffer
+def _get_compressor(method: spec.CompressionMethod) -> compressor.Compressor:
+  """Get the compressor plugin for a given compression method."""
+  compressor_instance = _COMPRESSORS.get(type(method))
+  if compressor_instance is None:
+    raise compressor.CompressionError(
+        f"No compressor registered for {type(method).__name__}")
+  return compressor_instance
 
 
 def _apply_flatbuffer_alignment(model_bytes: bytearray) -> bytearray:
   """Applies proper FlatBuffer alignment to a model.
-  
+
   The Python flatbuffers library doesn't respect `force_align` schema attributes,
   so we use the C++ wrapper which properly handles alignment requirements.
-  
+
   Args:
     model_bytes: The model flatbuffer to align
-    
+
   Returns:
     The properly aligned model flatbuffer
   """
@@ -295,45 +122,58 @@ def _apply_flatbuffer_alignment(model_bytes: bytearray) -> bytearray:
 def compress(model_in: ByteString, specs: Iterable[spec.Tensor]) -> bytearray:
   """Compresses a model .tflite flatbuffer.
 
+  Compresses tensors according to the given specs and inserts DECODE operators
+  to decompress them at runtime.
+
   Args:
     model_in: the original, uncompressed .tflite flatbuffer
     specs: an iterable of compression specs, see module spec.py
 
   Returns:
-    A compressed flatbuffer.
+    A compressed flatbuffer with DECODE operators inserted.
   """
   model = model_editor.read(model_in)
-  metadata = _MetadataBuilder()
+  compression_results: dict[tuple[int, int], compressor.CompressionResult] = {}
 
-  for spec in specs:
+  for tensor_spec in specs:
     try:
-      tensor = model.subgraphs[spec.subgraph].tensors[spec.tensor]
-      lut_compression = _check_lut_compression(spec.compression)
-      spec_bitwidth = lut_compression.index_bitwidth
-      axis = _identify_compression_axis(tensor)
-      compressed = _lut_compress_array(tensor.array, axis)
-      _check_bitwidth(compressed.index_bitwidth, spec_bitwidth, spec)
+      tensor = model.subgraphs[tensor_spec.subgraph].tensors[
+          tensor_spec.tensor]
 
-      # overwrite tensor data with indices
-      tensor.buffer.data = _pack_indices(compressed.indices, spec_bitwidth)
+      # Currently only one compression method per tensor
+      if len(tensor_spec.compression) != 1:
+        raise compressor.CompressionError(
+            "Each tensor must have exactly one compression method")
 
-      # write value buffer
-      value_buffer_data = _pack_lookup_tables(compressed.lookup_tables,
-                                              2**spec_bitwidth)
-      value_buffer = model_editor.Buffer(data=value_buffer_data)
-      model.buffers.append(value_buffer)  # Auto-sets value_buffer.index
+      method = tensor_spec.compression[0]
+      plugin = _get_compressor(method)
+      original_size = len(tensor.buffer.data) if tensor.buffer.data else 0
+      result = plugin.compress(tensor, method)
 
-      # add compression metadata for tensor
-      lut_tensor = metadata.add_lut_tensor(subgraph_id=spec.subgraph)
-      lut_tensor.tensor = spec.tensor
-      lut_tensor.valueBuffer = value_buffer.index
-      lut_tensor.indexBitwidth = spec_bitwidth
+      compressed_size = len(result.encoded_data) + len(result.ancillary_data)
+      if compressed_size > original_size:
+        warnings.warn(
+            f"Compression of tensor {tensor.name!r} (subgraph "
+            f"{tensor_spec.subgraph}, tensor {tensor_spec.tensor}) resulted "
+            f"in expansion: {original_size} bytes -> {compressed_size} bytes "
+            f"(encoded: {len(result.encoded_data)}, "
+            f"ancillary: {len(result.ancillary_data)})",
+            stacklevel=2)
 
+      # Replace tensor data with encoded data
+      tensor.buffer.data = result.encoded_data
+
+      # Store result for DECODE insertion
+      compression_results[(tensor_spec.subgraph, tensor_spec.tensor)] = result
+
+    except compressor.CompressionError:
+      raise
     except Exception as e:
-      raise CompressionError(f"error compressing {spec}") from e
+      raise compressor.CompressionError(
+          f"error compressing {tensor_spec}") from e
 
-  # add compression metadata to model
-  model.metadata[TFLITE_METADATA_KEY] = metadata.compile()
+  # Insert DECODE operators into the graph
+  decode_insert.insert_decode_operators(model, compression_results)
 
   # Build the model and apply proper alignment
   unaligned_model = model.build()

--- a/tensorflow/lite/micro/compression/compress_test.py
+++ b/tensorflow/lite/micro/compression/compress_test.py
@@ -11,162 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Integration tests for the compression system."""
 
-import bitarray
-import bitarray.util
+import warnings
+
 import numpy as np
 import unittest
 
 from tflite_micro.tensorflow.lite.micro.compression import compress
-from tflite_micro.tensorflow.lite.micro.compression import metadata_py_generated as schema
+from tflite_micro.tensorflow.lite.micro.compression import compressor
+from tflite_micro.tensorflow.lite.micro.compression import decode_insert
 from tflite_micro.tensorflow.lite.micro.compression import model_editor
 from tflite_micro.tensorflow.lite.micro.compression import spec
 from tflite_micro.tensorflow.lite.python import schema_py_generated as tflite
-
-
-class TestPackIndices(unittest.TestCase):
-
-  def test_basic_case(self):
-    indices = np.array([1, 2, 3])
-    bitwidth = 4
-    result = compress._pack_indices(indices, bitwidth)
-    expected_bytes = bytes([0b0001_0010, 0b0011_0000])
-    self.assertEqual(result, expected_bytes)
-
-  def test_single_element(self):
-    indices = np.array([10])
-    bitwidth = 8
-    result = compress._pack_indices(indices, bitwidth)
-    expected_bytes = bytes([0b0000_1010])
-    self.assertEqual(result, expected_bytes)
-
-  def test_different_bitwidth(self):
-    indices = np.array([1, 2, 3])
-    bitwidth = 8
-    result = compress._pack_indices(indices, bitwidth)
-    expected_bytes = bytes([0b0000_0001, 0b0000_0010, 0b0000_0011])
-    self.assertEqual(result, expected_bytes)
-
-  def test_large_numbers(self):
-    indices = np.array([255, 128, 64])
-    bitwidth = 8
-    result = compress._pack_indices(indices, bitwidth)
-    expected_bytes = bytes([0b1111_1111, 0b1000_0000, 0b0100_0000])
-    self.assertEqual(result, expected_bytes)
-
-  def test_multidimensional_array(self):
-    indices = np.array([[1, 2], [3, 4]])
-    bitwidth = 4
-    result = compress._pack_indices(indices, bitwidth)
-    expected_bytes = bytes([0b0001_0010, 0b0011_0100])
-    self.assertEqual(result, expected_bytes)
-
-  def test_zero_bitwidth(self):
-    indices = np.array([0, 1, 2])
-    bitwidth = 0
-    with self.assertRaises(ValueError):
-      compress._pack_indices(indices, bitwidth)
-
-  def test_empty_array(self):
-    indices = np.array([])
-    bitwidth = 4
-    result = compress._pack_indices(indices, bitwidth)
-    expected_bytes = b""
-    self.assertEqual(result, expected_bytes)
-
-  def test_bitwidth_1(self):
-    indices = np.array([1, 0, 1, 1, 0, 1])
-    bitwidth = 1
-    result = compress._pack_indices(indices, bitwidth)
-    expected_bytes = bytes([0b101101_00])
-    self.assertEqual(result, expected_bytes)
-
-  def test_bitwidth_2(self):
-    indices = np.array([1, 2, 3, 0])
-    bitwidth = 2
-    result = compress._pack_indices(indices, bitwidth)
-    expected_bytes = bytes([0b01_10_11_00])
-    self.assertEqual(result, expected_bytes)
-
-  def test_bitwidth_3(self):
-    indices = np.array([1, 3, 5, 7])
-    bitwidth = 3
-    result = compress._pack_indices(indices, bitwidth)
-    expected_bytes = bytes([0b001_011_10, 0b1_111_0000])
-    self.assertEqual(result, expected_bytes)
-
-  def test_bitwidth_5(self):
-    indices = np.array([1, 2, 16, 31])
-    bitwidth = 5
-    result = compress._pack_indices(indices, bitwidth)
-    expected_bytes = bytes([0b00001_000, 0b10_10000_1, 0b1111_0000])
-    self.assertEqual(result, expected_bytes)
-
-  def test_bitwidth_7(self):
-    indices = np.array([1, 64, 127, 32])
-    bitwidth = 7
-    result = compress._pack_indices(indices, bitwidth)
-    expected_bytes = bytes(
-        [0b0000001_1, 0b000000_11, 0b11111_010, 0b0000_0000])
-    self.assertEqual(result, expected_bytes)
-
-
-class TestPackLookupTables(unittest.TestCase):
-
-  def test_int16_positive(self):
-    tables = [np.array([0x1234, 0x5678], dtype='<i2')]
-    table_len = 2
-    expected_output = bytes([0x34, 0x12, 0x78, 0x56])
-    result = compress._pack_lookup_tables(tables, table_len)
-    self.assertEqual(result, expected_output)
-
-  def test_int16_negative(self):
-    tables = [np.array([-0x1234, -0x5678], dtype='<i2')]
-    table_len = 2
-    # Expected output is two's complement
-    expected_output = bytes([0xcc, 0xed, 0x88, 0xa9])
-    result = compress._pack_lookup_tables(tables, table_len)
-    self.assertEqual(result, expected_output)
-
-  def test_float16(self):
-    tables = [np.array([1.5, -2.5], dtype='<f2')]
-    table_len = 2
-    expected_output = bytes([0x00, 0x3e, 0x00, 0xc1])
-    result = compress._pack_lookup_tables(tables, table_len)
-    self.assertEqual(result, expected_output)
-
-  def test_multiple_tables(self):
-    tables = [
-        np.array([0x1234, 0x5678], dtype='<i2'),
-        np.array([0x6abc, 0x7ef0], dtype='<i2')
-    ]
-    table_len = 2
-    expected_output = bytes([0x34, 0x12, 0x78, 0x56, 0xbc, 0x6a, 0xf0, 0x7e])
-    result = compress._pack_lookup_tables(tables, table_len)
-    self.assertEqual(result, expected_output)
-
-  def test_int16_with_padding(self):
-    tables = [np.array([0x1234], dtype='<i2')]
-    table_len = 3
-    expected_output = bytes([0x34, 0x12, 0x00, 0x00, 0x00, 0x00])
-    result = compress._pack_lookup_tables(tables, table_len)
-    self.assertEqual(result, expected_output)
-
-  def test_float16_with_padding(self):
-    tables = [np.array([1.5], dtype='<f2')]
-    table_len = 3
-    expected_output = bytes([0x00, 0x3e, 0x00, 0x00, 0x00, 0x00])
-    result = compress._pack_lookup_tables(tables, table_len)
-    self.assertEqual(result, expected_output)
-
-  def test_multiple_tables_with_padding(self):
-    tables = [np.array([0x1234], dtype='<i2'), np.array([0x5678], dtype='<i2')]
-    table_len = 3
-    expected_output = bytes([
-        0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x78, 0x56, 0x00, 0x00, 0x00, 0x00
-    ])
-    result = compress._pack_lookup_tables(tables, table_len)
-    self.assertEqual(result, expected_output)
 
 
 def _build_test_model():
@@ -178,48 +35,69 @@ def _build_test_model():
   t0 = Tensor(shape=(16, 1),
               dtype=tflite.TensorType.UINT8,
               data=np.array(range(16), dtype="<u1"),
+              name="tensor0",
               quantization=Quantization(scales=1, zero_points=0))
   t1 = Tensor(shape=(16, 1),
               dtype=tflite.TensorType.INT8,
               data=np.array(range(-16, 0), dtype="<i1"),
+              name="tensor1",
               quantization=Quantization(scales=1, zero_points=0))
   t2 = Tensor(shape=(16, 1),
               dtype=tflite.TensorType.INT16,
               data=np.array(range(-1616, -1600), dtype="<i2"),
+              name="tensor2",
               quantization=Quantization(scales=1, zero_points=0))
   t3 = Tensor(shape=(16, 1),
               dtype=tflite.TensorType.INT32,
               data=np.array(range(-160_016, -160_000), dtype="<i4"),
+              name="tensor3",
               quantization=Quantization(scales=1, zero_points=0))
   t4 = Tensor(shape=(16, 1),
               dtype=tflite.TensorType.INT32,
               data=np.array(range(16), dtype="<i4"),
+              name="tensor4_uncompressed",
               quantization=Quantization(scales=1, zero_points=0))
-  t5 = Tensor(shape=(4, 5),
-              dtype=tflite.TensorType.INT16,
-              data=np.array(((1, 5, 9, 13, 17), (2, 6, 10, 14, 18),
-                             (3, 7, 11, 15, 19), (4, 8, 12, 16, 20)),
-                            dtype="<i2"),
-              quantization=Quantization(scales=[1, 1, 1, 1, 1],
-                                        zero_points=[0, 0, 0, 0, 0],
-                                        axis=1))
-  t6 = Tensor(shape=(5, 4),
-              dtype=tflite.TensorType.INT16,
-              data=np.array(((1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12),
-                             (13, 14, 15, 16), (17, 18, 19, 20)),
-                            dtype="<i2"),
-              quantization=Quantization(scales=[1, 1, 1, 1, 1],
-                                        zero_points=[0, 0, 0, 0, 0],
-                                        axis=0))
-  t7 = Tensor(shape=(5, 4),
-              dtype=tflite.TensorType.INT16,
-              data=np.array(((1, 2, 3, 4), (1, 2, 3, 4), (1, 2, 3, 4),
-                             (1, 2, 3, 4), (1, 2, 3, 4)),
-                            dtype="<i2"),
-              quantization=Quantization(scales=1, zero_points=0))
+  # yapf: disable
+  t5 = Tensor(
+      shape=(4, 5),
+      dtype=tflite.TensorType.INT16,
+      data=np.array((( 1,  5,  9, 13, 17),
+                     ( 2,  6, 10, 14, 18),
+                     ( 3,  7, 11, 15, 19),
+                     ( 4,  8, 12, 16, 20)), dtype="<i2"),
+      name="tensor5_perchannel",
+      quantization=Quantization(
+          scales=[1, 1, 1, 1, 1], zero_points=[0, 0, 0, 0, 0], axis=1))
+  t6 = Tensor(
+      shape=(5, 4),
+      dtype=tflite.TensorType.INT16,
+      data=np.array((( 1,  2,  3,  4),
+                     ( 5,  6,  7,  8),
+                     ( 9, 10, 11, 12),
+                     (13, 14, 15, 16),
+                     (17, 18, 19, 20)), dtype="<i2"),
+      name="tensor6_axis0",
+      quantization=Quantization(
+          scales=[1, 1, 1, 1, 1], zero_points=[0, 0, 0, 0, 0], axis=0))
+  t7 = Tensor(
+      shape=(5, 4),
+      dtype=tflite.TensorType.INT16,
+      data=np.array(((1, 2, 3, 4),
+                     (1, 2, 3, 4),
+                     (1, 2, 3, 4),
+                     (1, 2, 3, 4),
+                     (1, 2, 3, 4)), dtype="<i2"),
+      name="tensor7_pertensor",
+      quantization=Quantization(scales=1, zero_points=0))
+  # yapf: enable
   t8 = Tensor(shape=(16, 1),
               dtype=tflite.TensorType.UINT8,
-              data=np.array(range(16), dtype="<u1"))
+              data=np.array(range(16), dtype="<u1"),
+              name="tensor8_no_quantization")
+
+  # Output tensors (no data)
+  out0 = Tensor(shape=(16, 1), dtype=tflite.TensorType.INT16, name="output0")
+  out1 = Tensor(shape=(16, 1), dtype=tflite.TensorType.INT16, name="output1")
 
   model = Model(metadata={"metadata0": b""},
                 subgraphs=[
@@ -227,7 +105,10 @@ def _build_test_model():
                              operators=[
                                  Operator(opcode=tflite.BuiltinOperator.ADD,
                                           inputs=[t0, t1],
-                                          outputs=[t2])
+                                          outputs=[out0]),
+                                 Operator(opcode=tflite.BuiltinOperator.MUL,
+                                          inputs=[t2, t3],
+                                          outputs=[out1]),
                              ])
                 ])
 
@@ -275,8 +156,8 @@ TEST_COMPRESSION_SPEC = [
 ]
 
 
-class TestsCompression(unittest.TestCase):
-  """Tests with the uncompressed model."""
+class TestCompression(unittest.TestCase):
+  """Integration tests for the compress() function."""
 
   @classmethod
   def setUpClass(cls):
@@ -284,15 +165,156 @@ class TestsCompression(unittest.TestCase):
     cls.flatbuffer = _build_test_model()
     cls.uncompressed = model_editor.read(cls.flatbuffer)
 
-  def test_compression_metadata(self):
-    """The compressed model has compression metadata."""
-    compressed = compress.compress(self.flatbuffer, TEST_COMPRESSION_SPEC)
-    model = model_editor.read(compressed)
-    self.assertIn("metadata0", self.uncompressed.metadata)
-    self.assertIn(compress.TFLITE_METADATA_KEY, model.metadata)
+  def test_compression_produces_valid_flatbuffer(self):
+    """Compressed model is a valid flatbuffer that can be read back."""
+    compressed_fb = compress.compress(self.flatbuffer, TEST_COMPRESSION_SPEC)
+    model = model_editor.read(compressed_fb)
+    self.assertIsNotNone(model)
+    self.assertEqual(len(model.subgraphs), 1)
 
-  def test_smaller_bitwidth(self):
-    """Specifying LUT compression with too small a bitwidth fails"""
+  def test_decode_operators_inserted(self):
+    """DECODE operators are inserted for compressed tensors."""
+    compressed_fb = compress.compress(self.flatbuffer, TEST_COMPRESSION_SPEC)
+    model = model_editor.read(compressed_fb)
+    sg = model.subgraphs[0]
+
+    # Find DECODE operators
+    decode_ops = [
+        op for op in sg.operators if op.opcode == tflite.BuiltinOperator.CUSTOM
+        and op.custom_code == decode_insert.DECODE_CUSTOM_OP_NAME
+    ]
+
+    # Should have DECODE ops for compressed tensors that are used as inputs
+    # t0, t1 used by ADD; t2, t3 used by MUL
+    # t5, t6, t7 are not used as inputs in the test model
+    self.assertGreater(len(decode_ops), 0)
+
+  def test_decode_operator_structure(self):
+    """DECODE operators have correct input/output structure."""
+    # Build a simple model where weights are used as input
+    # yapf: disable
+    weights = model_editor.Tensor(
+        shape=(4, 4),
+        dtype=tflite.TensorType.INT8,
+        data=np.array([[1, 2, 1, 2],
+                       [3, 4, 3, 4],
+                       [1, 2, 1, 2],
+                       [3, 4, 3, 4]], dtype=np.int8),
+        name="weights",
+        quantization=model_editor.Quantization(scales=0.5, zero_points=0),
+    )
+    # yapf: enable
+    input_t = model_editor.Tensor(
+        shape=(1, 4),
+        dtype=tflite.TensorType.INT8,
+        name="input",
+    )
+    output_t = model_editor.Tensor(
+        shape=(1, 4),
+        dtype=tflite.TensorType.INT8,
+        name="output",
+    )
+
+    model = model_editor.Model(subgraphs=[
+        model_editor.Subgraph(
+            tensors=[weights],
+            operators=[
+                model_editor.Operator(
+                    opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+                    inputs=[input_t, weights],
+                    outputs=[output_t],
+                )
+            ],
+        )
+    ])
+    fb = model.build()
+
+    specs = [
+        spec.Tensor(
+            subgraph=0,
+            tensor=0,
+            compression=[spec.LookUpTableCompression(index_bitwidth=4)])
+    ]
+
+    compressed_fb = compress.compress(fb, specs)
+    result = model_editor.read(compressed_fb)
+    sg = result.subgraphs[0]
+
+    # Find DECODE operator
+    decode_ops = [
+        op for op in sg.operators if op.opcode == tflite.BuiltinOperator.CUSTOM
+        and op.custom_code == decode_insert.DECODE_CUSTOM_OP_NAME
+    ]
+    self.assertEqual(len(decode_ops), 1)
+    decode_op = decode_ops[0]
+
+    # DECODE has 2 inputs: encoded tensor and ancillary data
+    self.assertEqual(len(decode_op.inputs), 2)
+    # DECODE has 1 output
+    self.assertEqual(len(decode_op.outputs), 1)
+    # Output has same shape as original weights
+    self.assertEqual(decode_op.outputs[0].shape, (4, 4))
+
+  def test_ancillary_data_format(self):
+    """Ancillary data has correct DCM header format."""
+    # yapf: disable
+    weights = model_editor.Tensor(
+        shape=(4, 4),
+        dtype=tflite.TensorType.INT8,
+        data=np.array([[1, 2, 1, 2],
+                       [3, 4, 3, 4],
+                       [1, 2, 1, 2],
+                       [3, 4, 3, 4]], dtype=np.int8),
+        name="weights",
+        quantization=model_editor.Quantization(scales=0.5, zero_points=0),
+    )
+    # yapf: enable
+    input_t = model_editor.Tensor(shape=(1, 4),
+                                  dtype=tflite.TensorType.INT8,
+                                  name="input")
+    output_t = model_editor.Tensor(shape=(1, 4),
+                                   dtype=tflite.TensorType.INT8,
+                                   name="output")
+
+    model = model_editor.Model(subgraphs=[
+        model_editor.Subgraph(
+            tensors=[weights],
+            operators=[
+                model_editor.Operator(
+                    opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+                    inputs=[input_t, weights],
+                    outputs=[output_t],
+                )
+            ],
+        )
+    ])
+    fb = model.build()
+
+    specs = [
+        spec.Tensor(
+            subgraph=0,
+            tensor=0,
+            compression=[spec.LookUpTableCompression(index_bitwidth=4)])
+    ]
+
+    compressed_fb = compress.compress(fb, specs)
+    result = model_editor.read(compressed_fb)
+
+    # Find DECODE and get ancillary tensor
+    decode_op = next(op for op in result.subgraphs[0].operators
+                     if op.custom_code == decode_insert.DECODE_CUSTOM_OP_NAME)
+    ancillary = decode_op.inputs[1]
+
+    # Verify DCM header
+    dcm_bytes = bytes(ancillary.array[:16])
+    self.assertEqual(dcm_bytes[0], 0)  # decode_type = LUT
+    self.assertEqual(dcm_bytes[1], 1)  # DCM version
+    self.assertEqual(dcm_bytes[4], 1)  # LUT version
+    self.assertEqual(dcm_bytes[5] & 0x07, 4)  # bitwidth = 4
+    self.assertEqual(dcm_bytes[6], 4)  # stride = num unique values
+
+  def test_smaller_bitwidth_raises(self):
+    """Specifying LUT compression with too small a bitwidth fails."""
     specs = [
         spec.Tensor(
             subgraph=0,
@@ -300,11 +322,11 @@ class TestsCompression(unittest.TestCase):
             compression=[spec.LookUpTableCompression(index_bitwidth=3)],
         ),
     ]
-    self.assertRaises(compress.CompressionError,
+    self.assertRaises(compressor.CompressionError,
                       lambda: compress.compress(self.flatbuffer, specs))
 
-  def test_larger_bitwidth(self):
-    """Specifying LUT compression with too large a bitwidth succeeds"""
+  def test_larger_bitwidth_succeeds(self):
+    """Specifying LUT compression with too large a bitwidth succeeds."""
     specs = [
         spec.Tensor(
             subgraph=0,
@@ -312,10 +334,11 @@ class TestsCompression(unittest.TestCase):
             compression=[spec.LookUpTableCompression(index_bitwidth=5)],
         ),
     ]
+    # Should not raise
     _ = compress.compress(self.flatbuffer, specs)
 
-  def test_invalid_tensor_spec(self):
-    """Specifying a tensor that doesn't exist raises CompressonError."""
+  def test_invalid_tensor_spec_raises(self):
+    """Specifying a tensor that doesn't exist raises CompressionError."""
     specs = [
         spec.Tensor(
             subgraph=666,
@@ -323,7 +346,7 @@ class TestsCompression(unittest.TestCase):
             compression=[spec.LookUpTableCompression(index_bitwidth=4)],
         ),
     ]
-    self.assertRaises(compress.CompressionError,
+    self.assertRaises(compressor.CompressionError,
                       lambda: compress.compress(self.flatbuffer, specs))
 
     specs = [
@@ -333,11 +356,11 @@ class TestsCompression(unittest.TestCase):
             compression=[spec.LookUpTableCompression(index_bitwidth=4)],
         ),
     ]
-    self.assertRaises(compress.CompressionError,
+    self.assertRaises(compressor.CompressionError,
                       lambda: compress.compress(self.flatbuffer, specs))
 
-  def test_no_axis(self):
-    """Raises if no quantization from which to infer compression axis."""
+  def test_no_quantization_uses_per_tensor(self):
+    """Unquantized tensors compress with per-tensor compression (no error)."""
     specs = [
         spec.Tensor(
             subgraph=0,
@@ -345,222 +368,113 @@ class TestsCompression(unittest.TestCase):
             compression=[spec.LookUpTableCompression(index_bitwidth=4)],
         ),
     ]
-    self.assertRaises(compress.CompressionError,
+    # Should succeed - unquantized tensors use per-tensor compression
+    _ = compress.compress(self.flatbuffer, specs)
+
+  def test_huffman_compression_not_implemented(self):
+    """Huffman compression raises not implemented error."""
+    specs = [
+        spec.Tensor(
+            subgraph=0,
+            tensor=0,
+            compression=[spec.HuffmanCompression()],
+        ),
+    ]
+    self.assertRaises(compressor.CompressionError,
                       lambda: compress.compress(self.flatbuffer, specs))
 
+  def test_pruning_compression_not_implemented(self):
+    """Pruning compression raises not implemented error."""
+    specs = [
+        spec.Tensor(
+            subgraph=0,
+            tensor=0,
+            compression=[spec.PruningCompression()],
+        ),
+    ]
+    self.assertRaises(compressor.CompressionError,
+                      lambda: compress.compress(self.flatbuffer, specs))
 
-class TestLutCompressedArray(unittest.TestCase):
+  def test_compression_expansion_warning(self):
+    """Warning emitted when compression results in expansion."""
+    # Build a tiny model where compression overhead exceeds savings
+    tiny_weights = model_editor.Tensor(
+        shape=(2, ),
+        dtype=tflite.TensorType.INT8,
+        data=np.array([1, 2], dtype=np.int8),  # 2 bytes original
+        name="tiny",
+        quantization=model_editor.Quantization(scales=0.5, zero_points=0),
+    )
+    input_t = model_editor.Tensor(shape=(1, ),
+                                  dtype=tflite.TensorType.INT8,
+                                  name="input")
+    output_t = model_editor.Tensor(shape=(1, ),
+                                   dtype=tflite.TensorType.INT8,
+                                   name="output")
+    model = model_editor.Model(subgraphs=[
+        model_editor.Subgraph(
+            tensors=[tiny_weights],
+            operators=[
+                model_editor.Operator(
+                    opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+                    inputs=[input_t, tiny_weights],
+                    outputs=[output_t],
+                )
+            ],
+        )
+    ])
+    fb = model.build()
 
-  def test_bitwidth(self):
-    """Bitwidth is determined from index values."""
-    a = compress._LutCompressedArray()
-    a.indices = np.array((0, 1, 2, 3))
-    self.assertEqual(a.index_bitwidth, 2)
+    specs = [
+        spec.Tensor(
+            subgraph=0,
+            tensor=0,
+            compression=[spec.LookUpTableCompression(index_bitwidth=4)],
+        )
+    ]
 
-    a.indices = np.array((0, 1, 2, 3, 4))
-    self.assertEqual(a.index_bitwidth, 3)
+    with warnings.catch_warnings(record=True) as w:
+      warnings.simplefilter("always")
+      compress.compress(fb, specs)
 
-    a.indices = np.array((0, 1, 1, 2, 2))
-    self.assertEqual(a.index_bitwidth, 2)
-
-    a.indices = np.array((0, 0, 0, 0))
-    self.assertEqual(a.index_bitwidth, 1)
+      expansion_warnings = [x for x in w if "expansion" in str(x.message)]
+      self.assertEqual(len(expansion_warnings), 1)
+      self.assertIn("tiny", str(expansion_warnings[0].message))
 
 
-class TestCompressedModel(unittest.TestCase):
-  """Test the compressed model."""
+class TestPluginDispatch(unittest.TestCase):
+  """Tests for the plugin dispatch system."""
 
-  @classmethod
-  def setUpClass(cls):
-    super().setUpClass()
-    # Create a model
-    uncompressed_fb = _build_test_model()
-    cls.uncompressed = model_editor.read(uncompressed_fb)
+  def test_get_compressor_lut(self):
+    """LUT compression method dispatches to LutCompressor."""
+    method = spec.LookUpTableCompression(index_bitwidth=4)
+    compressor_instance = compress._get_compressor(method)
+    from tflite_micro.tensorflow.lite.micro.compression import lut
+    self.assertIsInstance(compressor_instance, lut.LutCompressor)
 
-    # Compress the model
-    compressed_fb = compress.compress(uncompressed_fb, TEST_COMPRESSION_SPEC)
-    cls.compressed = model_editor.read(compressed_fb)
+  def test_get_compressor_huffman(self):
+    """Huffman compression method dispatches to HuffmanCompressor."""
+    method = spec.HuffmanCompression()
+    compressor_instance = compress._get_compressor(method)
+    from tflite_micro.tensorflow.lite.micro.compression import huffman
+    self.assertIsInstance(compressor_instance, huffman.HuffmanCompressor)
 
-    # Extract the compression metadata
-    metadata_flatbuffer_bytes = cls.compressed.metadata[
-        compress.TFLITE_METADATA_KEY]
-    cls.metadata = schema.MetadataT.InitFromPackedBuf(
-        metadata_flatbuffer_bytes, 0)
+  def test_get_compressor_pruning(self):
+    """Pruning compression method dispatches to PruningCompressor."""
+    method = spec.PruningCompression()
+    compressor_instance = compress._get_compressor(method)
+    from tflite_micro.tensorflow.lite.micro.compression import pruning
+    self.assertIsInstance(compressor_instance, pruning.PruningCompressor)
 
-  def test_uncompressed_tensors(self):
-    """Tensors not in compression spec are not compressed.
-    """
-    # For all tensors in all subgraphs
-    for subgraph in self.uncompressed.subgraphs:
-      lut_tensors = self.metadata.subgraphs[subgraph.index].lutTensors
+  def test_get_compressor_unknown_raises(self):
+    """Unknown compression method raises CompressionError."""
 
-      for tensor in subgraph.tensors:
-        # Search through specs
-        match = lambda s: (s.subgraph == subgraph.index and s.tensor == tensor.
-                           index)
-        spec = next((s for s in TEST_COMPRESSION_SPEC if match(s)), None)
+    class UnknownCompression(spec.CompressionMethod):
+      pass
 
-        # If the tensor is not in specs
-        if spec is None:
-          # Search through compression metadata
-          match = lambda t: t.tensor == tensor.index
-          metadata = next((t for t in lut_tensors if match(t)), None)
-
-          # The tensor should not appear in compression metadata
-          self.assertIsNone(metadata)
-
-  def _get_compressed(
-      self, *, subgraph: int,
-      tensor: int) -> tuple[int, bitarray.bitarray, np.ndarray]:
-    """Helper: extracts the compressed tensor parts for a given spec.
-
-    Returns:
-      bitwidth
-      indices
-      values
-    """
-    subgraph_obj = self.compressed.subgraphs[subgraph]
-    tensor_obj = subgraph_obj.tensors[tensor]
-    lut_tensors = self.metadata.subgraphs[subgraph_obj.index].lutTensors
-    lut_tensor = next(t for t in lut_tensors if t.tensor == tensor_obj.index)
-    bitwidth = lut_tensor.indexBitwidth
-
-    indices = bitarray.bitarray(buffer=tensor_obj.buffer.data, endian="big")
-    n_indices = np.prod(tensor_obj.shape)
-    indices = indices[:n_indices * bitwidth]  # trim possible padding
-
-    value_buffer = self.compressed.buffers[lut_tensor.valueBuffer]
-    values = np.frombuffer(value_buffer.data, dtype=tensor_obj.numpy_dtype)
-
-    return bitwidth, indices, values
-
-  def _make_indices(self, s: str) -> bitarray.bitarray:
-    """Helper: makes indices from "01" strings for use as expected values."""
-    return bitarray.bitarray(s, endian="big")
-
-  def test_compressed_uint8(self):
-    bitwidth, indices, values = self._get_compressed(subgraph=0, tensor=0)
-    self.assertEqual(bitwidth, 4)
-
-    # yapf: disable
-    expected_indices = self._make_indices("""
-      0000 0001 0010 0011
-      0100 0101 0110 0111
-      1000 1001 1010 1011
-      1100 1101 1110 1111
-    """)
-    # yapf: enable
-    self.assertEqual(indices, expected_indices)
-
-    expected_values = np.array(range(16), dtype="<u1")
-    np.testing.assert_array_equal(values, expected_values)
-
-  def test_compressed_int8(self):
-    bitwidth, indices, values = self._get_compressed(subgraph=0, tensor=1)
-    self.assertEqual(bitwidth, 4)
-
-    # yapf: disable
-    expected_indices = self._make_indices("""
-      0000 0001 0010 0011
-      0100 0101 0110 0111
-      1000 1001 1010 1011
-      1100 1101 1110 1111
-    """)
-    # yapf: enable
-    self.assertEqual(indices, expected_indices)
-
-    expected_values = np.array(range(-16, 0), dtype="<i1")
-    np.testing.assert_array_equal(values, expected_values)
-
-  def test_compressed_int16(self):
-    bitwidth, indices, values = self._get_compressed(subgraph=0, tensor=2)
-    self.assertEqual(bitwidth, 4)
-
-    # yapf: disable
-    expected_indices = self._make_indices("""
-      0000 0001 0010 0011
-      0100 0101 0110 0111
-      1000 1001 1010 1011
-      1100 1101 1110 1111
-    """)
-    # yapf: enable
-    self.assertEqual(indices, expected_indices)
-
-    expected_values = np.array(range(-1616, -1600), dtype="<i2")
-    np.testing.assert_array_equal(values, expected_values)
-
-  def test_compressed_int32(self):
-    bitwidth, indices, values = self._get_compressed(subgraph=0, tensor=3)
-    self.assertEqual(bitwidth, 4)
-
-    # yapf: disable
-    expected_indices = self._make_indices("""
-      0000 0001 0010 0011
-      0100 0101 0110 0111
-      1000 1001 1010 1011
-      1100 1101 1110 1111
-    """)
-    # yapf: enable
-    self.assertEqual(indices, expected_indices)
-
-    expected_values = np.array(range(-160_016, -160_000), dtype="<i4")
-    np.testing.assert_array_equal(values, expected_values)
-
-  def test_axis_1(self):
-    """Compression along quanitzation_dimension == 1."""
-    bitwidth, indices, values = self._get_compressed(subgraph=0, tensor=5)
-    self.assertEqual(bitwidth, 2)
-
-    # yapf: disable
-    expected_indices = self._make_indices("""
-      00 00 00 00 00
-      01 01 01 01 01
-      10 10 10 10 10
-      11 11 11 11 11
-    """)
-    # yapf: enable
-    self.assertEqual(indices, expected_indices)
-
-    expected_values = np.array(range(1, 21), dtype=np.dtype("<i2"))
-    np.testing.assert_array_equal(values, expected_values)
-
-  def test_axis_0(self):
-    """Compression along quanitzation_dimension == 0."""
-    bitwidth, indices, values = self._get_compressed(subgraph=0, tensor=6)
-    self.assertEqual(bitwidth, 2)
-
-    # yapf: disable
-    expected_indices = self._make_indices("""
-      00 01 10 11
-      00 01 10 11
-      00 01 10 11
-      00 01 10 11
-      00 01 10 11
-    """)
-    # yapf: enable
-    self.assertEqual(indices, expected_indices)
-
-    expected_values = np.array(range(1, 21), dtype=np.dtype("<i2"))
-    np.testing.assert_array_equal(values, expected_values)
-
-  def test_per_tensor(self):
-    """Compression with one value table per tensor."""
-    bitwidth, indices, values = self._get_compressed(subgraph=0, tensor=7)
-    self.assertEqual(bitwidth, 2)
-
-    # yapf: disable
-    expected_indices = self._make_indices("""
-      00 01 10 11
-      00 01 10 11
-      00 01 10 11
-      00 01 10 11
-      00 01 10 11
-    """)
-    # yapf: enable
-    self.assertEqual(indices, expected_indices)
-
-    expected_values = np.array(range(1, 5), dtype=np.dtype("<i2"))
-    np.testing.assert_array_equal(values, expected_values)
+    method = UnknownCompression()
+    self.assertRaises(compressor.CompressionError,
+                      lambda: compress._get_compressor(method))
 
 
 if __name__ == "__main__":

--- a/tensorflow/lite/micro/compression/compress_test.py
+++ b/tensorflow/lite/micro/compression/compress_test.py
@@ -313,6 +313,11 @@ class TestCompression(unittest.TestCase):
     self.assertEqual(dcm_bytes[5] & 0x07, 4)  # bitwidth = 4
     self.assertEqual(dcm_bytes[6], 4)  # stride = num unique values
 
+  def test_empty_spec_raises(self):
+    """Empty compression spec is an error, not a silent no-op."""
+    self.assertRaisesRegex(compressor.CompressionError, "empty",
+                           lambda: compress.compress(self.flatbuffer, []))
+
   def test_smaller_bitwidth_raises(self):
     """Specifying LUT compression with too small a bitwidth fails."""
     specs = [

--- a/tensorflow/lite/micro/compression/compression_integration_test.py
+++ b/tensorflow/lite/micro/compression/compression_integration_test.py
@@ -1,0 +1,505 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration tests for compression with TFLM interpreter.
+
+These tests verify that compressed models produce correct inference results
+when run through the TFLM Python interpreter. Tests compress models and
+compare outputs against uncompressed originals.
+
+These tests only run when compression is enabled (--//:with_compression).
+"""
+
+import os
+import unittest
+import numpy as np
+
+from tflite_micro.python.tflite_micro import runtime
+from tflite_micro.tensorflow.lite.micro.compression import compress
+from tflite_micro.tensorflow.lite.micro.compression import decode_insert
+from tflite_micro.tensorflow.lite.micro.compression import model_editor
+from tflite_micro.tensorflow.lite.micro.compression import spec
+from tflite_micro.tensorflow.lite.python import schema_py_generated as tflite
+
+
+def _build_compressible_model(weight_shape=(4, 4),
+                              index_bitwidth=2,
+                              per_channel=False,
+                              unquantized=False):
+  """Build a model with clustered weights for compression testing.
+
+  Args:
+    weight_shape: Shape of the weight tensor as (rows, cols).
+    index_bitwidth: Bits per index. Determines unique value count (2^bitwidth).
+    per_channel: If True, use per-channel quantization (one scale per row).
+    unquantized: If True, omit quantization from weights.
+
+  Returns:
+    A TFLite flatbuffer (bytes) containing a simple FULLY_CONNECTED model
+    with weights that have limited unique values per channel.
+  """
+  rows, cols = weight_shape
+  unique_count = 2**index_bitwidth
+
+  # Create weights with limited unique values per channel
+  pattern = np.arange(1, unique_count + 1, dtype=np.int8)
+  weight_data = np.resize(pattern, (rows, cols))
+
+  if unquantized:
+    quantization = None
+  elif per_channel:
+    # Per-channel: one scale per output channel (row in FC weights)
+    scales = [0.5 + 0.1 * i for i in range(rows)]
+    zero_points = [0] * rows
+    quantization = model_editor.Quantization(
+        scales=scales,
+        zero_points=zero_points,
+        axis=0,
+    )
+  else:
+    quantization = model_editor.Quantization(scales=0.5, zero_points=0)
+
+  weights = model_editor.Tensor(
+      shape=weight_shape,
+      dtype=tflite.TensorType.INT8,
+      data=weight_data,
+      name="weights",
+      quantization=quantization,
+  )
+
+  input_t = model_editor.Tensor(
+      shape=(1, cols),
+      dtype=tflite.TensorType.INT8,
+      name="input",
+  )
+  output_t = model_editor.Tensor(
+      shape=(1, rows),
+      dtype=tflite.TensorType.INT8,
+      name="output",
+  )
+
+  model = model_editor.Model(subgraphs=[
+      model_editor.Subgraph(
+          tensors=[weights],
+          inputs=[input_t],
+          outputs=[output_t],
+          operators=[
+              model_editor.Operator(
+                  opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+                  inputs=[input_t, weights],
+                  outputs=[output_t],
+              )
+          ],
+      )
+  ])
+  return model.build()
+
+
+class LutCompressionTest(unittest.TestCase):
+  """Integration tests for LUT (lookup table) compression."""
+
+  def test_lut_compressed_model_matches_uncompressed(self):
+    """LUT-compressed model produces same outputs as uncompressed."""
+    flatbuffer = _build_compressible_model()
+
+    # Create compression spec for weights tensor (index 0 in tensors list)
+    specs = [
+        spec.Tensor(
+            subgraph=0,
+            tensor=0,
+            compression=[spec.LookUpTableCompression(index_bitwidth=2)],
+        )
+    ]
+
+    # Compress
+    compressed_fb = compress.compress(flatbuffer, specs)
+
+    # Run inference on both (convert bytearray to bytes for interpreter)
+    uncompressed_interp = runtime.Interpreter.from_bytes(bytes(flatbuffer))
+    compressed_interp = runtime.Interpreter.from_bytes(bytes(compressed_fb))
+
+    # Test with multiple random inputs
+    np.random.seed(42)
+    for _ in range(10):
+      test_input = np.random.randint(-128, 127, (1, 4), dtype=np.int8)
+
+      uncompressed_interp.set_input(test_input, 0)
+      uncompressed_interp.invoke()
+      expected = uncompressed_interp.get_output(0)
+
+      compressed_interp.set_input(test_input, 0)
+      compressed_interp.invoke()
+      actual = compressed_interp.get_output(0)
+
+      np.testing.assert_array_equal(expected, actual)
+
+  def test_lut_decode_operators_present(self):
+    """DECODE operators are inserted for LUT-compressed tensors."""
+    flatbuffer = _build_compressible_model()
+
+    specs = [
+        spec.Tensor(
+            subgraph=0,
+            tensor=0,
+            compression=[spec.LookUpTableCompression(index_bitwidth=2)],
+        )
+    ]
+
+    compressed_fb = compress.compress(flatbuffer, specs)
+    model = model_editor.read(compressed_fb)
+    sg = model.subgraphs[0]
+
+    # Find DECODE operators
+    decode_ops = [
+        op for op in sg.operators if op.opcode == tflite.BuiltinOperator.CUSTOM
+        and op.custom_code == decode_insert.DECODE_CUSTOM_OP_NAME
+    ]
+
+    self.assertEqual(len(decode_ops), 1)
+
+  def test_lut_compressed_model_is_smaller(self):
+    """LUT-compressed model is smaller than original.
+
+    Uses a large enough weight tensor (64x64 = 4096 bytes) that compression
+    savings outweigh the overhead from lookup tables and DECODE operators.
+    With 2-bit indices, 4096 bytes becomes 1024 bytes of indices.
+    """
+    flatbuffer = _build_compressible_model(weight_shape=(64, 64))
+
+    specs = [
+        spec.Tensor(
+            subgraph=0,
+            tensor=0,
+            compression=[spec.LookUpTableCompression(index_bitwidth=2)],
+        )
+    ]
+
+    compressed_fb = compress.compress(flatbuffer, specs)
+
+    original_size = len(flatbuffer)
+    compressed_size = len(compressed_fb)
+
+    self.assertLess(
+        compressed_size, original_size,
+        f"Compressed model ({compressed_size} bytes) should be smaller than "
+        f"original ({original_size} bytes)")
+
+  def test_lut_4bit_compression(self):
+    """4-bit LUT compression produces correct inference results."""
+    flatbuffer = _build_compressible_model(index_bitwidth=4)
+
+    specs = [
+        spec.Tensor(
+            subgraph=0,
+            tensor=0,
+            compression=[spec.LookUpTableCompression(index_bitwidth=4)],
+        )
+    ]
+
+    compressed_fb = compress.compress(flatbuffer, specs)
+
+    uncompressed_interp = runtime.Interpreter.from_bytes(bytes(flatbuffer))
+    compressed_interp = runtime.Interpreter.from_bytes(bytes(compressed_fb))
+
+    test_input = np.array([[1, 2, 3, 4]], dtype=np.int8)
+
+    uncompressed_interp.set_input(test_input, 0)
+    uncompressed_interp.invoke()
+    expected = uncompressed_interp.get_output(0)
+
+    compressed_interp.set_input(test_input, 0)
+    compressed_interp.invoke()
+    actual = compressed_interp.get_output(0)
+
+    np.testing.assert_array_equal(expected, actual)
+
+  def test_lut_per_channel_quantization(self):
+    """Per-channel quantized weights compress and decompress correctly."""
+    flatbuffer = _build_compressible_model(per_channel=True)
+
+    specs = [
+        spec.Tensor(
+            subgraph=0,
+            tensor=0,
+            compression=[spec.LookUpTableCompression(index_bitwidth=2)],
+        )
+    ]
+
+    compressed_fb = compress.compress(flatbuffer, specs)
+
+    uncompressed_interp = runtime.Interpreter.from_bytes(bytes(flatbuffer))
+    compressed_interp = runtime.Interpreter.from_bytes(bytes(compressed_fb))
+
+    test_input = np.array([[1, 2, 3, 4]], dtype=np.int8)
+
+    uncompressed_interp.set_input(test_input, 0)
+    uncompressed_interp.invoke()
+    expected = uncompressed_interp.get_output(0)
+
+    compressed_interp.set_input(test_input, 0)
+    compressed_interp.invoke()
+    actual = compressed_interp.get_output(0)
+
+    np.testing.assert_array_equal(expected, actual)
+
+  def test_lut_unquantized_weights(self):
+    """Unquantized weights compress and decompress correctly."""
+    flatbuffer = _build_compressible_model(unquantized=True)
+
+    specs = [
+        spec.Tensor(
+            subgraph=0,
+            tensor=0,
+            compression=[spec.LookUpTableCompression(index_bitwidth=2)],
+        )
+    ]
+
+    compressed_fb = compress.compress(flatbuffer, specs)
+
+    uncompressed_interp = runtime.Interpreter.from_bytes(bytes(flatbuffer))
+    compressed_interp = runtime.Interpreter.from_bytes(bytes(compressed_fb))
+
+    test_input = np.array([[1, 2, 3, 4]], dtype=np.int8)
+
+    uncompressed_interp.set_input(test_input, 0)
+    uncompressed_interp.invoke()
+    expected = uncompressed_interp.get_output(0)
+
+    compressed_interp.set_input(test_input, 0)
+    compressed_interp.invoke()
+    actual = compressed_interp.get_output(0)
+
+    np.testing.assert_array_equal(expected, actual)
+
+
+def _build_shared_weights_model():
+  """Build a model where one compressed tensor is shared between two operators.
+
+  Model structure:
+    input1 -> [FC1 with weights1] -> output1
+    input2 -> [FC2 with weights2] -> intermediate -> [FC3 with weights1] -> output2
+
+  weights1 is shared between FC1 and FC3. weights2 is used only by FC2, which
+  runs between the two consumers of weights1.
+  """
+  # 4 unique values per tensor for 2-bit LUT compression. Small values avoid
+  # saturation in chained layers. Different row sums produce varied outputs.
+  weights1_data = np.array([
+      [-1, 0, 0, 1],
+      [-1, 0, 1, 1],
+      [-1, 1, 1, 1],
+      [0, 1, 1, 1],
+  ],
+                           dtype=np.int8)
+  weights1 = model_editor.Tensor(
+      shape=(4, 4),
+      dtype=tflite.TensorType.INT8,
+      data=weights1_data,
+      name="weights1",
+      quantization=model_editor.Quantization(scales=1.0, zero_points=0),
+  )
+
+  weights2_data = np.array([
+      [1, 1, 1, 1],
+      [1, 1, 2, 2],
+      [1, 2, 2, 3],
+      [2, 2, 3, 3],
+  ],
+                           dtype=np.int8)
+  weights2 = model_editor.Tensor(
+      shape=(4, 4),
+      dtype=tflite.TensorType.INT8,
+      data=weights2_data,
+      name="weights2",
+      quantization=model_editor.Quantization(scales=1.0, zero_points=0),
+  )
+
+  # All tensors need matching quantization for FULLY_CONNECTED
+  quant = model_editor.Quantization(scales=1.0, zero_points=0)
+
+  input1 = model_editor.Tensor(
+      shape=(1, 4),
+      dtype=tflite.TensorType.INT8,
+      name="input1",
+      quantization=quant,
+  )
+  input2 = model_editor.Tensor(
+      shape=(1, 4),
+      dtype=tflite.TensorType.INT8,
+      name="input2",
+      quantization=quant,
+  )
+  output1 = model_editor.Tensor(
+      shape=(1, 4),
+      dtype=tflite.TensorType.INT8,
+      name="output1",
+      quantization=quant,
+  )
+  intermediate = model_editor.Tensor(
+      shape=(1, 4),
+      dtype=tflite.TensorType.INT8,
+      name="intermediate",
+      quantization=quant,
+  )
+  output2 = model_editor.Tensor(
+      shape=(1, 4),
+      dtype=tflite.TensorType.INT8,
+      name="output2",
+      quantization=quant,
+  )
+
+  model = model_editor.Model(subgraphs=[
+      model_editor.Subgraph(
+          tensors=[weights1, weights2],
+          inputs=[input1, input2],
+          outputs=[output1, output2],
+          operators=[
+              # FC1: uses weights1
+              model_editor.Operator(
+                  opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+                  inputs=[input1, weights1],
+                  outputs=[output1],
+              ),
+              # FC2: uses weights2 (runs between FC1 and FC3)
+              model_editor.Operator(
+                  opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+                  inputs=[input2, weights2],
+                  outputs=[intermediate],
+              ),
+              # FC3: uses weights1 (second consumer, after DECODE(weights2))
+              model_editor.Operator(
+                  opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+                  inputs=[intermediate, weights1],
+                  outputs=[output2],
+              ),
+          ],
+      )
+  ])
+  return model.build()
+
+
+class AltDecompressionMemoryTest(unittest.TestCase):
+  """Tests for alternate decompression memory with shared compressed tensors.
+
+  These tests verify correct behavior when compressed tensors are shared
+  between multiple operators and alternate decompression memory is enabled.
+  """
+
+  def test_shared_compressed_tensor_with_alt_memory(self):
+    """Verify correct results when a shared compressed tensor is used with alt
+    decompression memory.
+
+    This test uses a graph where a compressed tensor (weights1) is consumed by
+    two operators (FC1 and FC3), with an intervening DECODE of a different
+    compressed tensor (weights2) between them.
+
+    The interpreter's alternate decompression memory has a limitation: each
+    DECODE's Prepare resets the allocation offset to zero. This means all
+    DECODE outputs are allocated at the same address, so they overwrite each
+    other. A DECODE output can only be used until the next DECODE runs.
+
+    To work around this limitation, the DECODE insertion code inserts a
+    separate DECODE immediately before each consumer of a compressed tensor,
+    rather than sharing one DECODE output among all consumers.
+    """
+    flatbuffer = _build_shared_weights_model()
+
+    specs = [
+        spec.Tensor(
+            subgraph=0,
+            tensor=0,  # weights1
+            compression=[spec.LookUpTableCompression(index_bitwidth=2)],
+        ),
+        spec.Tensor(
+            subgraph=0,
+            tensor=1,  # weights2
+            compression=[spec.LookUpTableCompression(index_bitwidth=2)],
+        ),
+    ]
+
+    compressed_fb = compress.compress(flatbuffer, specs)
+
+    # Run without alt decompression memory (baseline)
+    interp_no_alt = runtime.Interpreter.from_bytes(bytes(compressed_fb))
+
+    # Run with alt decompression memory
+    interp_with_alt = runtime.Interpreter.from_bytes(
+        bytes(compressed_fb),
+        alt_decompression_memory_size=256,
+    )
+
+    test_input1 = np.array([[1, 1, 1, 1]], dtype=np.int8)
+    test_input2 = np.array([[1, 1, 1, 1]], dtype=np.int8)
+
+    interp_no_alt.set_input(test_input1, 0)
+    interp_no_alt.set_input(test_input2, 1)
+    interp_no_alt.invoke()
+    expected1 = interp_no_alt.get_output(0)
+    expected2 = interp_no_alt.get_output(1)
+
+    interp_with_alt.set_input(test_input1, 0)
+    interp_with_alt.set_input(test_input2, 1)
+    interp_with_alt.invoke()
+    actual1 = interp_with_alt.get_output(0)
+    actual2 = interp_with_alt.get_output(1)
+
+    np.testing.assert_array_equal(
+        expected1, actual1, "Output 1 mismatch with alt decompression memory")
+    np.testing.assert_array_equal(
+        expected2, actual2, "Output 2 mismatch with alt decompression memory")
+
+
+class HuffmanCompressionTest(unittest.TestCase):
+  """Integration tests for Huffman compression."""
+
+  @unittest.skip("Huffman compression not yet implemented")
+  def test_huffman_compressed_model_matches_uncompressed(self):
+    """Huffman-compressed model produces same outputs as uncompressed."""
+    pass
+
+  @unittest.skip("Huffman compression not yet implemented")
+  def test_huffman_decode_operators_present(self):
+    """DECODE operators are inserted for Huffman-compressed tensors."""
+    pass
+
+  @unittest.skip("Huffman compression not yet implemented")
+  def test_huffman_compressed_model_is_smaller(self):
+    """Huffman-compressed model is smaller than original."""
+    pass
+
+
+class PruningCompressionTest(unittest.TestCase):
+  """Integration tests for pruning compression."""
+
+  @unittest.skip("Pruning compression not yet implemented")
+  def test_pruning_compressed_model_matches_uncompressed(self):
+    """Pruning-compressed model produces same outputs as uncompressed."""
+    pass
+
+  @unittest.skip("Pruning compression not yet implemented")
+  def test_pruning_decode_operators_present(self):
+    """DECODE operators are inserted for pruning-compressed tensors."""
+    pass
+
+  @unittest.skip("Pruning compression not yet implemented")
+  def test_pruning_compressed_model_is_smaller(self):
+    """Pruning-compressed model is smaller than original."""
+    pass
+
+
+if __name__ == "__main__":
+  # Suppress TF C++ info/debug logs (0=DEBUG, 1=INFO, 2=WARNING, 3=ERROR)
+  os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
+  # Disable oneDNN to avoid non-deterministic floating point results
+  os.environ["TF_ENABLE_ONEDNN_OPTS"] = "0"
+  unittest.main()

--- a/tensorflow/lite/micro/compression/decode_insert.py
+++ b/tensorflow/lite/micro/compression/decode_insert.py
@@ -263,22 +263,27 @@ def insert_decode_operators(
       )
       return op, outputs
 
+    # Positions of the original operators, computed once so the sort and
+    # insertions below avoid a linear scan per lookup.
+    op_position = {op: i for i, op in enumerate(subgraph.operators)}
+
     # Group compressed tensors by consumer, then handle consumers in
-    # reverse position order so insertions don't invalidate positions
+    # reverse position order so insertions don't invalidate positions:
+    # each insertion falls after every consumer still to be processed,
+    # leaving the recorded positions valid.
     by_consumer: dict[model_editor.Operator, list[_CompressedTensorInfo]] = {}
     for info in tensor_infos:
       for consumer in info.consumers:
         by_consumer.setdefault(consumer, []).append(info)
 
     for consumer in sorted(by_consumer,
-                           key=subgraph.operators.index,
+                           key=lambda op: op_position[op],
                            reverse=True):
       infos = by_consumer[consumer]
       decode_op, decoded_tensors = build_decode(infos)
 
       # Insert DECODE immediately before this consumer
-      insert_pos = subgraph.operators.index(consumer)
-      subgraph.operators.insert(insert_pos, decode_op)
+      subgraph.operators.insert(op_position[consumer], decode_op)
 
       # Rewire only this consumer to use the decoded outputs
       for info, decoded in zip(infos, decoded_tensors):

--- a/tensorflow/lite/micro/compression/decode_insert.py
+++ b/tensorflow/lite/micro/compression/decode_insert.py
@@ -1,0 +1,267 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""DECODE operator insertion into TFLite model graphs.
+
+This module inserts DECODE operators into a compressed model. DECODE operators
+transform encoded tensors (with their paired ancillary data tensors) into
+tensors ready for use by downstream operators.
+
+The DECODE operator is registered as a custom operator named "TFLM_DECODE".
+Each DECODE output requires two inputs: the encoded tensor and the ancillary
+data tensor (containing the DCM header and decode-type-specific data).
+"""
+
+import warnings
+from collections import defaultdict
+from dataclasses import dataclass
+
+from tflite_micro.tensorflow.lite.micro.compression import compressor
+from tflite_micro.tensorflow.lite.micro.compression import model_editor
+from tflite_micro.tensorflow.lite.python import schema_py_generated as tflite
+
+# Custom operator name for DECODE
+DECODE_CUSTOM_OP_NAME = "TFLM_DECODE"
+
+
+@dataclass
+class _CompressedTensorInfo:
+  """Information about a compressed tensor for DECODE insertion."""
+  subgraph_idx: int
+  tensor_idx: int
+  tensor: model_editor.Tensor
+  encoded_data: bytes
+  ancillary_data: bytes
+  consumers: list[model_editor.Operator]
+
+
+def _find_tensor_consumers(
+    subgraph: model_editor.Subgraph,
+    tensor: model_editor.Tensor,
+) -> list[model_editor.Operator]:
+  """Find all operators in subgraph that use tensor as an input."""
+  consumers = []
+  for op in subgraph.operators:
+    if tensor in op.inputs:
+      consumers.append(op)
+  return consumers
+
+
+def _create_ancillary_tensor(
+    ancillary_data: bytes,
+    original_tensor: model_editor.Tensor,
+) -> model_editor.Tensor:
+  """Create an ancillary data tensor for a compressed tensor.
+
+  Args:
+    ancillary_data: The complete ancillary data (DCM + type-specific data).
+    original_tensor: The original tensor being decoded, for naming.
+
+  Returns:
+    A new Tensor containing the ancillary data.
+  """
+  name = None
+  if original_tensor.name:
+    name = f"{original_tensor.name}_ancillary"
+
+  return model_editor.Tensor(
+      shape=(len(ancillary_data), ),
+      dtype=tflite.TensorType.UINT8,
+      data=ancillary_data,
+      name=name,
+  )
+
+
+def _create_output_tensor(
+    original_tensor: model_editor.Tensor, ) -> model_editor.Tensor:
+  """Create the output tensor for a DECODE operator.
+
+  The output tensor has the same shape, dtype, and quantization as the
+  original tensor would have when decoded. It has no data---the DECODE
+  operator produces its values at runtime.
+
+  Args:
+    original_tensor: The original tensor being decoded.
+
+  Returns:
+    A new Tensor for the DECODE output.
+  """
+  name = None
+  if original_tensor.name:
+    name = f"{original_tensor.name}_decoded"
+
+  return model_editor.Tensor(
+      shape=original_tensor.shape,
+      dtype=original_tensor.dtype,
+      quantization=original_tensor.quantization,
+      name=name,
+  )
+
+
+def _rewire_consumers(
+    consumers: list[model_editor.Operator],
+    old_tensor: model_editor.Tensor,
+    new_tensor: model_editor.Tensor,
+) -> None:
+  """Replace old_tensor with new_tensor in all consumer inputs."""
+  for consumer in consumers:
+    consumer.inputs = [
+        new_tensor if t is old_tensor else t for t in consumer.inputs
+    ]
+
+
+def _rewrite_encoded_tensor(
+    tensor: model_editor.Tensor,
+    encoded_data: bytes,
+) -> None:
+  """Rewrite a compressed tensor to hold encoded data.
+
+  The original tensor contained uncompressed values with quantization. After
+  compression, it holds packed indices (or other encoded form) as raw bytes.
+  This function updates the tensor in place to reflect its new role.
+
+  Args:
+    tensor: The tensor to rewrite.
+    encoded_data: The compressed/encoded data bytes.
+  """
+  tensor.shape = (len(encoded_data), )
+  tensor.dtype = tflite.TensorType.UINT8
+  tensor.quantization = None
+  tensor.buffer.data = encoded_data
+
+
+def insert_decode_operators(
+    model: model_editor.Model,
+    compression_results: dict[tuple[int, int], compressor.CompressionResult],
+) -> None:
+  """Insert DECODE operators for all compressed tensors.
+
+  This function modifies the model in-place, inserting DECODE operators
+  before any operator that uses a compressed tensor as input.
+
+  A separate DECODE is inserted before each consumer, rather than sharing one
+  DECODE output among all consumers. This is required because the interpreter's
+  alternate decompression memory resets its allocation offset for each DECODE's
+  Prepare, causing all DECODE outputs to be allocated at the same address. If
+  two consumers share one DECODE and another DECODE runs between them, the
+  intervening DECODE overwrites the shared output, corrupting data for the
+  second consumer.
+
+  For each consumer of a compressed tensor:
+  1. Create an ancillary data tensor containing DCM + type-specific data
+  2. Create an output tensor with the same shape/dtype as the decoded tensor
+  3. Insert a DECODE operator immediately before the consumer
+  4. Rewire the consumer to use the DECODE output
+
+  Args:
+    model: The model to modify in-place.
+    compression_results: Map from (subgraph_idx, tensor_idx) to the
+                         CompressionResult containing ancillary_data.
+  """
+  # Group compressed tensors by subgraph
+  by_subgraph: dict[int, list[_CompressedTensorInfo]] = defaultdict(list)
+
+  for (sg_idx, tensor_idx), result in compression_results.items():
+    subgraph = model.subgraphs[sg_idx]
+    tensor = subgraph.tensors[tensor_idx]
+    consumers = _find_tensor_consumers(subgraph, tensor)
+
+    if not consumers:
+      # Check if tensor is a subgraph output
+      is_output = tensor in subgraph.outputs
+      if is_output:
+        # TODO: Handle compressed tensors that are subgraph outputs.
+        # This occurs in multi-subgraph models using IF/WHILE where a
+        # compressed tensor flows out of a subgraph.
+        raise NotImplementedError(
+            f"Compressed tensor {tensor.name!r} (subgraph {sg_idx}, "
+            f"tensor {tensor_idx}) is a subgraph output with no consumers. "
+            "Compressed subgraph outputs are not yet supported.")
+      else:
+        warnings.warn(
+            f"Compressed tensor {tensor.name!r} (subgraph {sg_idx}, "
+            f"tensor {tensor_idx}) has no consumers and is not a subgraph "
+            "output. No DECODE operator will be inserted.",
+            stacklevel=2)
+      continue
+
+    info = _CompressedTensorInfo(
+        subgraph_idx=sg_idx,
+        tensor_idx=tensor_idx,
+        tensor=tensor,
+        encoded_data=result.encoded_data,
+        ancillary_data=result.ancillary_data,
+        consumers=consumers,
+    )
+    by_subgraph[sg_idx].append(info)
+
+  # Process each subgraph
+  for sg_idx, tensor_infos in by_subgraph.items():
+    subgraph = model.subgraphs[sg_idx]
+
+    # Collect all (consumer, tensor_info) pairs and sort by consumer position
+    # in reverse order so insertions don't invalidate positions
+    consumer_pairs = []
+    for info in tensor_infos:
+      for consumer in info.consumers:
+        consumer_pairs.append((consumer, info))
+
+    consumer_pairs.sort(
+        key=lambda pair: subgraph.operators.index(pair[0]),
+        reverse=True,
+    )
+
+    # Cache ancillary tensors by original tensor to avoid duplicates. Each
+    # DECODE needs its own output tensor, but ancillary data is identical for
+    # all DECODEs of the same compressed tensor.
+    ancillary_cache: dict[model_editor.Tensor, model_editor.Tensor] = {}
+
+    # Track tensors to rewrite after all output tensors are created, since
+    # _create_output_tensor reads the original tensor's shape/dtype/quantization.
+    tensors_to_rewrite: dict[model_editor.Tensor, bytes] = {}
+
+    for consumer, info in consumer_pairs:
+      # Reuse or create ancillary data tensor
+      if info.tensor not in ancillary_cache:
+        ancillary_tensor = _create_ancillary_tensor(
+            info.ancillary_data,
+            info.tensor,
+        )
+        subgraph.tensors.append(ancillary_tensor)
+        ancillary_cache[info.tensor] = ancillary_tensor
+        tensors_to_rewrite[info.tensor] = info.encoded_data
+      else:
+        ancillary_tensor = ancillary_cache[info.tensor]
+
+      # Create output tensor (one per DECODE)
+      output_tensor = _create_output_tensor(info.tensor)
+      subgraph.tensors.append(output_tensor)
+
+      # Create DECODE operator
+      decode_op = model_editor.Operator(
+          opcode=tflite.BuiltinOperator.CUSTOM,
+          custom_code=DECODE_CUSTOM_OP_NAME,
+          inputs=[info.tensor, ancillary_tensor],
+          outputs=[output_tensor],
+      )
+
+      # Insert DECODE immediately before this consumer
+      insert_pos = subgraph.operators.index(consumer)
+      subgraph.operators.insert(insert_pos, decode_op)
+
+      # Rewire only this consumer to use the decoded output
+      _rewire_consumers([consumer], info.tensor, output_tensor)
+
+    # Rewrite encoded tensors after all output tensors are created
+    for tensor, encoded_data in tensors_to_rewrite.items():
+      _rewrite_encoded_tensor(tensor, encoded_data)

--- a/tensorflow/lite/micro/compression/decode_insert.py
+++ b/tensorflow/lite/micro/compression/decode_insert.py
@@ -46,18 +46,6 @@ class _CompressedTensorInfo:
   is_output: bool
 
 
-def _find_tensor_consumers(
-    subgraph: model_editor.Subgraph,
-    tensor: model_editor.Tensor,
-) -> list[model_editor.Operator]:
-  """Find all operators in subgraph that use tensor as an input."""
-  consumers = []
-  for op in subgraph.operators:
-    if tensor in op.inputs:
-      consumers.append(op)
-  return consumers
-
-
 def _create_ancillary_tensor(
     ancillary_data: bytes,
     original_tensor: model_editor.Tensor,
@@ -240,7 +228,7 @@ def insert_decode_operators(
   for (sg_idx, tensor_idx), result in compression_results.items():
     subgraph = model.subgraphs[sg_idx]
     tensor = subgraph.tensors[tensor_idx]
-    consumers = _find_tensor_consumers(subgraph, tensor)
+    consumers = subgraph.consumers_of(tensor)
     is_output = tensor in subgraph.outputs
 
     if not consumers and not is_output:

--- a/tensorflow/lite/micro/compression/decode_insert.py
+++ b/tensorflow/lite/micro/compression/decode_insert.py
@@ -195,34 +195,26 @@ def insert_decode_operators(
   before any operator that uses a compressed tensor as input, and appending
   a DECODE for compressed tensors listed as subgraph outputs.
 
-  A separate DECODE is inserted before each consumer, rather than sharing one
-  DECODE output among all consumers. This is required because the interpreter's
-  alternate decompression memory resets its allocation offset for each DECODE's
-  Prepare, causing all DECODE outputs to be allocated at the same address. If
-  two consumers share one DECODE and another DECODE runs between them, the
-  intervening DECODE overwrites the shared output, corrupting data for the
-  second consumer.
-
-  Conversely, all compressed tensors read by one consumer are decoded by a
-  single DECODE. Values a consumer needs simultaneously must coexist, and
-  only the outputs of a single DECODE do: the allocation reset happens
-  between DECODE operators, not between the outputs of one.
+  A separate DECODE is inserted before each consumer, and one DECODE
+  decodes all the compressed tensors its consumer reads. DECODE outputs
+  are tensors with a lifetime limited to the very next operator in the
+  subgraph, so sharing one DECODE among multiple consumers would
+  violate the lifetime rule. The DECODE operator trades increased
+  latency for decreased memory usage.
 
   For each consumer of compressed tensors:
   1. Create an ancillary data tensor (DCM + type-specific data) for each
      compressed tensor the consumer reads
-  2. Create an output tensor with the same shape/dtype as each decoded
-     tensor
+  2. Create an output tensor as a copy of each original tensor
   3. Insert one DECODE operator immediately before the consumer
   4. Rewire the consumer to use the DECODE outputs
 
-  A subgraph's output list is treated as one more consumer, one which reads
-  its tensors only after the last operator runs: a calling operator (IF,
-  WHILE) copies subgraph outputs when the subgraph returns, and the client
-  reads model outputs after invocation. Compressed tensors in the output
-  list are therefore decoded by a single DECODE appended after the last
-  operator, and their output list entries are rewired to the decoded
-  values, which no other DECODE runs late enough to overwrite.
+  A subgraph's output list is treated as one more consumer, one which
+  reads its tensors only after the last operator runs: a calling
+  operator (IF, WHILE) copies subgraph outputs when the subgraph
+  returns. Compressed tensors in the output list are therefore decoded
+  by a single DECODE appended after the last operator, and their output
+  list entries are rewired to the decoded values.
 
   Distinct tensors can share one buffer, in the same or different
   subgraphs, where the converter deduplicated identical constants.

--- a/tensorflow/lite/micro/compression/decode_insert.py
+++ b/tensorflow/lite/micro/compression/decode_insert.py
@@ -43,6 +43,7 @@ class _CompressedTensorInfo:
   encoded_data: bytes
   ancillary_data: bytes
   consumers: list[model_editor.Operator]
+  is_output: bool
 
 
 def _find_tensor_consumers(
@@ -146,8 +147,9 @@ def insert_decode_operators(
 ) -> None:
   """Insert DECODE operators for all compressed tensors.
 
-  This function modifies the model in-place, inserting DECODE operators
-  before any operator that uses a compressed tensor as input.
+  This function modifies the model in-place, inserting a DECODE operator
+  before any operator that uses a compressed tensor as input, and appending
+  a DECODE for compressed tensors listed as subgraph outputs.
 
   A separate DECODE is inserted before each consumer, rather than sharing one
   DECODE output among all consumers. This is required because the interpreter's
@@ -163,6 +165,14 @@ def insert_decode_operators(
   3. Insert a DECODE operator immediately before the consumer
   4. Rewire the consumer to use the DECODE output
 
+  A subgraph's output list is treated as one more consumer, one which reads
+  its tensors only after the last operator runs: a calling operator (IF,
+  WHILE) copies subgraph outputs when the subgraph returns, and the client
+  reads model outputs after invocation. A DECODE for each compressed tensor
+  in the output list is therefore appended after the last operator, and the
+  output list entry is rewired to the decoded value, which no consumer's
+  DECODE runs late enough to overwrite.
+
   Args:
     model: The model to modify in-place.
     compression_results: Map from (subgraph_idx, tensor_idx) to the
@@ -175,24 +185,14 @@ def insert_decode_operators(
     subgraph = model.subgraphs[sg_idx]
     tensor = subgraph.tensors[tensor_idx]
     consumers = _find_tensor_consumers(subgraph, tensor)
+    is_output = tensor in subgraph.outputs
 
-    if not consumers:
-      # Check if tensor is a subgraph output
-      is_output = tensor in subgraph.outputs
-      if is_output:
-        # TODO: Handle compressed tensors that are subgraph outputs.
-        # This occurs in multi-subgraph models using IF/WHILE where a
-        # compressed tensor flows out of a subgraph.
-        raise NotImplementedError(
-            f"Compressed tensor {tensor.name!r} (subgraph {sg_idx}, "
-            f"tensor {tensor_idx}) is a subgraph output with no consumers. "
-            "Compressed subgraph outputs are not yet supported.")
-      else:
-        warnings.warn(
-            f"Compressed tensor {tensor.name!r} (subgraph {sg_idx}, "
-            f"tensor {tensor_idx}) has no consumers and is not a subgraph "
-            "output. No DECODE operator will be inserted.",
-            stacklevel=2)
+    if not consumers and not is_output:
+      warnings.warn(
+          f"Compressed tensor {tensor.name!r} (subgraph {sg_idx}, "
+          f"tensor {tensor_idx}) has no consumers and is not a subgraph "
+          "output. No DECODE operator will be inserted.",
+          stacklevel=2)
       continue
 
     info = _CompressedTensorInfo(
@@ -202,12 +202,35 @@ def insert_decode_operators(
         encoded_data=result.encoded_data,
         ancillary_data=result.ancillary_data,
         consumers=consumers,
+        is_output=is_output,
     )
     by_subgraph[sg_idx].append(info)
 
   # Process each subgraph
   for sg_idx, tensor_infos in by_subgraph.items():
     subgraph = model.subgraphs[sg_idx]
+
+    # Cache ancillary tensors by original tensor to avoid duplicates. Each
+    # DECODE needs its own output tensor, but ancillary data is identical for
+    # all DECODEs of the same compressed tensor.
+    ancillary_cache: dict[model_editor.Tensor, model_editor.Tensor] = {}
+
+    # Track tensors to rewrite after all output tensors are created, since
+    # _create_output_tensor reads the original tensor's shape/dtype/quantization.
+    tensors_to_rewrite: dict[model_editor.Tensor, bytes] = {}
+
+    def ancillary_for(info: _CompressedTensorInfo) -> model_editor.Tensor:
+      """Reuse or create the ancillary tensor for info's tensor.
+
+      First use also schedules the original tensor's rewrite to encoded data.
+      """
+      ancillary = ancillary_cache.get(info.tensor)
+      if ancillary is None:
+        ancillary = _create_ancillary_tensor(info.ancillary_data, info.tensor)
+        subgraph.tensors.append(ancillary)
+        ancillary_cache[info.tensor] = ancillary
+        tensors_to_rewrite[info.tensor] = info.encoded_data
+      return ancillary
 
     # Collect all (consumer, tensor_info) pairs and sort by consumer position
     # in reverse order so insertions don't invalidate positions
@@ -221,27 +244,8 @@ def insert_decode_operators(
         reverse=True,
     )
 
-    # Cache ancillary tensors by original tensor to avoid duplicates. Each
-    # DECODE needs its own output tensor, but ancillary data is identical for
-    # all DECODEs of the same compressed tensor.
-    ancillary_cache: dict[model_editor.Tensor, model_editor.Tensor] = {}
-
-    # Track tensors to rewrite after all output tensors are created, since
-    # _create_output_tensor reads the original tensor's shape/dtype/quantization.
-    tensors_to_rewrite: dict[model_editor.Tensor, bytes] = {}
-
     for consumer, info in consumer_pairs:
-      # Reuse or create ancillary data tensor
-      if info.tensor not in ancillary_cache:
-        ancillary_tensor = _create_ancillary_tensor(
-            info.ancillary_data,
-            info.tensor,
-        )
-        subgraph.tensors.append(ancillary_tensor)
-        ancillary_cache[info.tensor] = ancillary_tensor
-        tensors_to_rewrite[info.tensor] = info.encoded_data
-      else:
-        ancillary_tensor = ancillary_cache[info.tensor]
+      ancillary_tensor = ancillary_for(info)
 
       # Create output tensor (one per DECODE)
       output_tensor = _create_output_tensor(info.tensor)
@@ -261,6 +265,26 @@ def insert_decode_operators(
 
       # Rewire only this consumer to use the decoded output
       _rewire_consumers([consumer], info.tensor, output_tensor)
+
+    # Decode compressed tensors read from the subgraph's output list. The
+    # output list reads its tensors only after the last operator runs, so
+    # its DECODEs are appended at the end (see docstring).
+    for info in tensor_infos:
+      if not info.is_output:
+        continue
+      ancillary_tensor = ancillary_for(info)
+      output_tensor = _create_output_tensor(info.tensor)
+      subgraph.tensors.append(output_tensor)
+      subgraph.operators.append(
+          model_editor.Operator(
+              opcode=tflite.BuiltinOperator.CUSTOM,
+              custom_code=DECODE_CUSTOM_OP_NAME,
+              inputs=[info.tensor, ancillary_tensor],
+              outputs=[output_tensor],
+          ))
+      subgraph.outputs = [
+          output_tensor if t is info.tensor else t for t in subgraph.outputs
+      ]
 
     # Rewrite encoded tensors after all output tensors are created
     for tensor, encoded_data in tensors_to_rewrite.items():

--- a/tensorflow/lite/micro/compression/decode_insert.py
+++ b/tensorflow/lite/micro/compression/decode_insert.py
@@ -126,7 +126,9 @@ def _rewrite_encoded_tensor(
 
   The original tensor contained uncompressed values with quantization. After
   compression, it holds packed indices (or other encoded form) as raw bytes.
-  This function updates the tensor in place to reflect its new role.
+  The tensor receives a fresh Buffer, leaving the original buffer and any
+  tensors aliasing it untouched; identical encodings converge again in the
+  final deduplication pass.
 
   Args:
     tensor: The tensor to rewrite.
@@ -135,7 +137,52 @@ def _rewrite_encoded_tensor(
   tensor.shape = (len(encoded_data), )
   tensor.dtype = tflite.TensorType.UINT8
   tensor.quantization = None
-  tensor.buffer.data = encoded_data
+  tensor.buffer = model_editor.Buffer(data=encoded_data)
+
+
+def _drop_partially_covered_buffers(
+    model: model_editor.Model,
+    compression_results: dict[tuple[int, int], compressor.CompressionResult],
+) -> dict[tuple[int, int], compressor.CompressionResult]:
+  """Drop compressed tensors whose buffer an uncompressed tensor shares.
+
+  The uncompressed tensor keeps the original data in the model, so
+  compressing any alias of its buffer adds encoded data, ancillary
+  data, and DECODE latency without reducing model size. Warn and
+  return the results without the dropped entries.
+
+  Args:
+    model: The model the results apply to.
+    compression_results: Map from (subgraph_idx, tensor_idx) to
+                         CompressionResult.
+
+  Returns:
+    compression_results, minus entries for partially covered buffers.
+  """
+  coordinates = {
+      id(model.subgraphs[s].tensors[t]): (s, t)
+      for (s, t) in compression_results
+  }
+  by_buffer: dict[int, list[model_editor.Tensor]] = defaultdict(list)
+  for tensor in model_editor.iter_tensors(model):
+    if tensor.buffer is not None:
+      by_buffer[id(tensor.buffer)].append(tensor)
+
+  results = dict(compression_results)
+  for aliases in by_buffer.values():
+    covered = [t for t in aliases if id(t) in coordinates]
+    if covered and len(covered) < len(aliases):
+      uncovered = [t for t in aliases if id(t) not in coordinates]
+      warnings.warn(
+          f"Not compressing tensor(s) "
+          f"{[t.name for t in covered]}: sharing a buffer with "
+          f"uncompressed tensor(s) {[t.name for t in uncovered]}, whose "
+          "data stays in the model, so compression cannot reduce model "
+          "size.",
+          stacklevel=3)
+      for tensor in covered:
+        del results[coordinates[id(tensor)]]
+  return results
 
 
 def insert_decode_operators(
@@ -177,11 +224,24 @@ def insert_decode_operators(
   operator, and their output list entries are rewired to the decoded
   values, which no other DECODE runs late enough to overwrite.
 
+  Distinct tensors can share one buffer, in the same or different
+  subgraphs, where the converter deduplicated identical constants.
+  Compressed tensors sharing a buffer with uncompressed tensors are
+  skipped with a warning: the uncompressed data must stay in the model,
+  so compressing an alias cannot reduce model size. Otherwise each
+  rewritten tensor and ancillary tensor receives its own buffer, and a
+  final deduplication pass merges byte-identical buffers and prunes
+  unreferenced ones, preserving the converter's sharing wherever
+  compression results allow and dissolving it where they diverge.
+
   Args:
     model: The model to modify in-place.
     compression_results: Map from (subgraph_idx, tensor_idx) to the
                          CompressionResult containing ancillary_data.
   """
+  compression_results = _drop_partially_covered_buffers(
+      model, compression_results)
+
   # Group compressed tensors by subgraph
   by_subgraph: dict[int, list[_CompressedTensorInfo]] = defaultdict(list)
 
@@ -214,26 +274,22 @@ def insert_decode_operators(
   for sg_idx, tensor_infos in by_subgraph.items():
     subgraph = model.subgraphs[sg_idx]
 
-    # Cache ancillary tensors by original tensor to avoid duplicates. Each
-    # DECODE needs its own output tensor, but ancillary data is identical for
-    # all DECODEs of the same compressed tensor.
-    ancillary_cache: dict[model_editor.Tensor, model_editor.Tensor] = {}
+    # Cache ancillary tensors by content to avoid duplicates within
+    # this subgraph. Each DECODE needs its own output tensor, but
+    # DECODEs whose ancillary data coincides can read one tensor.
+    ancillary_cache: dict[bytes, model_editor.Tensor] = {}
 
     # Track tensors to rewrite after all output tensors are created, since
     # _create_output_tensor reads the original tensor's shape/dtype/quantization.
     tensors_to_rewrite: dict[model_editor.Tensor, bytes] = {}
 
     def ancillary_for(info: _CompressedTensorInfo) -> model_editor.Tensor:
-      """Reuse or create the ancillary tensor for info's tensor.
-
-      First use also schedules the original tensor's rewrite to encoded data.
-      """
-      ancillary = ancillary_cache.get(info.tensor)
+      """Reuse or create the ancillary tensor for info's ancillary data."""
+      ancillary = ancillary_cache.get(info.ancillary_data)
       if ancillary is None:
         ancillary = _create_ancillary_tensor(info.ancillary_data, info.tensor)
         subgraph.tensors.append(ancillary)
-        ancillary_cache[info.tensor] = ancillary
-        tensors_to_rewrite[info.tensor] = info.encoded_data
+        ancillary_cache[info.ancillary_data] = ancillary
       return ancillary
 
     def build_decode(
@@ -248,6 +304,7 @@ def insert_decode_operators(
       outputs = []
       for info in infos:
         ancillary_tensor = ancillary_for(info)
+        tensors_to_rewrite[info.tensor] = info.encoded_data
         decoded = _create_output_tensor(info.tensor)
         subgraph.tensors.append(decoded)
         inputs.extend([info.tensor, ancillary_tensor])
@@ -300,3 +357,9 @@ def insert_decode_operators(
     # Rewrite encoded tensors after all output tensors are created
     for tensor, encoded_data in tensors_to_rewrite.items():
       _rewrite_encoded_tensor(tensor, encoded_data)
+
+  # Every rewrite and ancillary tensor made a fresh buffer; converge
+  # byte-identical ones and drop those left unreferenced, preserving
+  # the sharing the converter created wherever results allow.
+  model_editor.dedupe_buffers(model)
+  model_editor.prune_buffers(model)

--- a/tensorflow/lite/micro/compression/decode_insert.py
+++ b/tensorflow/lite/micro/compression/decode_insert.py
@@ -87,9 +87,9 @@ def _create_output_tensor(
     original_tensor: model_editor.Tensor, ) -> model_editor.Tensor:
   """Create the output tensor for a DECODE operator.
 
-  The output tensor has the same shape, dtype, and quantization as the
-  original tensor would have when decoded. It has no data---the DECODE
-  operator produces its values at runtime.
+  The output tensor is a copy of the original tensor, differing only in
+  name and in having no data: the DECODE operator produces the values
+  at runtime.
 
   Args:
     original_tensor: The original tensor being decoded.
@@ -101,12 +101,9 @@ def _create_output_tensor(
   if original_tensor.name:
     name = f"{original_tensor.name}_decoded"
 
-  return model_editor.Tensor(
-      shape=original_tensor.shape,
-      dtype=original_tensor.dtype,
-      quantization=original_tensor.quantization,
-      name=name,
-  )
+  tensor = original_tensor.copy(name=name)
+  tensor.buffer = None
+  return tensor
 
 
 def _rewire_consumers(

--- a/tensorflow/lite/micro/compression/decode_insert.py
+++ b/tensorflow/lite/micro/compression/decode_insert.py
@@ -159,19 +159,26 @@ def insert_decode_operators(
   intervening DECODE overwrites the shared output, corrupting data for the
   second consumer.
 
-  For each consumer of a compressed tensor:
-  1. Create an ancillary data tensor containing DCM + type-specific data
-  2. Create an output tensor with the same shape/dtype as the decoded tensor
-  3. Insert a DECODE operator immediately before the consumer
-  4. Rewire the consumer to use the DECODE output
+  Conversely, all compressed tensors read by one consumer are decoded by a
+  single DECODE. Values a consumer needs simultaneously must coexist, and
+  only the outputs of a single DECODE do: the allocation reset happens
+  between DECODE operators, not between the outputs of one.
+
+  For each consumer of compressed tensors:
+  1. Create an ancillary data tensor (DCM + type-specific data) for each
+     compressed tensor the consumer reads
+  2. Create an output tensor with the same shape/dtype as each decoded
+     tensor
+  3. Insert one DECODE operator immediately before the consumer
+  4. Rewire the consumer to use the DECODE outputs
 
   A subgraph's output list is treated as one more consumer, one which reads
   its tensors only after the last operator runs: a calling operator (IF,
   WHILE) copies subgraph outputs when the subgraph returns, and the client
-  reads model outputs after invocation. A DECODE for each compressed tensor
-  in the output list is therefore appended after the last operator, and the
-  output list entry is rewired to the decoded value, which no consumer's
-  DECODE runs late enough to overwrite.
+  reads model outputs after invocation. Compressed tensors in the output
+  list are therefore decoded by a single DECODE appended after the last
+  operator, and their output list entries are rewired to the decoded
+  values, which no other DECODE runs late enough to overwrite.
 
   Args:
     model: The model to modify in-place.
@@ -232,59 +239,61 @@ def insert_decode_operators(
         tensors_to_rewrite[info.tensor] = info.encoded_data
       return ancillary
 
-    # Collect all (consumer, tensor_info) pairs and sort by consumer position
-    # in reverse order so insertions don't invalidate positions
-    consumer_pairs = []
-    for info in tensor_infos:
-      for consumer in info.consumers:
-        consumer_pairs.append((consumer, info))
+    def build_decode(
+        infos: list[_CompressedTensorInfo]
+    ) -> tuple[model_editor.Operator, list[model_editor.Tensor]]:
+      """Build one DECODE operator decoding all of infos' tensors.
 
-    consumer_pairs.sort(
-        key=lambda pair: subgraph.operators.index(pair[0]),
-        reverse=True,
-    )
-
-    for consumer, info in consumer_pairs:
-      ancillary_tensor = ancillary_for(info)
-
-      # Create output tensor (one per DECODE)
-      output_tensor = _create_output_tensor(info.tensor)
-      subgraph.tensors.append(output_tensor)
-
-      # Create DECODE operator
-      decode_op = model_editor.Operator(
+      Returns the operator and its decoded output tensors, parallel to
+      infos.
+      """
+      inputs = []
+      outputs = []
+      for info in infos:
+        ancillary_tensor = ancillary_for(info)
+        decoded = _create_output_tensor(info.tensor)
+        subgraph.tensors.append(decoded)
+        inputs.extend([info.tensor, ancillary_tensor])
+        outputs.append(decoded)
+      op = model_editor.Operator(
           opcode=tflite.BuiltinOperator.CUSTOM,
           custom_code=DECODE_CUSTOM_OP_NAME,
-          inputs=[info.tensor, ancillary_tensor],
-          outputs=[output_tensor],
+          inputs=inputs,
+          outputs=outputs,
       )
+      return op, outputs
+
+    # Group compressed tensors by consumer, then handle consumers in
+    # reverse position order so insertions don't invalidate positions
+    by_consumer: dict[model_editor.Operator, list[_CompressedTensorInfo]] = {}
+    for info in tensor_infos:
+      for consumer in info.consumers:
+        by_consumer.setdefault(consumer, []).append(info)
+
+    for consumer in sorted(by_consumer,
+                           key=subgraph.operators.index,
+                           reverse=True):
+      infos = by_consumer[consumer]
+      decode_op, decoded_tensors = build_decode(infos)
 
       # Insert DECODE immediately before this consumer
       insert_pos = subgraph.operators.index(consumer)
       subgraph.operators.insert(insert_pos, decode_op)
 
-      # Rewire only this consumer to use the decoded output
-      _rewire_consumers([consumer], info.tensor, output_tensor)
+      # Rewire only this consumer to use the decoded outputs
+      for info, decoded in zip(infos, decoded_tensors):
+        _rewire_consumers([consumer], info.tensor, decoded)
 
-    # Decode compressed tensors read from the subgraph's output list. The
-    # output list reads its tensors only after the last operator runs, so
-    # its DECODEs are appended at the end (see docstring).
-    for info in tensor_infos:
-      if not info.is_output:
-        continue
-      ancillary_tensor = ancillary_for(info)
-      output_tensor = _create_output_tensor(info.tensor)
-      subgraph.tensors.append(output_tensor)
-      subgraph.operators.append(
-          model_editor.Operator(
-              opcode=tflite.BuiltinOperator.CUSTOM,
-              custom_code=DECODE_CUSTOM_OP_NAME,
-              inputs=[info.tensor, ancillary_tensor],
-              outputs=[output_tensor],
-          ))
-      subgraph.outputs = [
-          output_tensor if t is info.tensor else t for t in subgraph.outputs
-      ]
+    # Decode compressed tensors read from the subgraph's output list, all
+    # with one DECODE appended after the last operator (see docstring).
+    output_infos = [info for info in tensor_infos if info.is_output]
+    if output_infos:
+      decode_op, decoded_tensors = build_decode(output_infos)
+      subgraph.operators.append(decode_op)
+      for info, decoded in zip(output_infos, decoded_tensors):
+        subgraph.outputs = [
+            decoded if t is info.tensor else t for t in subgraph.outputs
+        ]
 
     # Rewrite encoded tensors after all output tensors are created
     for tensor, encoded_data in tensors_to_rewrite.items():

--- a/tensorflow/lite/micro/compression/decode_insert_runtime_test.py
+++ b/tensorflow/lite/micro/compression/decode_insert_runtime_test.py
@@ -1,0 +1,272 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Runtime tests for DECODE outputs crossing subgraph boundaries.
+
+These tests build multi-subgraph models containing WHILE, compress selected
+constant tensors with the LUT compressor, insert DECODE operators with
+decode_insert, and run the result on the TFLM interpreter. They exercise the
+two directions in which a DECODE output can cross a subgraph boundary:
+
+1. Out of a callee subgraph: a compressed constant listed in a callee
+   subgraph's output list, decoded by an appended DECODE, and copied to the
+   calling operator's outputs by the runtime.
+
+2. Into a callee subgraph: a compressed constant consumed by a WHILE
+   operator, whose decoded value the runtime copies into the cond and body
+   subgraph inputs. WHILE reads its inputs again after invoking the cond
+   subgraph, so a DECODE inside cond that shares alternate decompression
+   memory with the caller's DECODE can overwrite the value between reads.
+
+Each case runs both with the arena memory planner and with alternate
+decompression memory, since the two allocate DECODE outputs differently:
+the planner gives each output a distinct, lifetime-managed buffer, while
+alternate memory restarts at the same base address for every DECODE.
+"""
+
+import numpy as np
+import unittest
+
+from tflite_micro.python.tflite_micro import runtime
+from tflite_micro.tensorflow.lite.micro.compression import decode_insert
+from tflite_micro.tensorflow.lite.micro.compression import lut
+from tflite_micro.tensorflow.lite.micro.compression import model_editor
+from tflite_micro.tensorflow.lite.micro.compression import spec
+from tflite_micro.tensorflow.lite.python import schema_py_generated as tflite
+
+_SHAPE = (4, )
+_ARENA_SIZE = 65536
+_ALT_MEMORY_SIZE = 1024
+
+
+def _while_operator(cond_subgraph_idx, body_subgraph_idx, inputs, outputs):
+  """Create a WHILE operator with its subgraph indices.
+
+  model_editor has no public API for builtin options, so set them on the
+  backing OperatorT directly.
+  """
+  op = model_editor.Operator(
+      opcode=tflite.BuiltinOperator.WHILE,
+      inputs=inputs,
+      outputs=outputs,
+  )
+  options = tflite.WhileOptionsT()
+  options.condSubgraphIndex = cond_subgraph_idx
+  options.bodySubgraphIndex = body_subgraph_idx
+  op._fb.builtinOptionsType = tflite.BuiltinOptions.WhileOptions
+  op._fb.builtinOptions = options
+  return op
+
+
+def _float_tensor(name, data=None):
+  return model_editor.Tensor(
+      shape=_SHAPE,
+      dtype=tflite.TensorType.FLOAT32,
+      data=data,
+      name=name,
+  )
+
+
+def _cond_subgraph(threshold_values):
+  """Build a cond subgraph computing LESS(input, threshold_constant)."""
+  c_in = _float_tensor("cond_in")
+  threshold = _float_tensor("threshold",
+                            np.array(threshold_values, dtype=np.float32))
+  cond_out = model_editor.Tensor(
+      shape=_SHAPE,
+      dtype=tflite.TensorType.BOOL,
+      name="cond_out",
+  )
+  return model_editor.Subgraph(
+      tensors=[threshold],
+      operators=[
+          model_editor.Operator(
+              opcode=tflite.BuiltinOperator.LESS,
+              inputs=[c_in, threshold],
+              outputs=[cond_out],
+          )
+      ],
+      inputs=[c_in],
+      outputs=[cond_out],
+  )
+
+
+def _build_body_output_model():
+  """Model whose WHILE body subgraph outputs a constant.
+
+  Subgraph 0 feeds input x into WHILE. The cond subgraph tests x < 5. The
+  body subgraph has no operators; its sole output is the constant K =
+  [7, 8, 7, 8]. With x = 0: cond is true, the body replaces x with K, cond
+  is then false (7 < 5), and the model outputs K.
+
+  The tensor at coordinates (2, 0) is K, the body output constant. The
+  tensor at (1, 0) is the cond threshold.
+  """
+  x0 = _float_tensor("x0")
+  y0 = _float_tensor("y0")
+  sg0 = model_editor.Subgraph(
+      operators=[_while_operator(1, 2, [x0], [y0])],
+      inputs=[x0],
+      outputs=[y0],
+  )
+
+  sg1 = _cond_subgraph([5.0, 6.0, 5.0, 6.0])
+
+  b_in = _float_tensor("body_in")
+  k = _float_tensor("k", np.array([7.0, 8.0, 7.0, 8.0], dtype=np.float32))
+  sg2 = model_editor.Subgraph(
+      tensors=[k],
+      operators=[],
+      inputs=[b_in],
+      outputs=[k],
+  )
+
+  model = model_editor.Model(subgraphs=[sg0, sg1, sg2])
+  model._fb.version = 3
+  return model
+
+
+def _build_while_input_model():
+  """Model whose WHILE operator consumes a constant as its input.
+
+  Subgraph 0 feeds the constant INIT = [10, 20, 10, 20] into WHILE as the
+  initial loop value. The cond subgraph tests x < 3, false from the start,
+  so the loop body (ADD 1) never runs and the model outputs INIT unchanged.
+
+  The tensor at coordinates (0, 0) is INIT, the WHILE input constant. The
+  tensor at (1, 0) is the cond threshold.
+  """
+  init = _float_tensor("init",
+                       np.array([10.0, 20.0, 10.0, 20.0], dtype=np.float32))
+  y0 = _float_tensor("y0")
+  sg0 = model_editor.Subgraph(
+      tensors=[init],
+      operators=[_while_operator(1, 2, [init], [y0])],
+      inputs=[],
+      outputs=[y0],
+  )
+
+  sg1 = _cond_subgraph([3.0, 4.0, 3.0, 4.0])
+
+  b_in = _float_tensor("body_in")
+  one = _float_tensor("one", np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float32))
+  b_out = _float_tensor("body_out")
+  sg2 = model_editor.Subgraph(
+      operators=[
+          model_editor.Operator(
+              opcode=tflite.BuiltinOperator.ADD,
+              inputs=[b_in, one],
+              outputs=[b_out],
+          )
+      ],
+      inputs=[b_in],
+      outputs=[b_out],
+  )
+
+  model = model_editor.Model(subgraphs=[sg0, sg1, sg2])
+  model._fb.version = 3
+  return model
+
+
+def _compress_and_insert(model, coordinates):
+  """LUT-compress the tensors at (subgraph, tensor) coordinates and insert
+  DECODE operators for them."""
+  compressor_plugin = lut.LutCompressor()
+  method = spec.LookUpTableCompression(index_bitwidth=1)
+  results = {}
+  for sg_idx, tensor_idx in coordinates:
+    tensor = model.subgraphs[sg_idx].tensors[tensor_idx]
+    results[(sg_idx, tensor_idx)] = compressor_plugin.compress(tensor, method)
+  decode_insert.insert_decode_operators(model, results)
+
+
+def _run(model, x0=None, alt_memory_size=0):
+  """Build the model and run one inference on the TFLM interpreter."""
+  flatbuffer = bytes(model.build())
+  interpreter = runtime.Interpreter.from_bytes(
+      flatbuffer,
+      custom_op_registerers=[],
+      arena_size=_ARENA_SIZE,
+      alt_decompression_memory_size=alt_memory_size,
+  )
+  if x0 is not None:
+    interpreter.set_input(x0, 0)
+  interpreter.invoke()
+  return interpreter.get_output(0)
+
+
+class TestDecodeOutOfSubgraph(unittest.TestCase):
+  """A DECODE output listed as a callee subgraph output.
+
+  The calling operator copies callee outputs to its own outputs immediately
+  after the callee returns, before any other subgraph (and thus any other
+  DECODE) runs, so the decoded values must survive in both memory modes.
+  """
+
+  X0 = np.zeros(_SHAPE, dtype=np.float32)
+  EXPECTED = np.array([7.0, 8.0, 7.0, 8.0], dtype=np.float32)
+
+  def test_arena(self):
+    model = _build_body_output_model()
+    _compress_and_insert(model, [(2, 0)])
+    output = _run(model, x0=self.X0)
+    np.testing.assert_array_equal(output, self.EXPECTED)
+
+  def test_alt_memory(self):
+    model = _build_body_output_model()
+    _compress_and_insert(model, [(2, 0)])
+    output = _run(model, x0=self.X0, alt_memory_size=_ALT_MEMORY_SIZE)
+    np.testing.assert_array_equal(output, self.EXPECTED)
+
+  def test_alt_memory_with_decode_in_cond(self):
+    # The cond threshold is also compressed, so a DECODE inside cond
+    # overwrites the shared alternate memory after the body's decoded
+    # output was copied out. The copy must have preserved the values.
+    model = _build_body_output_model()
+    _compress_and_insert(model, [(2, 0), (1, 0)])
+    output = _run(model, x0=self.X0, alt_memory_size=_ALT_MEMORY_SIZE)
+    np.testing.assert_array_equal(output, self.EXPECTED)
+
+
+class TestDecodeIntoSubgraph(unittest.TestCase):
+  """A DECODE output consumed as a WHILE operator input.
+
+  WHILE reads its inputs once to seed the cond subgraph, then again after
+  cond returns, to seed the body subgraph and initialize its outputs. A
+  DECODE inside cond that shares alternate decompression memory with the
+  DECODE feeding WHILE overwrites the value between those reads.
+  """
+
+  EXPECTED = np.array([10.0, 20.0, 10.0, 20.0], dtype=np.float32)
+
+  def test_arena(self):
+    model = _build_while_input_model()
+    _compress_and_insert(model, [(0, 0), (1, 0)])
+    output = _run(model)
+    np.testing.assert_array_equal(output, self.EXPECTED)
+
+  def test_alt_memory(self):
+    model = _build_while_input_model()
+    _compress_and_insert(model, [(0, 0)])
+    output = _run(model, alt_memory_size=_ALT_MEMORY_SIZE)
+    np.testing.assert_array_equal(output, self.EXPECTED)
+
+  def test_alt_memory_with_decode_in_cond(self):
+    model = _build_while_input_model()
+    _compress_and_insert(model, [(0, 0), (1, 0)])
+    output = _run(model, alt_memory_size=_ALT_MEMORY_SIZE)
+    np.testing.assert_array_equal(output, self.EXPECTED)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tensorflow/lite/micro/compression/decode_insert_test.py
+++ b/tensorflow/lite/micro/compression/decode_insert_test.py
@@ -359,6 +359,8 @@ class TestDecodeInsertion(unittest.TestCase):
     self.assertIs(fc_op2.inputs[1], decode_op2.outputs[0])
     # The two DECODEs should have different outputs
     self.assertIsNot(decode_op1.outputs[0], decode_op2.outputs[0])
+    # The two DECODEs should share the same encoded tensor
+    self.assertIs(decode_op1.inputs[0], decode_op2.inputs[0])
     # The two DECODEs should share the same ancillary tensor
     self.assertIs(decode_op1.inputs[1], decode_op2.inputs[1])
 
@@ -509,6 +511,9 @@ class TestDecodeInsertion(unittest.TestCase):
     self.assertIs(fc_op.inputs[1], consumer_decode.outputs[0])
     self.assertIs(sg.outputs[1], output_decode.outputs[0])
     self.assertIsNot(consumer_decode.outputs[0], output_decode.outputs[0])
+
+    # Both DECODEs share the encoded tensor
+    self.assertIs(consumer_decode.inputs[0], output_decode.inputs[0])
 
     # Both DECODEs share the ancillary tensor
     self.assertIs(consumer_decode.inputs[1], output_decode.inputs[1])

--- a/tensorflow/lite/micro/compression/decode_insert_test.py
+++ b/tensorflow/lite/micro/compression/decode_insert_test.py
@@ -158,6 +158,49 @@ def _build_output_constant_model():
   return model
 
 
+def _build_shared_buffer_model(subgraph_count):
+  """Build subgraphs whose weights tensors all share one Buffer.
+
+  Models the TfLite converter's deduplication of identical constants:
+  distinct tensors, in the same or different subgraphs, backed by a
+  single Buffer.
+  """
+  shared = model_editor.Buffer(data=np.ones((4, 4), dtype=np.int8).tobytes())
+  subgraphs = []
+  for i in range(subgraph_count):
+    weights = model_editor.Tensor(
+        shape=(4, 4),
+        dtype=tflite.TensorType.INT8,
+        buffer=shared,
+        name=f"weights{i}",
+        quantization=model_editor.Quantization(scales=0.5, zero_points=0),
+    )
+    input_t = model_editor.Tensor(
+        shape=(1, 4),
+        dtype=tflite.TensorType.INT8,
+        name=f"input{i}",
+    )
+    output_t = model_editor.Tensor(
+        shape=(1, 4),
+        dtype=tflite.TensorType.INT8,
+        name=f"output{i}",
+    )
+    subgraphs.append(
+        model_editor.Subgraph(
+            tensors=[weights],
+            operators=[
+                model_editor.Operator(
+                    opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+                    inputs=[input_t, weights],
+                    outputs=[output_t],
+                )
+            ],
+            inputs=[input_t],
+            outputs=[output_t],
+        ))
+  return model_editor.Model(subgraphs=subgraphs)
+
+
 def _make_dummy_ancillary_data() -> bytes:
   """Create dummy ancillary data for testing."""
   dcm = decode.DecodeCommonMetadata(
@@ -315,6 +358,90 @@ class TestDecodeInsertion(unittest.TestCase):
     self.assertIsNot(decode_op1.outputs[0], decode_op2.outputs[0])
     # The two DECODEs should share the same ancillary tensor
     self.assertIs(decode_op1.inputs[1], decode_op2.inputs[1])
+
+  def test_ancillary_buffer_shared_across_subgraphs(self):
+    """Tensors sharing a Buffer get ancillary tensors sharing a Buffer."""
+    model = _build_shared_buffer_model(subgraph_count=2)
+
+    ancillary_data = _make_dummy_ancillary_data()
+    compression_results = {
+        (0, 0):
+        compressor.CompressionResult(
+            encoded_data=b'\x00\x00',
+            ancillary_data=ancillary_data,
+        ),
+        (1, 0):
+        compressor.CompressionResult(
+            encoded_data=b'\x00\x00',
+            ancillary_data=ancillary_data,
+        ),
+    }
+
+    decode_insert.insert_decode_operators(model, compression_results)
+
+    decode0 = model.subgraphs[0].operators[0]
+    decode1 = model.subgraphs[1].operators[0]
+    encoded0, ancillary0 = decode0.inputs[0], decode0.inputs[1]
+    encoded1, ancillary1 = decode1.inputs[0], decode1.inputs[1]
+
+    # Tensors are per-subgraph; buffers are shared across subgraphs
+    self.assertIsNot(ancillary0, ancillary1)
+    self.assertIs(ancillary0.buffer, ancillary1.buffer)
+
+    # The encoded tensors keep sharing their original Buffer
+    self.assertIsNot(encoded0, encoded1)
+    self.assertIs(encoded0.buffer, encoded1.buffer)
+
+  def test_ancillary_tensor_shared_within_subgraph(self):
+    """Aliased tensors in one subgraph share one ancillary tensor."""
+    model = _build_shared_buffer_model(subgraph_count=1)
+    sg = model.subgraphs[0]
+
+    # Add a second tensor aliasing the weights buffer, with its own
+    # consumer; copy() shares the buffer, as converter dedup does
+    weights = sg.tensor_by_name("weights0")
+    alias = weights.copy(name="alias")
+    sg.tensors.append(alias)
+    input_t = model_editor.Tensor(
+        shape=(1, 4),
+        dtype=tflite.TensorType.INT8,
+        name="input_alias",
+    )
+    output_t = model_editor.Tensor(
+        shape=(1, 4),
+        dtype=tflite.TensorType.INT8,
+        name="output_alias",
+    )
+    sg.operators.append(
+        model_editor.Operator(
+            opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+            inputs=[input_t, alias],
+            outputs=[output_t],
+        ))
+
+    ancillary_data = _make_dummy_ancillary_data()
+    compression_results = {
+        (0, 0):
+        compressor.CompressionResult(
+            encoded_data=b'\x00\x00',
+            ancillary_data=ancillary_data,
+        ),
+        (0, 1):
+        compressor.CompressionResult(
+            encoded_data=b'\x00\x00',
+            ancillary_data=ancillary_data,
+        ),
+    }
+
+    decode_insert.insert_decode_operators(model, compression_results)
+
+    # One DECODE before each consumer, sharing one ancillary tensor
+    decodes = [
+        op for op in sg.operators
+        if op.custom_code == decode_insert.DECODE_CUSTOM_OP_NAME
+    ]
+    self.assertEqual(len(decodes), 2)
+    self.assertIs(decodes[0].inputs[1], decodes[1].inputs[1])
 
   def test_output_constant_gets_decode(self):
     """Compressed tensor in subgraph outputs gets DECODE appended last."""

--- a/tensorflow/lite/micro/compression/decode_insert_test.py
+++ b/tensorflow/lite/micro/compression/decode_insert_test.py
@@ -60,6 +60,8 @@ def _build_simple_fc_model():
                   outputs=[output_t],
               )
           ],
+          inputs=[input_t],
+          outputs=[output_t],
       )
   ])
   return model
@@ -110,6 +112,8 @@ def _build_shared_weights_model():
                   outputs=[output2],
               ),
           ],
+          inputs=[input1, input2],
+          outputs=[output1, output2],
       )
   ])
   return model
@@ -152,6 +156,7 @@ def _build_output_constant_model():
                   outputs=[output_t],
               )
           ],
+          inputs=[input_t],
           outputs=[output_t, table],
       )
   ])

--- a/tensorflow/lite/micro/compression/decode_insert_test.py
+++ b/tensorflow/lite/micro/compression/decode_insert_test.py
@@ -223,13 +223,15 @@ class TestDecodeInsertion(unittest.TestCase):
     self.assertEqual(decode_op.inputs[1].dtype, tflite.TensorType.UINT8)
 
   def test_decode_output_structure(self):
-    """DECODE operator output has correct shape and dtype."""
+    """DECODE operator output is a data-less copy of the original."""
     model = _build_simple_fc_model()
     weights_tensor = model.subgraphs[0].tensor_by_name("weights")
 
-    # Save original properties before rewrite
-    original_shape = weights_tensor.shape
-    original_dtype = weights_tensor.dtype
+    # Snapshot what the output must look like before insertion rewrites
+    # the original into the encoded tensor: a copy of the original,
+    # renamed, with no data.
+    expected = weights_tensor.copy(name="weights_decoded")
+    expected.buffer = None
 
     compression_results = {
         (0, 0):
@@ -241,12 +243,16 @@ class TestDecodeInsertion(unittest.TestCase):
 
     decode_insert.insert_decode_operators(model, compression_results)
 
-    decode_op = model.subgraphs[0].operators[0]
-    output = decode_op.outputs[0]
+    output = model.subgraphs[0].operators[0].outputs[0]
 
-    # Output matches original (pre-rewrite) tensor shape and dtype
-    self.assertEqual(output.shape, original_shape)
-    self.assertEqual(output.dtype, original_dtype)
+    # Output has no data; DECODE produces the values at runtime
+    self.assertIsNone(output.buffer)
+    self.assertIsNone(output.array)
+
+    # Output matches the expected copy in every field, present or
+    # future; the new name and cleared buffer are part of the
+    # expectation, not exclusions
+    self.assertTrue(output.equal(expected))
 
   def test_consumer_rewired_to_decode_output(self):
     """FC operator input rewired to use DECODE output."""

--- a/tensorflow/lite/micro/compression/decode_insert_test.py
+++ b/tensorflow/lite/micro/compression/decode_insert_test.py
@@ -670,8 +670,8 @@ class TestDecodeInsertion(unittest.TestCase):
     self.assertEqual(bytes(ancillary_tensor.array), ancillary_data)
 
     # Verify DCM header
-    dcm_bytes = ancillary_tensor.array[:16]
-    self.assertEqual(dcm_bytes[0], 0)  # decode_type = LUT
+    dcm_bytes = bytes(ancillary_tensor.array[:16])
+    self.assertEqual(dcm_bytes[0], decode.DecodeType.LUT)
     self.assertEqual(dcm_bytes[1], 1)  # DCM version
 
   def test_no_consumers_no_decode(self):

--- a/tensorflow/lite/micro/compression/decode_insert_test.py
+++ b/tensorflow/lite/micro/compression/decode_insert_test.py
@@ -434,6 +434,63 @@ class TestDecodeInsertion(unittest.TestCase):
     self.assertEqual(len(decodes), 2)
     self.assertIs(decodes[0].inputs[1], decodes[1].inputs[1])
 
+  def test_divergent_aliases_dissolve_sharing(self):
+    """Aliases whose compression results differ get separate buffers."""
+    model = _build_shared_buffer_model(subgraph_count=2)
+
+    compression_results = {
+        (0, 0):
+        _make_dummy_compression_result(bitwidth=1, value_table=b'\x01'),
+        (1, 0):
+        _make_dummy_compression_result(bitwidth=2,
+                                       value_table=b'\x01\x02\x03\x04'),
+    }
+
+    decode_insert.insert_decode_operators(model, compression_results)
+
+    decode0 = model.subgraphs[0].operators[0]
+    decode1 = model.subgraphs[1].operators[0]
+    encoded0, ancillary0 = decode0.inputs[0], decode0.inputs[1]
+    encoded1, ancillary1 = decode1.inputs[0], decode1.inputs[1]
+
+    # Each alias carries its own results; nothing is shared
+    self.assertIsNot(encoded0.buffer, encoded1.buffer)
+    self.assertIsNot(ancillary0.buffer, ancillary1.buffer)
+    self.assertEqual(encoded0.buffer.data,
+                     compression_results[(0, 0)].encoded_data)
+    self.assertEqual(encoded1.buffer.data,
+                     compression_results[(1, 0)].encoded_data)
+    self.assertEqual(ancillary0.buffer.data,
+                     compression_results[(0, 0)].ancillary_data)
+    self.assertEqual(ancillary1.buffer.data,
+                     compression_results[(1, 0)].ancillary_data)
+
+  def test_partially_covered_buffer_not_compressed(self):
+    """A tensor sharing its buffer with an uncompressed tensor is
+    skipped."""
+    model = _build_shared_buffer_model(subgraph_count=2)
+    weights0 = model.subgraphs[0].tensor_by_name("weights0")
+    original_buffer = weights0.buffer
+    original_data = original_buffer.data
+
+    # Compress only one of the two tensors sharing the buffer
+    compression_results = {(0, 0): _make_dummy_compression_result()}
+
+    with warnings.catch_warnings(record=True) as caught:
+      warnings.simplefilter("always")
+      decode_insert.insert_decode_operators(model, compression_results)
+
+      self.assertEqual(len(caught), 1)
+      self.assertIn("weights0", str(caught[0].message))
+      self.assertIn("weights1", str(caught[0].message))
+
+    # No DECODE inserted anywhere; the tensor is untouched
+    for subgraph in model.subgraphs:
+      self.assertEqual(len(subgraph.operators), 1)
+    self.assertIs(weights0.buffer, original_buffer)
+    self.assertEqual(weights0.buffer.data, original_data)
+    self.assertEqual(weights0.dtype, tflite.TensorType.INT8)
+
   def test_output_constant_gets_decode(self):
     """Compressed tensor in subgraph outputs gets DECODE appended last."""
     model = _build_output_constant_model()

--- a/tensorflow/lite/micro/compression/decode_insert_test.py
+++ b/tensorflow/lite/micro/compression/decode_insert_test.py
@@ -20,10 +20,10 @@ that decodes to the models' tensor contents. Insertion treats both as
 opaque structure, so the tests do not depend on their validity.
 """
 
+import unittest
 import warnings
 
 import numpy as np
-import unittest
 
 from tflite_micro.tensorflow.lite.micro.compression import compressor
 from tflite_micro.tensorflow.lite.micro.compression import decode
@@ -790,6 +790,59 @@ class TestDecodeInsertion(unittest.TestCase):
 
     self.assertEqual(ancillary.name, "weights_ancillary")
     self.assertEqual(output.name, "weights_decoded")
+
+  def test_mixed_compressed_and_uncompressed_inputs(self):
+    """CONCATENATION with one compressed and one plain input."""
+    weights = model_editor.Tensor(
+        shape=(4, 4),
+        dtype=tflite.TensorType.INT8,
+        data=np.ones((4, 4), dtype=np.int8),
+        name="weights",
+        quantization=model_editor.Quantization(scales=0.5, zero_points=0),
+    )
+    plain = model_editor.Tensor(
+        shape=(4, 4),
+        dtype=tflite.TensorType.INT8,
+        data=np.zeros((4, 4), dtype=np.int8),
+        name="plain",
+    )
+    output_t = model_editor.Tensor(
+        shape=(4, 8),
+        dtype=tflite.TensorType.INT8,
+        name="output",
+    )
+
+    concat_op = model_editor.Operator(
+        opcode=tflite.BuiltinOperator.CONCATENATION,
+        inputs=[weights, plain],
+        outputs=[output_t],
+    )
+
+    model = model_editor.Model(subgraphs=[
+        model_editor.Subgraph(
+            tensors=[weights, plain],
+            operators=[concat_op],
+        )
+    ])
+
+    # Only compress weights, not plain
+    compression_results = {(0, 0): _make_dummy_compression_result()}
+
+    decode_insert.insert_decode_operators(model, compression_results)
+
+    sg = model.subgraphs[0]
+
+    # One DECODE + one CONCATENATION
+    self.assertEqual(len(sg.operators), 2)
+    decode_op = sg.operators[0]
+
+    # DECODE has 2 inputs and 1 output (only the compressed tensor)
+    self.assertEqual(len(decode_op.inputs), 2)
+    self.assertEqual(len(decode_op.outputs), 1)
+
+    # CONCATENATION: first input rewired to DECODE output, second unchanged
+    self.assertIs(sg.operators[1].inputs[0], decode_op.outputs[0])
+    self.assertIs(sg.operators[1].inputs[1], plain)
 
   def test_encoded_tensor_rewritten(self):
     """Compressed tensor is rewritten with encoded data, UINT8 type, no quant."""

--- a/tensorflow/lite/micro/compression/decode_insert_test.py
+++ b/tensorflow/lite/micro/compression/decode_insert_test.py
@@ -1,0 +1,417 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for DECODE operator insertion."""
+
+import warnings
+
+import numpy as np
+import unittest
+
+from tflite_micro.tensorflow.lite.micro.compression import compressor
+from tflite_micro.tensorflow.lite.micro.compression import decode
+from tflite_micro.tensorflow.lite.micro.compression import decode_insert
+from tflite_micro.tensorflow.lite.micro.compression import model_editor
+from tflite_micro.tensorflow.lite.python import schema_py_generated as tflite
+
+
+def _build_simple_fc_model():
+  """Build a simple model with one FC operator and compressible weights."""
+  # yapf: disable
+  weights = model_editor.Tensor(
+      shape=(4, 4),
+      dtype=tflite.TensorType.INT8,
+      data=np.array([[1, 2, 1, 2],
+                     [3, 4, 3, 4],
+                     [1, 2, 1, 2],
+                     [3, 4, 3, 4]], dtype=np.int8),
+      name="weights",
+      quantization=model_editor.Quantization(scales=0.5, zero_points=0),
+  )
+  # yapf: enable
+  input_t = model_editor.Tensor(
+      shape=(1, 4),
+      dtype=tflite.TensorType.INT8,
+      name="input",
+  )
+  output_t = model_editor.Tensor(
+      shape=(1, 4),
+      dtype=tflite.TensorType.INT8,
+      name="output",
+  )
+
+  model = model_editor.Model(subgraphs=[
+      model_editor.Subgraph(
+          tensors=[weights],
+          operators=[
+              model_editor.Operator(
+                  opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+                  inputs=[input_t, weights],
+                  outputs=[output_t],
+              )
+          ],
+      )
+  ])
+  return model
+
+
+def _build_shared_weights_model():
+  """Build model where one tensor is used by multiple operators."""
+  weights = model_editor.Tensor(
+      shape=(4, 4),
+      dtype=tflite.TensorType.INT8,
+      data=np.ones((4, 4), dtype=np.int8),
+      name="shared_weights",
+      quantization=model_editor.Quantization(scales=0.5, zero_points=0),
+  )
+  input1 = model_editor.Tensor(
+      shape=(1, 4),
+      dtype=tflite.TensorType.INT8,
+      name="input1",
+  )
+  input2 = model_editor.Tensor(
+      shape=(1, 4),
+      dtype=tflite.TensorType.INT8,
+      name="input2",
+  )
+  output1 = model_editor.Tensor(
+      shape=(1, 4),
+      dtype=tflite.TensorType.INT8,
+      name="output1",
+  )
+  output2 = model_editor.Tensor(
+      shape=(1, 4),
+      dtype=tflite.TensorType.INT8,
+      name="output2",
+  )
+
+  model = model_editor.Model(subgraphs=[
+      model_editor.Subgraph(
+          tensors=[weights],
+          operators=[
+              model_editor.Operator(
+                  opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+                  inputs=[input1, weights],
+                  outputs=[output1],
+              ),
+              model_editor.Operator(
+                  opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+                  inputs=[input2, weights],
+                  outputs=[output2],
+              ),
+          ],
+      )
+  ])
+  return model
+
+
+def _make_dummy_ancillary_data() -> bytes:
+  """Create dummy ancillary data for testing."""
+  dcm = decode.DecodeCommonMetadata(
+      decode_type=decode.DecodeType.LUT,
+      user_data=b'\x01\x04\x10' + b'\x00' * 9,  # lut_version, bitwidth, stride
+  )
+  value_tables = bytes([1, 2, 3, 4] + [0] * 12)  # 16-byte padded table
+  return dcm.to_bytes() + value_tables
+
+
+class TestDecodeInsertion(unittest.TestCase):
+  """Tests for insert_decode_operators function."""
+
+  def test_insert_single_decode_operator(self):
+    """DECODE operator inserted before FC that uses compressed weights."""
+    model = _build_simple_fc_model()
+    weights_tensor = model.subgraphs[0].tensor_by_name("weights")
+
+    # Create compression result
+    compression_results = {
+        (0, 0):
+        compressor.CompressionResult(
+            encoded_data=b'\x00\x00',
+            ancillary_data=_make_dummy_ancillary_data(),
+        )
+    }
+
+    # Insert DECODE operators
+    decode_insert.insert_decode_operators(model, compression_results)
+
+    sg = model.subgraphs[0]
+
+    # Should have 2 operators: DECODE then FC
+    self.assertEqual(len(sg.operators), 2)
+    self.assertEqual(sg.operators[0].opcode, tflite.BuiltinOperator.CUSTOM)
+    self.assertEqual(sg.operators[0].custom_code,
+                     decode_insert.DECODE_CUSTOM_OP_NAME)
+    self.assertEqual(sg.operators[1].opcode,
+                     tflite.BuiltinOperator.FULLY_CONNECTED)
+
+  def test_decode_inputs_structure(self):
+    """DECODE operator has correct inputs: encoded tensor + ancillary."""
+    model = _build_simple_fc_model()
+    weights_tensor = model.subgraphs[0].tensor_by_name("weights")
+
+    compression_results = {
+        (0, 0):
+        compressor.CompressionResult(
+            encoded_data=b'\x00\x00',
+            ancillary_data=_make_dummy_ancillary_data(),
+        )
+    }
+
+    decode_insert.insert_decode_operators(model, compression_results)
+
+    decode_op = model.subgraphs[0].operators[0]
+
+    # DECODE has 2 inputs
+    self.assertEqual(len(decode_op.inputs), 2)
+    # First input is the encoded tensor (original weights)
+    self.assertIs(decode_op.inputs[0], weights_tensor)
+    # Second input is ancillary tensor
+    self.assertEqual(decode_op.inputs[1].dtype, tflite.TensorType.UINT8)
+
+  def test_decode_output_structure(self):
+    """DECODE operator output has correct shape and dtype."""
+    model = _build_simple_fc_model()
+    weights_tensor = model.subgraphs[0].tensor_by_name("weights")
+
+    # Save original properties before rewrite
+    original_shape = weights_tensor.shape
+    original_dtype = weights_tensor.dtype
+
+    compression_results = {
+        (0, 0):
+        compressor.CompressionResult(
+            encoded_data=b'\x00\x00',
+            ancillary_data=_make_dummy_ancillary_data(),
+        )
+    }
+
+    decode_insert.insert_decode_operators(model, compression_results)
+
+    decode_op = model.subgraphs[0].operators[0]
+    output = decode_op.outputs[0]
+
+    # Output matches original (pre-rewrite) tensor shape and dtype
+    self.assertEqual(output.shape, original_shape)
+    self.assertEqual(output.dtype, original_dtype)
+
+  def test_consumer_rewired_to_decode_output(self):
+    """FC operator input rewired to use DECODE output."""
+    model = _build_simple_fc_model()
+    weights_tensor = model.subgraphs[0].tensor_by_name("weights")
+
+    compression_results = {
+        (0, 0):
+        compressor.CompressionResult(
+            encoded_data=b'\x00\x00',
+            ancillary_data=_make_dummy_ancillary_data(),
+        )
+    }
+
+    decode_insert.insert_decode_operators(model, compression_results)
+
+    decode_op = model.subgraphs[0].operators[0]
+    fc_op = model.subgraphs[0].operators[1]
+
+    # FC's second input (weights) should now be DECODE's output
+    self.assertIs(fc_op.inputs[1], decode_op.outputs[0])
+    # Original weights tensor should NOT be in FC inputs
+    self.assertNotIn(weights_tensor, fc_op.inputs)
+
+  def test_shared_tensor_decode_per_consumer(self):
+    """Tensor used by multiple ops gets separate DECODE for each consumer."""
+    model = _build_shared_weights_model()
+    weights_tensor = model.subgraphs[0].tensor_by_name("shared_weights")
+
+    compression_results = {
+        (0, 0):
+        compressor.CompressionResult(
+            encoded_data=b'\x00\x00',
+            ancillary_data=_make_dummy_ancillary_data(),
+        )
+    }
+
+    decode_insert.insert_decode_operators(model, compression_results)
+
+    sg = model.subgraphs[0]
+
+    # Should have 4 operators: 2 DECODEs + 2 FCs (DECODE before each FC)
+    self.assertEqual(len(sg.operators), 4)
+    self.assertEqual(sg.operators[0].opcode, tflite.BuiltinOperator.CUSTOM)
+    self.assertEqual(sg.operators[1].opcode,
+                     tflite.BuiltinOperator.FULLY_CONNECTED)
+    self.assertEqual(sg.operators[2].opcode, tflite.BuiltinOperator.CUSTOM)
+    self.assertEqual(sg.operators[3].opcode,
+                     tflite.BuiltinOperator.FULLY_CONNECTED)
+
+    decode_op1 = sg.operators[0]
+    fc_op1 = sg.operators[1]
+    decode_op2 = sg.operators[2]
+    fc_op2 = sg.operators[3]
+
+    # Each FC should use its own DECODE's output
+    self.assertIs(fc_op1.inputs[1], decode_op1.outputs[0])
+    self.assertIs(fc_op2.inputs[1], decode_op2.outputs[0])
+    # The two DECODEs should have different outputs
+    self.assertIsNot(decode_op1.outputs[0], decode_op2.outputs[0])
+    # The two DECODEs should share the same ancillary tensor
+    self.assertIs(decode_op1.inputs[1], decode_op2.inputs[1])
+
+  def test_ancillary_tensor_contains_dcm(self):
+    """Ancillary tensor data contains valid DCM header."""
+    model = _build_simple_fc_model()
+
+    ancillary_data = _make_dummy_ancillary_data()
+    compression_results = {
+        (0, 0):
+        compressor.CompressionResult(
+            encoded_data=b'\x00\x00',
+            ancillary_data=ancillary_data,
+        )
+    }
+
+    decode_insert.insert_decode_operators(model, compression_results)
+
+    decode_op = model.subgraphs[0].operators[0]
+    ancillary_tensor = decode_op.inputs[1]
+
+    # Ancillary tensor data should match what we provided
+    self.assertEqual(bytes(ancillary_tensor.array), ancillary_data)
+
+    # Verify DCM header
+    dcm_bytes = ancillary_tensor.array[:16]
+    self.assertEqual(dcm_bytes[0], 0)  # decode_type = LUT
+    self.assertEqual(dcm_bytes[1], 1)  # DCM version
+
+  def test_no_consumers_no_decode(self):
+    """Tensor with no consumers gets no DECODE operator and emits warning."""
+    # Create model where compressed tensor is not used as input
+    unused_tensor = model_editor.Tensor(
+        shape=(4, 4),
+        dtype=tflite.TensorType.INT8,
+        data=np.ones((4, 4), dtype=np.int8),
+        name="unused",
+        quantization=model_editor.Quantization(scales=0.5, zero_points=0),
+    )
+    input_t = model_editor.Tensor(
+        shape=(1, 4),
+        dtype=tflite.TensorType.INT8,
+        name="input",
+    )
+    output_t = model_editor.Tensor(
+        shape=(1, 4),
+        dtype=tflite.TensorType.INT8,
+        name="output",
+    )
+    other_weights = model_editor.Tensor(
+        shape=(4, 4),
+        dtype=tflite.TensorType.INT8,
+        data=np.ones((4, 4), dtype=np.int8),
+        name="other_weights",
+        quantization=model_editor.Quantization(scales=0.5, zero_points=0),
+    )
+
+    model = model_editor.Model(subgraphs=[
+        model_editor.Subgraph(
+            tensors=[unused_tensor, other_weights],
+            operators=[
+                model_editor.Operator(
+                    opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+                    inputs=[input_t, other_weights],
+                    outputs=[output_t],
+                )
+            ],
+        )
+    ])
+
+    # Compress the unused tensor
+    compression_results = {
+        (0, 0):
+        compressor.CompressionResult(
+            encoded_data=b'\x00\x00',
+            ancillary_data=_make_dummy_ancillary_data(),
+        )
+    }
+
+    with warnings.catch_warnings(record=True) as w:
+      warnings.simplefilter("always")
+      decode_insert.insert_decode_operators(model, compression_results)
+
+      # Should emit a warning about no consumers
+      self.assertEqual(len(w), 1)
+      self.assertIn("no consumers", str(w[0].message))
+      self.assertIn("unused", str(w[0].message))
+
+    # Should still have just 1 operator (no DECODE inserted)
+    self.assertEqual(len(model.subgraphs[0].operators), 1)
+
+  def test_tensor_naming(self):
+    """Output and ancillary tensors get appropriate names."""
+    model = _build_simple_fc_model()
+
+    compression_results = {
+        (0, 0):
+        compressor.CompressionResult(
+            encoded_data=b'\x00\x00',
+            ancillary_data=_make_dummy_ancillary_data(),
+        )
+    }
+
+    decode_insert.insert_decode_operators(model, compression_results)
+
+    decode_op = model.subgraphs[0].operators[0]
+    ancillary = decode_op.inputs[1]
+    output = decode_op.outputs[0]
+
+    self.assertEqual(ancillary.name, "weights_ancillary")
+    self.assertEqual(output.name, "weights_decoded")
+
+  def test_encoded_tensor_rewritten(self):
+    """Compressed tensor is rewritten with encoded data, UINT8 type, no quant."""
+    model = _build_simple_fc_model()
+    weights_tensor = model.subgraphs[0].tensor_by_name("weights")
+
+    encoded_data = b'\xAB\xCD\xEF'
+    compression_results = {
+        (0, 0):
+        compressor.CompressionResult(
+            encoded_data=encoded_data,
+            ancillary_data=_make_dummy_ancillary_data(),
+        )
+    }
+
+    decode_insert.insert_decode_operators(model, compression_results)
+
+    # Original tensor should be rewritten
+    self.assertEqual(weights_tensor.shape, (len(encoded_data), ))
+    self.assertEqual(weights_tensor.dtype, tflite.TensorType.UINT8)
+    self.assertIsNone(weights_tensor.quantization)
+    self.assertEqual(weights_tensor.buffer.data, encoded_data)
+
+
+class TestHelperFunctions(unittest.TestCase):
+  """Tests for internal helper functions."""
+
+  def test_find_tensor_consumers(self):
+    """_find_tensor_consumers finds all ops using a tensor."""
+    model = _build_shared_weights_model()
+    sg = model.subgraphs[0]
+    weights = sg.tensor_by_name("shared_weights")
+
+    consumers = decode_insert._find_tensor_consumers(sg, weights)
+
+    self.assertEqual(len(consumers), 2)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tensorflow/lite/micro/compression/decode_insert_test.py
+++ b/tensorflow/lite/micro/compression/decode_insert_test.py
@@ -222,7 +222,6 @@ class TestDecodeInsertion(unittest.TestCase):
   def test_insert_single_decode_operator(self):
     """DECODE operator inserted before FC that uses compressed weights."""
     model = _build_simple_fc_model()
-    weights_tensor = model.subgraphs[0].tensor_by_name("weights")
 
     # Create compression result
     compression_results = {
@@ -328,7 +327,6 @@ class TestDecodeInsertion(unittest.TestCase):
   def test_shared_tensor_decode_per_consumer(self):
     """Tensor used by multiple ops gets separate DECODE for each consumer."""
     model = _build_shared_weights_model()
-    weights_tensor = model.subgraphs[0].tensor_by_name("shared_weights")
 
     compression_results = {
         (0, 0):

--- a/tensorflow/lite/micro/compression/decode_insert_test.py
+++ b/tensorflow/lite/micro/compression/decode_insert_test.py
@@ -115,6 +115,49 @@ def _build_shared_weights_model():
   return model
 
 
+def _build_output_constant_model():
+  """Build a model where a compressed constant is a subgraph output."""
+  table = model_editor.Tensor(
+      shape=(4, 4),
+      dtype=tflite.TensorType.INT8,
+      data=np.ones((4, 4), dtype=np.int8),
+      name="table",
+      quantization=model_editor.Quantization(scales=0.5, zero_points=0),
+  )
+  weights = model_editor.Tensor(
+      shape=(4, 4),
+      dtype=tflite.TensorType.INT8,
+      data=np.ones((4, 4), dtype=np.int8),
+      name="weights",
+      quantization=model_editor.Quantization(scales=0.5, zero_points=0),
+  )
+  input_t = model_editor.Tensor(
+      shape=(1, 4),
+      dtype=tflite.TensorType.INT8,
+      name="input",
+  )
+  output_t = model_editor.Tensor(
+      shape=(1, 4),
+      dtype=tflite.TensorType.INT8,
+      name="output",
+  )
+
+  model = model_editor.Model(subgraphs=[
+      model_editor.Subgraph(
+          tensors=[table],
+          operators=[
+              model_editor.Operator(
+                  opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+                  inputs=[input_t, weights],
+                  outputs=[output_t],
+              )
+          ],
+          outputs=[output_t, table],
+      )
+  ])
+  return model
+
+
 def _make_dummy_ancillary_data() -> bytes:
   """Create dummy ancillary data for testing."""
   dcm = decode.DecodeCommonMetadata(
@@ -266,6 +309,131 @@ class TestDecodeInsertion(unittest.TestCase):
     self.assertIsNot(decode_op1.outputs[0], decode_op2.outputs[0])
     # The two DECODEs should share the same ancillary tensor
     self.assertIs(decode_op1.inputs[1], decode_op2.inputs[1])
+
+  def test_output_constant_gets_decode(self):
+    """Compressed tensor in subgraph outputs gets DECODE appended last."""
+    model = _build_output_constant_model()
+    sg = model.subgraphs[0]
+    table = sg.tensor_by_name("table")
+    original_first_output = sg.outputs[0]
+
+    compression_results = {
+        (0, 0):
+        compressor.CompressionResult(
+            encoded_data=b'\x00\x00',
+            ancillary_data=_make_dummy_ancillary_data(),
+        )
+    }
+
+    decode_insert.insert_decode_operators(model, compression_results)
+
+    # DECODE appended after the FC operator
+    self.assertEqual(len(sg.operators), 2)
+    decode_op = sg.operators[1]
+    self.assertEqual(decode_op.opcode, tflite.BuiltinOperator.CUSTOM)
+    self.assertEqual(decode_op.custom_code,
+                     decode_insert.DECODE_CUSTOM_OP_NAME)
+    self.assertIs(decode_op.inputs[0], table)
+
+    # Output list entry rewired to the decoded tensor; other entry untouched
+    self.assertIs(sg.outputs[0], original_first_output)
+    self.assertIs(sg.outputs[1], decode_op.outputs[0])
+
+    # Original tensor rewritten to encoded data
+    self.assertEqual(table.dtype, tflite.TensorType.UINT8)
+
+  def test_consumed_and_output_tensor(self):
+    """Tensor both consumed and a subgraph output gets both DECODEs."""
+    model = _build_simple_fc_model()
+    sg = model.subgraphs[0]
+    weights = sg.tensor_by_name("weights")
+    fc_output = sg.operators[0].outputs[0]
+    sg.outputs = [fc_output, weights]
+
+    compression_results = {
+        (0, 0):
+        compressor.CompressionResult(
+            encoded_data=b'\x00\x00',
+            ancillary_data=_make_dummy_ancillary_data(),
+        )
+    }
+
+    decode_insert.insert_decode_operators(model, compression_results)
+
+    # Consumer DECODE before FC, output DECODE appended last
+    self.assertEqual(len(sg.operators), 3)
+    consumer_decode = sg.operators[0]
+    fc_op = sg.operators[1]
+    output_decode = sg.operators[2]
+    self.assertEqual(consumer_decode.opcode, tflite.BuiltinOperator.CUSTOM)
+    self.assertEqual(fc_op.opcode, tflite.BuiltinOperator.FULLY_CONNECTED)
+    self.assertEqual(output_decode.opcode, tflite.BuiltinOperator.CUSTOM)
+
+    # Each reader gets its own decoded tensor
+    self.assertIs(fc_op.inputs[1], consumer_decode.outputs[0])
+    self.assertIs(sg.outputs[1], output_decode.outputs[0])
+    self.assertIsNot(consumer_decode.outputs[0], output_decode.outputs[0])
+
+    # Both DECODEs share the ancillary tensor
+    self.assertIs(consumer_decode.inputs[1], output_decode.inputs[1])
+
+  def test_multiple_output_tensors_get_decodes(self):
+    """Each compressed subgraph output gets a DECODE appended at the end."""
+    table1 = model_editor.Tensor(
+        shape=(4, 4),
+        dtype=tflite.TensorType.INT8,
+        data=np.ones((4, 4), dtype=np.int8),
+        name="table1",
+        quantization=model_editor.Quantization(scales=0.5, zero_points=0),
+    )
+    table2 = model_editor.Tensor(
+        shape=(2, 2),
+        dtype=tflite.TensorType.INT8,
+        data=np.ones((2, 2), dtype=np.int8),
+        name="table2",
+        quantization=model_editor.Quantization(scales=0.5, zero_points=0),
+    )
+    output_t = model_editor.Tensor(
+        shape=(1, 4),
+        dtype=tflite.TensorType.INT8,
+        name="output",
+    )
+
+    model = model_editor.Model(subgraphs=[
+        model_editor.Subgraph(
+            tensors=[table1, table2],
+            operators=[],
+            outputs=[table1, output_t, table2],
+        )
+    ])
+    sg = model.subgraphs[0]
+
+    compression_results = {
+        (0, 0):
+        compressor.CompressionResult(
+            encoded_data=b'\x00\x00',
+            ancillary_data=_make_dummy_ancillary_data(),
+        ),
+        (0, 1):
+        compressor.CompressionResult(
+            encoded_data=b'\x01\x01',
+            ancillary_data=_make_dummy_ancillary_data(),
+        ),
+    }
+
+    decode_insert.insert_decode_operators(model, compression_results)
+
+    # One DECODE per compressed output tensor
+    self.assertEqual(len(sg.operators), 2)
+    decode_op1 = sg.operators[0]
+    decode_op2 = sg.operators[1]
+    self.assertIs(decode_op1.inputs[0], table1)
+    self.assertIs(decode_op2.inputs[0], table2)
+
+    # Output list rewired in place; uncompressed entry untouched
+    self.assertIs(sg.outputs[0], decode_op1.outputs[0])
+    self.assertIs(sg.outputs[1], output_t)
+    self.assertIs(sg.outputs[2], decode_op2.outputs[0])
 
   def test_ancillary_tensor_contains_dcm(self):
     """Ancillary tensor data contains valid DCM header."""

--- a/tensorflow/lite/micro/compression/decode_insert_test.py
+++ b/tensorflow/lite/micro/compression/decode_insert_test.py
@@ -377,8 +377,79 @@ class TestDecodeInsertion(unittest.TestCase):
     # Both DECODEs share the ancillary tensor
     self.assertIs(consumer_decode.inputs[1], output_decode.inputs[1])
 
-  def test_multiple_output_tensors_get_decodes(self):
-    """Each compressed subgraph output gets a DECODE appended at the end."""
+  def test_multiple_input_tensors_share_one_decode(self):
+    """All compressed tensors of one consumer are decoded by one DECODE."""
+    weights1 = model_editor.Tensor(
+        shape=(4, 4),
+        dtype=tflite.TensorType.INT8,
+        data=np.ones((4, 4), dtype=np.int8),
+        name="weights1",
+        quantization=model_editor.Quantization(scales=0.5, zero_points=0),
+    )
+    weights2 = model_editor.Tensor(
+        shape=(1, 4),
+        dtype=tflite.TensorType.INT8,
+        data=np.ones((1, 4), dtype=np.int8),
+        name="weights2",
+        quantization=model_editor.Quantization(scales=0.5, zero_points=0),
+    )
+    input_t = model_editor.Tensor(
+        shape=(1, 4),
+        dtype=tflite.TensorType.INT8,
+        name="input",
+    )
+    output_t = model_editor.Tensor(
+        shape=(1, 4),
+        dtype=tflite.TensorType.INT8,
+        name="output",
+    )
+
+    model = model_editor.Model(subgraphs=[
+        model_editor.Subgraph(
+            tensors=[weights1, weights2],
+            operators=[
+                model_editor.Operator(
+                    opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+                    inputs=[input_t, weights1, weights2],
+                    outputs=[output_t],
+                )
+            ],
+        )
+    ])
+    sg = model.subgraphs[0]
+
+    compression_results = {
+        (0, 0):
+        compressor.CompressionResult(
+            encoded_data=b'\x00\x00',
+            ancillary_data=_make_dummy_ancillary_data(),
+        ),
+        (0, 1):
+        compressor.CompressionResult(
+            encoded_data=b'\x01\x01',
+            ancillary_data=_make_dummy_ancillary_data(),
+        ),
+    }
+
+    decode_insert.insert_decode_operators(model, compression_results)
+
+    # One DECODE with two encoded/ancillary pairs, inserted before the FC
+    self.assertEqual(len(sg.operators), 2)
+    decode_op = sg.operators[0]
+    fc_op = sg.operators[1]
+    self.assertEqual(decode_op.opcode, tflite.BuiltinOperator.CUSTOM)
+    self.assertEqual(fc_op.opcode, tflite.BuiltinOperator.FULLY_CONNECTED)
+    self.assertEqual(len(decode_op.inputs), 4)
+    self.assertEqual(len(decode_op.outputs), 2)
+    self.assertIs(decode_op.inputs[0], weights1)
+    self.assertIs(decode_op.inputs[2], weights2)
+
+    # The consumer reads each decoded tensor from its original position
+    self.assertIs(fc_op.inputs[1], decode_op.outputs[0])
+    self.assertIs(fc_op.inputs[2], decode_op.outputs[1])
+
+  def test_multiple_output_tensors_share_one_decode(self):
+    """All compressed subgraph outputs are decoded by a single DECODE."""
     table1 = model_editor.Tensor(
         shape=(4, 4),
         dtype=tflite.TensorType.INT8,
@@ -423,17 +494,18 @@ class TestDecodeInsertion(unittest.TestCase):
 
     decode_insert.insert_decode_operators(model, compression_results)
 
-    # One DECODE per compressed output tensor
-    self.assertEqual(len(sg.operators), 2)
-    decode_op1 = sg.operators[0]
-    decode_op2 = sg.operators[1]
-    self.assertIs(decode_op1.inputs[0], table1)
-    self.assertIs(decode_op2.inputs[0], table2)
+    # One DECODE with two encoded/ancillary pairs and two outputs
+    self.assertEqual(len(sg.operators), 1)
+    decode_op = sg.operators[0]
+    self.assertEqual(len(decode_op.inputs), 4)
+    self.assertEqual(len(decode_op.outputs), 2)
+    self.assertIs(decode_op.inputs[0], table1)
+    self.assertIs(decode_op.inputs[2], table2)
 
     # Output list rewired in place; uncompressed entry untouched
-    self.assertIs(sg.outputs[0], decode_op1.outputs[0])
+    self.assertIs(sg.outputs[0], decode_op.outputs[0])
     self.assertIs(sg.outputs[1], output_t)
-    self.assertIs(sg.outputs[2], decode_op2.outputs[0])
+    self.assertIs(sg.outputs[2], decode_op.outputs[1])
 
   def test_ancillary_tensor_contains_dcm(self):
     """Ancillary tensor data contains valid DCM header."""

--- a/tensorflow/lite/micro/compression/decode_insert_test.py
+++ b/tensorflow/lite/micro/compression/decode_insert_test.py
@@ -434,6 +434,37 @@ class TestDecodeInsertion(unittest.TestCase):
     self.assertEqual(len(decodes), 2)
     self.assertIs(decodes[0].inputs[1], decodes[1].inputs[1])
 
+  def test_insertion_on_read_model(self):
+    """Insertion works on a model read from a flatbuffer.
+
+    Unlike the from-scratch fixtures elsewhere in this file, a read
+    model carries a populated buffer list, so this exercises the
+    pruning of the buffer orphaned when compression rewrites the
+    weights tensor.
+    """
+    scratch = _build_simple_fc_model()
+    model = model_editor.read(bytes(scratch.build()))
+    weights_bytes = model.subgraphs[0].tensor_by_name("weights").buffer.data
+
+    result = _make_dummy_compression_result(bitwidth=2,
+                                            value_table=b'\x01\x02\x03\x04')
+    decode_insert.insert_decode_operators(model, {(0, 0): result})
+
+    final = model_editor.read(bytes(model.build()))
+    sg = final.subgraphs[0]
+    decode_op = sg.operators[0]
+    self.assertEqual(decode_op.custom_code,
+                     decode_insert.DECODE_CUSTOM_OP_NAME)
+    self.assertEqual(decode_op.inputs[0].buffer.data, result.encoded_data)
+    self.assertEqual(decode_op.inputs[1].buffer.data, result.ancillary_data)
+
+    # The original weights buffer, orphaned by the rewrite, is pruned:
+    # only the conventional empty buffer, the encoded data, and the
+    # ancillary data remain
+    self.assertEqual(len(final.buffers), 3)
+    for buffer in final.buffers:
+      self.assertNotEqual(buffer.data, weights_bytes)
+
   def test_divergent_aliases_dissolve_sharing(self):
     """Aliases whose compression results differ get separate buffers."""
     model = _build_shared_buffer_model(subgraph_count=2)

--- a/tensorflow/lite/micro/compression/decode_insert_test.py
+++ b/tensorflow/lite/micro/compression/decode_insert_test.py
@@ -772,19 +772,5 @@ class TestDecodeInsertion(unittest.TestCase):
     self.assertEqual(weights_tensor.buffer.data, encoded_data)
 
 
-class TestHelperFunctions(unittest.TestCase):
-  """Tests for internal helper functions."""
-
-  def test_find_tensor_consumers(self):
-    """_find_tensor_consumers finds all ops using a tensor."""
-    model = _build_shared_weights_model()
-    sg = model.subgraphs[0]
-    weights = sg.tensor_by_name("shared_weights")
-
-    consumers = decode_insert._find_tensor_consumers(sg, weights)
-
-    self.assertEqual(len(consumers), 2)
-
-
 if __name__ == "__main__":
   unittest.main()

--- a/tensorflow/lite/micro/compression/decode_insert_test.py
+++ b/tensorflow/lite/micro/compression/decode_insert_test.py
@@ -528,19 +528,14 @@ class TestDecodeInsertion(unittest.TestCase):
         quantization=model_editor.Quantization(scales=0.5, zero_points=0),
     )
     weights2 = model_editor.Tensor(
-        shape=(1, 4),
+        shape=(2, 4),
         dtype=tflite.TensorType.INT8,
-        data=np.ones((1, 4), dtype=np.int8),
+        data=np.ones((2, 4), dtype=np.int8),
         name="weights2",
         quantization=model_editor.Quantization(scales=0.5, zero_points=0),
     )
-    input_t = model_editor.Tensor(
-        shape=(1, 4),
-        dtype=tflite.TensorType.INT8,
-        name="input",
-    )
     output_t = model_editor.Tensor(
-        shape=(1, 4),
+        shape=(6, 4),
         dtype=tflite.TensorType.INT8,
         name="output",
     )
@@ -550,11 +545,12 @@ class TestDecodeInsertion(unittest.TestCase):
             tensors=[weights1, weights2],
             operators=[
                 model_editor.Operator(
-                    opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
-                    inputs=[input_t, weights1, weights2],
+                    opcode=tflite.BuiltinOperator.CONCATENATION,
+                    inputs=[weights1, weights2],
                     outputs=[output_t],
                 )
             ],
+            outputs=[output_t],
         )
     ])
     sg = model.subgraphs[0]
@@ -574,20 +570,21 @@ class TestDecodeInsertion(unittest.TestCase):
 
     decode_insert.insert_decode_operators(model, compression_results)
 
-    # One DECODE with two encoded/ancillary pairs, inserted before the FC
+    # One DECODE with two encoded/ancillary pairs, inserted before the
+    # CONCATENATION
     self.assertEqual(len(sg.operators), 2)
     decode_op = sg.operators[0]
-    fc_op = sg.operators[1]
+    concat_op = sg.operators[1]
     self.assertEqual(decode_op.opcode, tflite.BuiltinOperator.CUSTOM)
-    self.assertEqual(fc_op.opcode, tflite.BuiltinOperator.FULLY_CONNECTED)
+    self.assertEqual(concat_op.opcode, tflite.BuiltinOperator.CONCATENATION)
     self.assertEqual(len(decode_op.inputs), 4)
     self.assertEqual(len(decode_op.outputs), 2)
     self.assertIs(decode_op.inputs[0], weights1)
     self.assertIs(decode_op.inputs[2], weights2)
 
     # The consumer reads each decoded tensor from its original position
-    self.assertIs(fc_op.inputs[1], decode_op.outputs[0])
-    self.assertIs(fc_op.inputs[2], decode_op.outputs[1])
+    self.assertIs(concat_op.inputs[0], decode_op.outputs[0])
+    self.assertIs(concat_op.inputs[1], decode_op.outputs[1])
 
   def test_multiple_output_tensors_share_one_decode(self):
     """All compressed subgraph outputs are decoded by a single DECODE."""

--- a/tensorflow/lite/micro/compression/decode_insert_test.py
+++ b/tensorflow/lite/micro/compression/decode_insert_test.py
@@ -11,7 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for DECODE operator insertion."""
+"""Unit tests for DECODE operator insertion.
+
+The models these tests build are structural fixtures for exercising
+insertion, not fully valid, runnable models. Likewise the compression
+payloads are dummies: sized and structured plausibly, but not data
+that decodes to the models' tensor contents. Insertion treats both as
+opaque structure, so the tests do not depend on their validity.
+"""
 
 import warnings
 
@@ -206,14 +213,29 @@ def _build_shared_buffer_model(subgraph_count):
   return model_editor.Model(subgraphs=subgraphs)
 
 
-def _make_dummy_ancillary_data() -> bytes:
-  """Create dummy ancillary data for testing."""
+def _make_dummy_compression_result(
+    element_count=16,
+    bitwidth=1,
+    value_table=b'\x01',
+) -> compressor.CompressionResult:
+  """Create a CompressionResult with plausible dummy payloads.
+
+  The ancillary data carries a LUT DCM describing the given index
+  bitwidth and value table, and the encoded data is sized for
+  element_count indices at that bitwidth. Tests pass values consistent
+  with the tensor they compress, but the payloads remain dummies (all
+  indices zero) that do not decode to the tensor's contents.
+  """
   dcm = decode.DecodeCommonMetadata(
       decode_type=decode.DecodeType.LUT,
-      user_data=b'\x01\x04\x10' + b'\x00' * 9,  # lut_version, bitwidth, stride
+      # lut_version, index bitwidth, value table stride in elements
+      user_data=bytes([1, bitwidth, len(value_table)]) + b'\x00' * 9,
   )
-  value_tables = bytes([1, 2, 3, 4] + [0] * 12)  # 16-byte padded table
-  return dcm.to_bytes() + value_tables
+  encoded_data = bytes((element_count * bitwidth + 7) // 8)
+  return compressor.CompressionResult(
+      encoded_data=encoded_data,
+      ancillary_data=dcm.to_bytes() + value_table,
+  )
 
 
 class TestDecodeInsertion(unittest.TestCase):
@@ -226,10 +248,8 @@ class TestDecodeInsertion(unittest.TestCase):
     # Create compression result
     compression_results = {
         (0, 0):
-        compressor.CompressionResult(
-            encoded_data=b'\x00\x00',
-            ancillary_data=_make_dummy_ancillary_data(),
-        )
+        _make_dummy_compression_result(bitwidth=2,
+                                       value_table=b'\x01\x02\x03\x04')
     }
 
     # Insert DECODE operators
@@ -252,10 +272,8 @@ class TestDecodeInsertion(unittest.TestCase):
 
     compression_results = {
         (0, 0):
-        compressor.CompressionResult(
-            encoded_data=b'\x00\x00',
-            ancillary_data=_make_dummy_ancillary_data(),
-        )
+        _make_dummy_compression_result(bitwidth=2,
+                                       value_table=b'\x01\x02\x03\x04')
     }
 
     decode_insert.insert_decode_operators(model, compression_results)
@@ -282,10 +300,8 @@ class TestDecodeInsertion(unittest.TestCase):
 
     compression_results = {
         (0, 0):
-        compressor.CompressionResult(
-            encoded_data=b'\x00\x00',
-            ancillary_data=_make_dummy_ancillary_data(),
-        )
+        _make_dummy_compression_result(bitwidth=2,
+                                       value_table=b'\x01\x02\x03\x04')
     }
 
     decode_insert.insert_decode_operators(model, compression_results)
@@ -308,10 +324,8 @@ class TestDecodeInsertion(unittest.TestCase):
 
     compression_results = {
         (0, 0):
-        compressor.CompressionResult(
-            encoded_data=b'\x00\x00',
-            ancillary_data=_make_dummy_ancillary_data(),
-        )
+        _make_dummy_compression_result(bitwidth=2,
+                                       value_table=b'\x01\x02\x03\x04')
     }
 
     decode_insert.insert_decode_operators(model, compression_results)
@@ -328,13 +342,7 @@ class TestDecodeInsertion(unittest.TestCase):
     """Tensor used by multiple ops gets separate DECODE for each consumer."""
     model = _build_shared_weights_model()
 
-    compression_results = {
-        (0, 0):
-        compressor.CompressionResult(
-            encoded_data=b'\x00\x00',
-            ancillary_data=_make_dummy_ancillary_data(),
-        )
-    }
+    compression_results = {(0, 0): _make_dummy_compression_result()}
 
     decode_insert.insert_decode_operators(model, compression_results)
 
@@ -368,19 +376,8 @@ class TestDecodeInsertion(unittest.TestCase):
     """Tensors sharing a Buffer get ancillary tensors sharing a Buffer."""
     model = _build_shared_buffer_model(subgraph_count=2)
 
-    ancillary_data = _make_dummy_ancillary_data()
-    compression_results = {
-        (0, 0):
-        compressor.CompressionResult(
-            encoded_data=b'\x00\x00',
-            ancillary_data=ancillary_data,
-        ),
-        (1, 0):
-        compressor.CompressionResult(
-            encoded_data=b'\x00\x00',
-            ancillary_data=ancillary_data,
-        ),
-    }
+    result = _make_dummy_compression_result()
+    compression_results = {(0, 0): result, (1, 0): result}
 
     decode_insert.insert_decode_operators(model, compression_results)
 
@@ -424,19 +421,8 @@ class TestDecodeInsertion(unittest.TestCase):
             outputs=[output_t],
         ))
 
-    ancillary_data = _make_dummy_ancillary_data()
-    compression_results = {
-        (0, 0):
-        compressor.CompressionResult(
-            encoded_data=b'\x00\x00',
-            ancillary_data=ancillary_data,
-        ),
-        (0, 1):
-        compressor.CompressionResult(
-            encoded_data=b'\x00\x00',
-            ancillary_data=ancillary_data,
-        ),
-    }
+    result = _make_dummy_compression_result()
+    compression_results = {(0, 0): result, (0, 1): result}
 
     decode_insert.insert_decode_operators(model, compression_results)
 
@@ -455,13 +441,7 @@ class TestDecodeInsertion(unittest.TestCase):
     table = sg.tensor_by_name("table")
     original_first_output = sg.outputs[0]
 
-    compression_results = {
-        (0, 0):
-        compressor.CompressionResult(
-            encoded_data=b'\x00\x00',
-            ancillary_data=_make_dummy_ancillary_data(),
-        )
-    }
+    compression_results = {(0, 0): _make_dummy_compression_result()}
 
     decode_insert.insert_decode_operators(model, compression_results)
 
@@ -490,10 +470,8 @@ class TestDecodeInsertion(unittest.TestCase):
 
     compression_results = {
         (0, 0):
-        compressor.CompressionResult(
-            encoded_data=b'\x00\x00',
-            ancillary_data=_make_dummy_ancillary_data(),
-        )
+        _make_dummy_compression_result(bitwidth=2,
+                                       value_table=b'\x01\x02\x03\x04')
     }
 
     decode_insert.insert_decode_operators(model, compression_results)
@@ -556,16 +534,8 @@ class TestDecodeInsertion(unittest.TestCase):
     sg = model.subgraphs[0]
 
     compression_results = {
-        (0, 0):
-        compressor.CompressionResult(
-            encoded_data=b'\x00\x00',
-            ancillary_data=_make_dummy_ancillary_data(),
-        ),
-        (0, 1):
-        compressor.CompressionResult(
-            encoded_data=b'\x01\x01',
-            ancillary_data=_make_dummy_ancillary_data(),
-        ),
+        (0, 0): _make_dummy_compression_result(element_count=16),
+        (0, 1): _make_dummy_compression_result(element_count=8),
     }
 
     decode_insert.insert_decode_operators(model, compression_results)
@@ -618,16 +588,8 @@ class TestDecodeInsertion(unittest.TestCase):
     sg = model.subgraphs[0]
 
     compression_results = {
-        (0, 0):
-        compressor.CompressionResult(
-            encoded_data=b'\x00\x00',
-            ancillary_data=_make_dummy_ancillary_data(),
-        ),
-        (0, 1):
-        compressor.CompressionResult(
-            encoded_data=b'\x01\x01',
-            ancillary_data=_make_dummy_ancillary_data(),
-        ),
+        (0, 0): _make_dummy_compression_result(element_count=16),
+        (0, 1): _make_dummy_compression_result(element_count=4),
     }
 
     decode_insert.insert_decode_operators(model, compression_results)
@@ -649,14 +611,9 @@ class TestDecodeInsertion(unittest.TestCase):
     """Ancillary tensor data contains valid DCM header."""
     model = _build_simple_fc_model()
 
-    ancillary_data = _make_dummy_ancillary_data()
-    compression_results = {
-        (0, 0):
-        compressor.CompressionResult(
-            encoded_data=b'\x00\x00',
-            ancillary_data=ancillary_data,
-        )
-    }
+    result = _make_dummy_compression_result(bitwidth=2,
+                                            value_table=b'\x01\x02\x03\x04')
+    compression_results = {(0, 0): result}
 
     decode_insert.insert_decode_operators(model, compression_results)
 
@@ -664,7 +621,7 @@ class TestDecodeInsertion(unittest.TestCase):
     ancillary_tensor = decode_op.inputs[1]
 
     # Ancillary tensor data should match what we provided
-    self.assertEqual(bytes(ancillary_tensor.array), ancillary_data)
+    self.assertEqual(bytes(ancillary_tensor.array), result.ancillary_data)
 
     # Verify DCM header
     dcm_bytes = bytes(ancillary_tensor.array[:16])
@@ -713,13 +670,7 @@ class TestDecodeInsertion(unittest.TestCase):
     ])
 
     # Compress the unused tensor
-    compression_results = {
-        (0, 0):
-        compressor.CompressionResult(
-            encoded_data=b'\x00\x00',
-            ancillary_data=_make_dummy_ancillary_data(),
-        )
-    }
+    compression_results = {(0, 0): _make_dummy_compression_result()}
 
     with warnings.catch_warnings(record=True) as w:
       warnings.simplefilter("always")
@@ -739,10 +690,8 @@ class TestDecodeInsertion(unittest.TestCase):
 
     compression_results = {
         (0, 0):
-        compressor.CompressionResult(
-            encoded_data=b'\x00\x00',
-            ancillary_data=_make_dummy_ancillary_data(),
-        )
+        _make_dummy_compression_result(bitwidth=2,
+                                       value_table=b'\x01\x02\x03\x04')
     }
 
     decode_insert.insert_decode_operators(model, compression_results)
@@ -764,7 +713,7 @@ class TestDecodeInsertion(unittest.TestCase):
         (0, 0):
         compressor.CompressionResult(
             encoded_data=encoded_data,
-            ancillary_data=_make_dummy_ancillary_data(),
+            ancillary_data=_make_dummy_compression_result().ancillary_data,
         )
     }
 

--- a/tensorflow/lite/micro/compression/huffman.py
+++ b/tensorflow/lite/micro/compression/huffman.py
@@ -25,7 +25,7 @@ from tflite_micro.tensorflow.lite.micro.compression import model_editor
 from tflite_micro.tensorflow.lite.micro.compression import spec
 
 
-class HuffmanCompressor:
+class HuffmanCompressor(compressor.Compressor):
   """Huffman compression plugin (stub).
 
   This stub exists to validate the plugin architecture. The actual Huffman

--- a/tensorflow/lite/micro/compression/lut.py
+++ b/tensorflow/lite/micro/compression/lut.py
@@ -241,7 +241,7 @@ def pack_lookup_tables(tables: list[np.ndarray], table_len: int) -> bytes:
   return bytes(buffer)
 
 
-class LutCompressor:
+class LutCompressor(compressor.Compressor):
   """LUT compression plugin implementing the Compressor protocol."""
 
   @property

--- a/tensorflow/lite/micro/compression/model_editor.py
+++ b/tensorflow/lite/micro/compression/model_editor.py
@@ -524,6 +524,17 @@ class Subgraph:
         return t
     raise KeyError(f"No tensor named {name!r}")
 
+  def consumers_of(self, tensor: Tensor) -> List[Operator]:
+    """Find the operators in this subgraph that read a tensor.
+
+    Args:
+      tensor: The tensor whose consumers to find.
+
+    Returns:
+      The operators, in subgraph order, with tensor among their inputs.
+    """
+    return [op for op in self.operators if tensor in op.inputs]
+
   @property
   def index(self) -> Optional[int]:
     """Subgraph index in the model's subgraph list.

--- a/tensorflow/lite/micro/compression/model_editor.py
+++ b/tensorflow/lite/micro/compression/model_editor.py
@@ -644,6 +644,32 @@ def dedupe_buffers(model: Model) -> None:
       tensor.buffer = existing
 
 
+def prune_buffers(model: Model) -> None:
+  """Drop buffers that no tensor references from model.buffers.
+
+  Rebuild the buffer list with only the conventional empty buffer 0
+  and the buffers some tensor references, renumbering indices. A model
+  built from scratch keeps an empty buffer list and the compiler emits
+  only referenced buffers, so pruning matters for models from read(),
+  whose buffer list the compiler preserves wholesale.
+
+  Args:
+      model: The model to modify in place.
+  """
+  if not model.buffers:
+    return
+  referenced = {
+      id(tensor.buffer)
+      for tensor in iter_tensors(model) if tensor.buffer is not None
+  }
+  survivors = _BufferList()
+  survivors.append(model.buffers[0])
+  for buffer in model.buffers[1:]:
+    if id(buffer) in referenced:
+      survivors.append(buffer)
+  model.buffers = survivors
+
+
 def read(buffer: bytes) -> Model:
   """Read a TFLite flatbuffer and return a Model object."""
   fb_model = tflite.ModelT.InitFromPackedBuf(buffer, 0)

--- a/tensorflow/lite/micro/compression/model_editor.py
+++ b/tensorflow/lite/micro/compression/model_editor.py
@@ -16,6 +16,7 @@
 Provides a clean API for creating, reading, and modifying TFLite models.
 """
 
+import copy
 from dataclasses import dataclass, field
 from typing import Optional, Union, List
 import numpy as np
@@ -86,6 +87,25 @@ class Quantization:
       q.quantizedDimension = self.axis
 
     return q
+
+
+def _fields_equal(a, b) -> bool:
+  """Compare two values recursively, including flatbuffer objects.
+
+  Sequences compare elementwise. Objects with fields, such as the
+  schema's flatbuffer classes, compare field by field, so fields
+  unknown to this module still participate.
+  """
+  if isinstance(a, (list, tuple, np.ndarray)) and isinstance(
+      b, (list, tuple, np.ndarray)):
+    return np.array_equal(a, b)
+  if hasattr(a, '__dict__') and hasattr(b, '__dict__'):
+    if type(a) is not type(b):
+      return False
+    keys = vars(a).keys() | vars(b).keys()
+    return all(
+        _fields_equal(getattr(a, k, None), getattr(b, k, None)) for k in keys)
+  return a == b
 
 
 class Tensor:
@@ -214,6 +234,62 @@ class Tensor:
       self.buffer = Buffer(data=buf_data)
     else:
       self.buffer.data = buf_data
+
+  def copy(self, name: Optional[str] = None) -> 'Tensor':
+    """Return a copy of this tensor, sharing this tensor's buffer.
+
+    The copy duplicates every field, including those of the backing
+    TensorT, except that it references the same Buffer object as the
+    original and has no index until added to a subgraph. Assign None
+    to the copy's buffer for a tensor with no data.
+
+    Args:
+        name: Optional name for the copy. If None, the copy keeps this
+              tensor's name.
+
+    Returns:
+        A new Tensor duplicating this one.
+    """
+    # Seed the memo so the deepcopy preserves buffer identity: sharing
+    # is by Buffer object, and a duplicate would compile to a duplicate
+    # buffer table entry.
+    memo = {id(self.buffer): self.buffer}
+    duplicate = copy.deepcopy(self, memo)
+    duplicate._index = None
+    if name is not None:
+      duplicate.name = name
+    return duplicate
+
+  def equal(self, other: 'Tensor') -> bool:
+    """Return True if this tensor equals other, field by field.
+
+    Compare the backing TensorTs recursively, so fields this module
+    does not manage still participate, plus quantization and buffer.
+    Buffers compare by identity, mirroring how the model expresses
+    sharing: tensors referencing distinct but byte-identical Buffers
+    compile to distinct buffer table entries and are not equal. The
+    tensors' positions in any subgraph do not participate.
+
+    Args:
+        other: The tensor to compare against.
+
+    Returns:
+        True if the tensors are equal.
+    """
+    if self.buffer is not other.buffer:
+      return False
+    if self.quantization != other.quantization:
+      return False
+    # Exclude the TensorT fields mirrored by the wrapper attributes
+    # compared above: buffer, an index assigned at build time, and
+    # quantization, which build() syncs from the wrapper attribute.
+    # Comparing the raw fields too would misreport tensors of mixed
+    # provenance, read versus constructed.
+    excluded = ('buffer', 'quantization')
+    keys = vars(self._fb).keys() | vars(other._fb).keys()
+    return all(
+        _fields_equal(getattr(self._fb, k, None), getattr(other._fb, k, None))
+        for k in keys if k not in excluded)
 
   @property
   def index(self) -> Optional[int]:

--- a/tensorflow/lite/micro/compression/model_editor.py
+++ b/tensorflow/lite/micro/compression/model_editor.py
@@ -597,6 +597,53 @@ class Model:
     return compiler.compile()
 
 
+def iter_tensors(model: Model):
+  """Yield every tensor in the model exactly once.
+
+  Walk the same sources the compiler collects from: each subgraph's
+  tensor list, inputs, outputs, and the tensors inline on operators.
+
+  Args:
+      model: The model whose tensors to yield.
+
+  Yields:
+      Each distinct Tensor in the model.
+  """
+  seen = set()
+  for sg in model.subgraphs:
+    sources = [sg.tensors, sg.inputs, sg.outputs]
+    sources.extend(op.inputs for op in sg.operators)
+    sources.extend(op.outputs for op in sg.operators)
+    for source in sources:
+      for tensor in source:
+        if id(tensor) not in seen:
+          seen.add(id(tensor))
+          yield tensor
+
+
+def dedupe_buffers(model: Model) -> None:
+  """Merge byte-identical buffers into one shared Buffer.
+
+  Repoint tensors whose buffers hold equal contents at a single
+  canonical Buffer object, the first encountered, mirroring the TfLite
+  converter's deduplication of identical constants. Leave tensors
+  marked is_variable alone: mutable data must not alias. Merged-away
+  buffers linger in model.buffers until pruned.
+
+  Args:
+      model: The model to modify in place.
+  """
+  canonical: dict[bytes, Buffer] = {}
+  for tensor in iter_tensors(model):
+    if tensor.buffer is None or tensor._fb.isVariable:
+      continue
+    existing = canonical.get(tensor.buffer.data)
+    if existing is None:
+      canonical[tensor.buffer.data] = tensor.buffer
+    else:
+      tensor.buffer = existing
+
+
 def read(buffer: bytes) -> Model:
   """Read a TFLite flatbuffer and return a Model object."""
   fb_model = tflite.ModelT.InitFromPackedBuf(buffer, 0)

--- a/tensorflow/lite/micro/compression/model_editor_test.py
+++ b/tensorflow/lite/micro/compression/model_editor_test.py
@@ -993,6 +993,79 @@ class TestDedupeBuffers(unittest.TestCase):
     self.assertIs(inline.buffer, listed.buffer)
 
 
+class TestPruneBuffers(unittest.TestCase):
+  """Tests for prune_buffers()."""
+
+  @staticmethod
+  def _read_model_with_two_constants(metadata=None):
+    c1 = Tensor(
+        shape=(4, ),
+        dtype=tflite.TensorType.INT8,
+        data=np.array([1, 2, 3, 4], dtype=np.int8),
+        name="c1",
+    )
+    c2 = Tensor(
+        shape=(4, ),
+        dtype=tflite.TensorType.INT8,
+        data=np.array([5, 6, 7, 8], dtype=np.int8),
+        name="c2",
+    )
+    scratch = Model(subgraphs=[Subgraph(tensors=[c1, c2])], metadata=metadata)
+    return model_editor.read(bytes(scratch.build()))
+
+  def test_drops_unreferenced_buffers(self):
+    """Orphaned buffers vanish; surviving data and indices stay right."""
+    model = self._read_model_with_two_constants()
+    self.assertEqual(len(model.buffers), 3)
+    sg = model.subgraphs[0]
+
+    # Orphan c1's buffer by repointing the tensor at c2's. The
+    # surviving buffer then changes position, exercising renumbering.
+    sg.tensor_by_name("c1").buffer = sg.tensor_by_name("c2").buffer
+
+    model_editor.prune_buffers(model)
+
+    self.assertEqual(len(model.buffers), 2)
+    roundtrip = model_editor.read(bytes(model.build()))
+    rt_sg = roundtrip.subgraphs[0]
+    np.testing.assert_array_equal(
+        rt_sg.tensor_by_name("c1").array, [5, 6, 7, 8])
+    np.testing.assert_array_equal(
+        rt_sg.tensor_by_name("c2").array, [5, 6, 7, 8])
+
+  def test_keeps_referenced_buffers(self):
+    """With every buffer referenced, pruning removes nothing."""
+    model = self._read_model_with_two_constants()
+    count_before = len(model.buffers)
+
+    model_editor.prune_buffers(model)
+
+    self.assertEqual(len(model.buffers), count_before)
+
+  def test_metadata_survives_pruning(self):
+    """Metadata, carried outside tensor buffers, is unaffected."""
+    model = self._read_model_with_two_constants(metadata={"m": b"payload"})
+
+    model_editor.prune_buffers(model)
+
+    roundtrip = model_editor.read(bytes(model.build()))
+    self.assertEqual(roundtrip.metadata["m"], b"payload")
+
+  def test_noop_on_scratch_model(self):
+    """A from-scratch model has no buffer list to prune."""
+    c1 = Tensor(shape=(4, ),
+                dtype=tflite.TensorType.INT8,
+                data=np.array([1, 2, 3, 4], dtype=np.int8),
+                name="c1")
+    model = Model(subgraphs=[Subgraph(tensors=[c1])])
+
+    model_editor.prune_buffers(model)
+
+    roundtrip = model_editor.read(bytes(model.build()))
+    np.testing.assert_array_equal(
+        roundtrip.subgraphs[0].tensor_by_name("c1").array, [1, 2, 3, 4])
+
+
 class TestReadEdgeCases(unittest.TestCase):
   """Test model_editor.read() with edge cases from real-world models.
 

--- a/tensorflow/lite/micro/compression/model_editor_test.py
+++ b/tensorflow/lite/micro/compression/model_editor_test.py
@@ -925,6 +925,74 @@ class TestTensorEqual(unittest.TestCase):
     self.assertTrue(t1.equal(t2))
 
 
+class TestDedupeBuffers(unittest.TestCase):
+  """Tests for dedupe_buffers()."""
+
+  @staticmethod
+  def _constant(name, values):
+    return Tensor(
+        shape=(4, ),
+        dtype=tflite.TensorType.INT8,
+        data=np.array(values, dtype=np.int8),
+        name=name,
+    )
+
+  def test_merges_identical_buffers_across_subgraphs(self):
+    """Byte-identical buffers converge on one canonical Buffer."""
+    c1 = self._constant("c1", [1, 2, 3, 4])
+    c2 = self._constant("c2", [1, 2, 3, 4])
+    model = Model(subgraphs=[
+        Subgraph(tensors=[c1]),
+        Subgraph(tensors=[c2]),
+    ])
+    self.assertIsNot(c1.buffer, c2.buffer)
+
+    model_editor.dedupe_buffers(model)
+
+    self.assertIs(c2.buffer, c1.buffer)
+
+    # The compiled model carries one buffer for both tensors, plus the
+    # conventional empty buffer 0
+    fb_model = tflite.ModelT.InitFromPackedBuf(bytes(model.build()), 0)
+    self.assertEqual(len(fb_model.buffers), 2)
+
+  def test_leaves_distinct_and_variable_buffers(self):
+    """Differing contents never merge; variable tensors never alias."""
+    c1 = self._constant("c1", [1, 2, 3, 4])
+    c2 = self._constant("c2", [5, 6, 7, 8])
+    variable = self._constant("v", [1, 2, 3, 4])
+    variable._fb.isVariable = True
+    model = Model(subgraphs=[Subgraph(tensors=[c1, c2, variable])])
+
+    model_editor.dedupe_buffers(model)
+
+    self.assertIsNot(c2.buffer, c1.buffer)
+    self.assertIsNot(variable.buffer, c1.buffer)
+
+  def test_reaches_inline_tensors(self):
+    """Tensors on operators, absent from the tensor list, participate."""
+    listed = self._constant("listed", [1, 2, 3, 4])
+    inline = self._constant("inline", [1, 2, 3, 4])
+    output_t = Tensor(shape=(4, ), dtype=tflite.TensorType.INT8, name="out")
+    model = Model(subgraphs=[
+        Subgraph(
+            tensors=[listed],
+            operators=[
+                Operator(
+                    opcode=tflite.BuiltinOperator.ADD,
+                    inputs=[listed, inline],
+                    outputs=[output_t],
+                )
+            ],
+            outputs=[output_t],
+        )
+    ])
+
+    model_editor.dedupe_buffers(model)
+
+    self.assertIs(inline.buffer, listed.buffer)
+
+
 class TestReadEdgeCases(unittest.TestCase):
   """Test model_editor.read() with edge cases from real-world models.
 

--- a/tensorflow/lite/micro/compression/model_editor_test.py
+++ b/tensorflow/lite/micro/compression/model_editor_test.py
@@ -828,6 +828,103 @@ class TestSubgraphInputsOutputs(unittest.TestCase):
       model.subgraphs[0].tensor_by_name("nonexistent")
 
 
+class TestTensorCopy(unittest.TestCase):
+  """Tests for Tensor.copy()."""
+
+  def _original(self):
+    return Tensor(
+        shape=(2, 2),
+        dtype=tflite.TensorType.INT8,
+        data=np.array([[1, 2], [3, 4]], dtype=np.int8),
+        name="original",
+        quantization=model_editor.Quantization(scales=0.5, zero_points=0),
+    )
+
+  def test_copy_shares_buffer(self):
+    """The copy references the same Buffer object as the original."""
+    original = self._original()
+    duplicate = original.copy()
+
+    self.assertIsNot(duplicate, original)
+    self.assertIs(duplicate.buffer, original.buffer)
+
+  def test_copy_is_independent(self):
+    """Mutating the copy leaves the original untouched."""
+    original = self._original()
+    duplicate = original.copy(name="duplicate")
+    self.assertEqual(duplicate.quantization, original.quantization)
+
+    duplicate.shape = (4, )
+    duplicate.dtype = tflite.TensorType.UINT8
+    duplicate.quantization.scales = 2.0
+
+    self.assertEqual(duplicate.name, "duplicate")
+    self.assertEqual(original.name, "original")
+    self.assertEqual(original.shape, (2, 2))
+    self.assertEqual(original.dtype, tflite.TensorType.INT8)
+    self.assertEqual(original.quantization.scales, 0.5)
+
+
+class TestTensorEqual(unittest.TestCase):
+  """Tests for Tensor.equal()."""
+
+  def _original(self):
+    return Tensor(
+        shape=(2, 2),
+        dtype=tflite.TensorType.INT8,
+        data=np.array([[1, 2], [3, 4]], dtype=np.int8),
+        name="original",
+        quantization=model_editor.Quantization(scales=0.5, zero_points=0),
+    )
+
+  def test_copy_equals_original(self):
+    """A copy sharing the original's buffer compares equal."""
+    original = self._original()
+    self.assertTrue(original.copy().equal(original))
+
+  def test_any_field_differing_is_unequal(self):
+    """A difference in any field, wrapper-managed or not, is unequal."""
+    original = self._original()
+
+    renamed = original.copy(name="renamed")
+    self.assertFalse(renamed.equal(original))
+
+    requantized = original.copy()
+    requantized.quantization.scales = 2.0
+    self.assertFalse(requantized.equal(original))
+
+    dataless = original.copy()
+    dataless.buffer = None
+    self.assertFalse(dataless.equal(original))
+
+    # Buffers compare by identity: equal bytes in a distinct Buffer
+    # still make a structurally different model
+    rebuffered = original.copy()
+    rebuffered.buffer = model_editor.Buffer(data=original.buffer.data)
+    self.assertFalse(rebuffered.equal(original))
+
+    variable = original.copy()
+    variable._fb.isVariable = True
+    self.assertFalse(variable.equal(original))
+
+  def test_backing_quantization_details_excluded(self):
+    """Quantization held only by the backing TensorT does not
+    participate.
+
+    equal() compares quantization at the wrapper level, where scale,
+    zero point, and axis live; min, max, and details carried only by
+    the backing TensorT are excluded by design.
+    """
+    scratch = Model(subgraphs=[Subgraph(tensors=[self._original()])])
+    fb = bytes(scratch.build())
+    t1 = model_editor.read(fb).subgraphs[0].tensor_by_name("original")
+
+    t2 = t1.copy()
+    t2._fb.quantization.min = [-1.0]
+
+    self.assertTrue(t1.equal(t2))
+
+
 class TestReadEdgeCases(unittest.TestCase):
   """Test model_editor.read() with edge cases from real-world models.
 
@@ -1110,6 +1207,25 @@ class TestFieldPreservation(unittest.TestCase):
     # Verify field preserved
     model_t2 = tflite.ModelT.InitFromPackedBuf(fb2, 0)
     self.assertTrue(model_t2.subgraphs[0].tensors[0].isVariable)
+
+  def test_tensor_copy_preserves_fields(self):
+    """Verify Tensor.copy() preserves fields model_editor doesn't manage."""
+    model_t = self._create_base_model()
+    model_t.subgraphs[0].tensors[0].isVariable = True
+
+    fb = self._build_model_with_schema(model_t)
+
+    model = model_editor.read(fb)
+    sg = model.subgraphs[0]
+    duplicate = sg.tensors[0].copy(name="copy")
+    sg.tensors.append(duplicate)
+    fb2 = model.build()
+
+    model_t2 = tflite.ModelT.InitFromPackedBuf(fb2, 0)
+    tensors = model_t2.subgraphs[0].tensors
+    self.assertEqual(tensors[-1].name, b"copy")
+    self.assertTrue(tensors[-1].isVariable)
+    self.assertEqual(tensors[-1].buffer, tensors[0].buffer)
 
   def test_tensor_shape_signature_preserved(self):
     """Verify Tensor.shapeSignature is preserved through read-modify-write."""

--- a/tensorflow/lite/micro/compression/model_editor_test.py
+++ b/tensorflow/lite/micro/compression/model_editor_test.py
@@ -827,6 +827,46 @@ class TestSubgraphInputsOutputs(unittest.TestCase):
     with self.assertRaises(KeyError):
       model.subgraphs[0].tensor_by_name("nonexistent")
 
+  def test_consumers_of(self):
+    """consumers_of finds the operators reading a tensor, in order."""
+    shared = Tensor(
+        shape=(4, 4),
+        dtype=tflite.TensorType.INT8,
+        data=np.ones((4, 4), dtype=np.int8),
+        name="shared",
+    )
+    input1 = Tensor(shape=(1, 4), dtype=tflite.TensorType.INT8, name="input1")
+    input2 = Tensor(shape=(1, 4), dtype=tflite.TensorType.INT8, name="input2")
+    output1 = Tensor(shape=(1, 4),
+                     dtype=tflite.TensorType.INT8,
+                     name="output1")
+    output2 = Tensor(shape=(1, 4),
+                     dtype=tflite.TensorType.INT8,
+                     name="output2")
+
+    fc1 = Operator(
+        opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+        inputs=[input1, shared],
+        outputs=[output1],
+    )
+    only_produces = Operator(
+        opcode=tflite.BuiltinOperator.RESHAPE,
+        inputs=[output1],
+        outputs=[output2],
+    )
+    fc2 = Operator(
+        opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+        inputs=[output2, shared],
+        outputs=[Tensor(shape=(1, 4), dtype=tflite.TensorType.INT8)],
+    )
+    sg = Subgraph(tensors=[shared],
+                  operators=[fc1, only_produces, fc2],
+                  inputs=[input1, input2])
+
+    self.assertEqual(sg.consumers_of(shared), [fc1, fc2])
+    self.assertEqual(sg.consumers_of(input1), [fc1])
+    self.assertEqual(sg.consumers_of(input2), [])
+
 
 class TestTensorCopy(unittest.TestCase):
   """Tests for Tensor.copy()."""

--- a/tensorflow/lite/micro/compression/proprietary_integration_test.py
+++ b/tensorflow/lite/micro/compression/proprietary_integration_test.py
@@ -1,0 +1,211 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration tests for compression using proprietary models.
+
+These tests verify that compressed models produce correct inference results
+when run through the TFLM Python interpreter. Tests compress models and
+compare outputs against uncompressed originals using random inputs.
+
+This test is tagged `manual` and requires a path to a directory containing
+.tflite model files.
+
+Usage:
+    bazel test //tensorflow/lite/micro/compression:proprietary_integration_test \
+        --//:with_compression \
+        --test_arg=/path/to/models
+
+Required files:
+    Each model requires a compression spec file:
+        model.spec.yaml  (replacing .tflite extension)
+
+    See spec.py for the YAML format. Example:
+        tensors:
+          - subgraph: 0
+            tensor: 2
+            compression:
+              - lut:
+                  index_bitwidth: 4
+
+Optional files:
+    model.config.json  (replacing .tflite extension)
+        Tolerance overrides: {"rtol": 1e-5, "atol": 1e-6}
+        Default is exact match (rtol=0, atol=0).
+"""
+
+import glob
+import json
+import os
+import sys
+import unittest
+
+import numpy as np
+
+from tflite_micro.python.tflite_micro import runtime
+from tflite_micro.tensorflow.lite.micro.compression import compress
+from tflite_micro.tensorflow.lite.micro.compression import model_editor
+from tflite_micro.tensorflow.lite.micro.compression import spec
+from tflite_micro.tensorflow.lite.python import schema_py_generated as tflite
+
+
+def _dtype_to_numpy(dtype: tflite.TensorType) -> np.dtype:
+  """Convert TFLite dtype to numpy dtype."""
+  type_map = {
+      tflite.TensorType.INT8: np.int8,
+      tflite.TensorType.INT16: np.int16,
+      tflite.TensorType.INT32: np.int32,
+      tflite.TensorType.INT64: np.int64,
+      tflite.TensorType.UINT8: np.uint8,
+      tflite.TensorType.UINT16: np.uint16,
+      tflite.TensorType.UINT32: np.uint32,
+      tflite.TensorType.FLOAT16: np.float16,
+      tflite.TensorType.FLOAT32: np.float32,
+      tflite.TensorType.FLOAT64: np.float64,
+      tflite.TensorType.BOOL: np.bool_,
+  }
+  return type_map.get(dtype, np.uint8)
+
+
+class ProprietaryModelTest(unittest.TestCase):
+  """Integration tests using proprietary models."""
+
+  # Parsed from command line in main()
+  models_dir = None
+
+  @classmethod
+  def setUpClass(cls):
+    if not cls.models_dir:
+      raise unittest.SkipTest(
+          "No models directory provided. "
+          "Usage: bazel test ... --test_arg=/path/to/models")
+
+    cls.model_paths = sorted(
+        glob.glob(os.path.join(cls.models_dir, '*.tflite')))
+    if not cls.model_paths:
+      raise unittest.SkipTest(f"No .tflite files found in {cls.models_dir}")
+
+  def test_all_models(self):
+    """Run compression test on each discovered model."""
+    for model_path in self.model_paths:
+      with self.subTest(model=os.path.basename(model_path)):
+        self._test_model_compression(model_path)
+
+  def _test_model_compression(self, model_path):
+    """Test that a compressed model produces same outputs as original."""
+    with open(model_path, 'rb') as f:
+      flatbuffer = f.read()
+
+    # Load compression spec from sidecar file
+    specs = self._load_compression_spec(model_path)
+
+    # Load tolerance config
+    rtol, atol = self._load_tolerance(model_path)
+
+    # Compress the model
+    compressed_fb = compress.compress(flatbuffer, specs)
+
+    # Create interpreters
+    original_interp = runtime.Interpreter.from_bytes(bytes(flatbuffer))
+    compressed_interp = runtime.Interpreter.from_bytes(bytes(compressed_fb))
+
+    # Generate random inputs and compare outputs
+    np.random.seed(42)
+    model = model_editor.read(flatbuffer)
+    sg = model.subgraphs[0]
+
+    for trial in range(5):
+      # Set inputs
+      for i, input_tensor in enumerate(sg.inputs):
+        test_input = self._generate_input(input_tensor)
+        original_interp.set_input(test_input, i)
+        compressed_interp.set_input(test_input, i)
+
+      # Run inference
+      original_interp.invoke()
+      compressed_interp.invoke()
+
+      # Compare outputs
+      for i in range(len(sg.outputs)):
+        expected = original_interp.get_output(i)
+        actual = compressed_interp.get_output(i)
+        self._compare_outputs(expected, actual, rtol, atol,
+                              f"trial {trial}, output {i}")
+
+  def _generate_input(self, tensor):
+    """Generate random input respecting tensor dtype."""
+    shape = tensor.shape
+    dtype = _dtype_to_numpy(tensor.dtype)
+
+    if np.issubdtype(dtype, np.floating):
+      return np.random.uniform(-1.0, 1.0, shape).astype(dtype)
+    elif np.issubdtype(dtype, np.integer):
+      info = np.iinfo(dtype)
+      return np.random.randint(info.min, info.max + 1, shape, dtype=dtype)
+    elif dtype == np.bool_:
+      return np.random.choice([False, True], shape)
+    return np.zeros(shape, dtype=dtype)
+
+  def _load_compression_spec(self, model_path):
+    """Load compression spec from sidecar YAML file.
+
+    Raises:
+      FileNotFoundError: If no spec file is found.
+    """
+    spec_path = model_path.replace('.tflite', '.spec.yaml')
+    if os.path.exists(spec_path):
+      with open(spec_path) as f:
+        return spec.parse_yaml(f.read())
+
+    raise FileNotFoundError(
+        f"No compression spec file found for {model_path}. "
+        f"Expected: {spec_path}")
+
+  def _load_tolerance(self, model_path):
+    """Load tolerance from sidecar config if present.
+
+    Returns (0, 0) for exact match if no config file exists.
+    """
+    config_path = model_path.replace('.tflite', '.config.json')
+    if os.path.exists(config_path):
+      with open(config_path) as f:
+        config = json.load(f)
+      return config.get('rtol', 0), config.get('atol', 0)
+    return 0, 0
+
+  def _compare_outputs(self, expected, actual, rtol, atol, context=""):
+    """Compare outputs with optional tolerance."""
+    msg = f"Output mismatch ({context})" if context else "Output mismatch"
+    if rtol == 0 and atol == 0:
+      np.testing.assert_array_equal(expected, actual, err_msg=msg)
+    else:
+      np.testing.assert_allclose(expected,
+                                 actual,
+                                 rtol=rtol,
+                                 atol=atol,
+                                 err_msg=msg)
+
+
+if __name__ == "__main__":
+  # Suppress TF C++ info/debug logs (0=DEBUG, 1=INFO, 2=WARNING, 3=ERROR)
+  os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
+  # Disable oneDNN to avoid non-deterministic floating point results
+  os.environ["TF_ENABLE_ONEDNN_OPTS"] = "0"
+
+  # Parse models directory from args, then strip it so tf.test doesn't see it
+  for arg in sys.argv[1:]:
+    if not arg.startswith('-') and os.path.isdir(arg):
+      ProprietaryModelTest.models_dir = arg
+      sys.argv.remove(arg)
+      break
+
+  unittest.main()

--- a/tensorflow/lite/micro/compression/pruning.py
+++ b/tensorflow/lite/micro/compression/pruning.py
@@ -25,7 +25,7 @@ from tflite_micro.tensorflow.lite.micro.compression import model_editor
 from tflite_micro.tensorflow.lite.micro.compression import spec
 
 
-class PruningCompressor:
+class PruningCompressor(compressor.Compressor):
   """Pruning compression plugin (stub).
 
   This stub exists to validate the plugin architecture. The actual pruning


### PR DESCRIPTION
This is a draft PR for running CI, review, and seeing the commits in
context. The commits along this branch will be individually submitted
for merge.

This replaces #3400, whose branch had fallen far behind main. Rather
than rebase, the tooling was rebuilt fresh on current main,
commit-by-commit, with tf-free tests that build fixtures via
model_editor instead of TensorFlow.

The first commit is the tflm_py_* shim-wrapper change submitted
separately as #3573; the remaining commits are the DECODE tooling.

See the linked issue for a description of the change.

BUG=implements #3256