### PR TITLE
fix: prevent integer overflow in tensor byte-size calculations

### DIFF
--- a/tensorflow/lite/micro/memory_helpers.cc
+++ b/tensorflow/lite/micro/memory_helpers.cc
@@ -106,12 +106,23 @@ TfLiteStatus TfLiteTypeSizeOf(TfLiteType type, size_t* size) {
 
 TfLiteStatus BytesRequiredForTensor(const tflite::Tensor& flatbuffer_tensor,
                                     size_t* bytes, size_t* type_size) {
-  int element_count = 1;
+  // Use size_t to avoid signed integer overflow. Validate each multiplication
+  // to reject malformed models with dimensions that would wrap around.
+  size_t element_count = 1;
   // If flatbuffer_tensor.shape == nullptr, then flatbuffer_tensor is a scalar
   // so has 1 element.
   if (flatbuffer_tensor.shape() != nullptr) {
     for (size_t n = 0; n < flatbuffer_tensor.shape()->size(); ++n) {
-      element_count *= flatbuffer_tensor.shape()->Get(n);
+      int32_t dim = flatbuffer_tensor.shape()->Get(n);
+      if (dim <= 0) {
+        return kTfLiteError;
+      }
+      size_t dim_u = static_cast<size_t>(dim);
+      // Check for multiplication overflow before multiplying.
+      if (element_count != 0 && dim_u > SIZE_MAX / element_count) {
+        return kTfLiteError;
+      }
+      element_count *= dim_u;
     }
   }
 
@@ -119,6 +130,10 @@ TfLiteStatus BytesRequiredForTensor(const tflite::Tensor& flatbuffer_tensor,
   TF_LITE_ENSURE_STATUS(
       ConvertTensorType(flatbuffer_tensor.type(), &tf_lite_type));
   TF_LITE_ENSURE_STATUS(TfLiteTypeSizeOf(tf_lite_type, type_size));
+  // Check for overflow in final multiplication: element_count * type_size.
+  if (element_count != 0 && *type_size > SIZE_MAX / element_count) {
+    return kTfLiteError;
+  }
   *bytes = element_count * (*type_size);
   return kTfLiteOk;
 }
@@ -127,15 +142,27 @@ TfLiteStatus TfLiteEvalTensorByteLength(const TfLiteEvalTensor* eval_tensor,
                                         size_t* out_bytes) {
   TFLITE_DCHECK(out_bytes != nullptr);
 
-  int element_count = 1;
+  // Use size_t to avoid signed integer overflow on untrusted dimension data.
+  size_t element_count = 1;
   // If eval_tensor->dims == nullptr, then tensor is a scalar so has 1 element.
   if (eval_tensor->dims != nullptr) {
     for (int n = 0; n < eval_tensor->dims->size; ++n) {
-      element_count *= eval_tensor->dims->data[n];
+      int32_t dim = eval_tensor->dims->data[n];
+      if (dim <= 0) {
+        return kTfLiteError;
+      }
+      size_t dim_u = static_cast<size_t>(dim);
+      if (element_count != 0 && dim_u > SIZE_MAX / element_count) {
+        return kTfLiteError;
+      }
+      element_count *= dim_u;
     }
   }
   size_t type_size;
   TF_LITE_ENSURE_STATUS(TfLiteTypeSizeOf(eval_tensor->type, &type_size));
+  if (element_count != 0 && type_size > SIZE_MAX / element_count) {
+    return kTfLiteError;
+  }
   *out_bytes = element_count * type_size;
   return kTfLiteOk;
 }
@@ -155,7 +182,16 @@ TfLiteStatus AllocateOutputDimensionsFromInput(TfLiteContext* context,
   TfLiteTypeSizeOf(input->type, &size);
   const int dimensions_count = tflite::GetTensorShape(input).DimensionsCount();
   for (int i = 0; i < dimensions_count; i++) {
-    size *= input->dims->data[i];
+    int32_t dim = input->dims->data[i];
+    if (dim <= 0) {
+      return kTfLiteError;
+    }
+    size_t dim_u = static_cast<size_t>(dim);
+    // Check for overflow before multiplying.
+    if (size != 0 && dim_u > SIZE_MAX / size) {
+      return kTfLiteError;
+    }
+    size *= dim_u;
   }
   output->bytes = size;
 
@@ -170,3 +206,4 @@ TfLiteStatus AllocateOutputDimensionsFromInput(TfLiteContext* context,
 }
 
 }  // namespace tflite
+


### PR DESCRIPTION
## Summary

Fix signed integer overflow in `BytesRequiredForTensor`, `TfLiteEvalTensorByteLength`, and `AllocateOutputDimensionsFromInput` that leads to heap out-of-bounds read/write when loading untrusted models.

## Vulnerability (#3552)

All three functions compute a running product of tensor dimensions using signed `int` arithmetic. A model with shape `[65536, 65536]` over `float32` requires 2^34 bytes (17 GiB), but the signed `int` product wraps to `0`. This causes a 0-byte allocation while the tensor metadata holds the original dimensions, leading to heap OOB read/write during kernel execution.

## Fix

- Switch running product from `int` to `size_t`
- Add checked multiplication (`SIZE_MAX / x`) before each multiply
- Reject dimensions `<= 0`
- Return `kTfLiteError` on overflow instead of silently wrapping

All three vulnerable functions in `memory_helpers.cc` are fixed with the same pattern.

BUG=#3552