### PR TITLE
docs: update deprecated Silabs repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Arduino         | [![Arduino](https://github.com/tensorflow/tflite-micro-arduino
 Espressif Systems Dev Boards  | [![ESP Dev Boards](https://github.com/espressif/tflite-micro-esp-examples/actions/workflows/ci.yml/badge.svg)](https://github.com/espressif/tflite-micro-esp-examples/actions/workflows/ci.yml) |
 Ingenic MIPS Boards | [![Ingenic MIPS Boards](https://github.com/yinzara/ingenic-tflite-micro/actions/workflows/ci.yml/badge.svg)](https://github.com/yinzara/ingenic-tflite-micro/tree/main/examples/hello_world) |
 Renesas Boards | [TFLM Examples for Renesas Boards](https://github.com/renesas/tflite-micro-renesas) |
-Silicon Labs Dev Kits        | [TFLM Examples for Silicon Labs Dev Kits](https://github.com/SiliconLabs/tflite-micro-efr32-examples)
+Silicon Labs Dev Kits | [TFLM Examples for Silicon Labs Dev Kits](https://github.com/SiliconLabsSoftware/machine_learning_applications/)
 Sparkfun Edge   | [![Sparkfun Edge](https://github.com/advaitjain/tflite-micro-sparkfun-edge-examples/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/advaitjain/tflite-micro-sparkfun-edge-examples/actions/workflows/ci.yml)
 Texas Instruments Dev Boards | [![Texas Instruments Dev Boards](https://github.com/TexasInstruments/tensorflow-lite-micro-examples/actions/workflows/ci.yml/badge.svg?event=status)](https://github.com/TexasInstruments/tensorflow-lite-micro-examples/actions/workflows/ci.yml)
 


### PR DESCRIPTION
Fixes #3556

This updates the deprecated Silicon Labs repository link in the README to the new active repository provided by the maintainers.
BUG=none