### PR TITLE
Validate tensor rank in CIRCULAR_BUFFER Prepare to prevent out-of-bounds read

### DIFF
--- a/tensorflow/lite/micro/kernels/circular_buffer_common.cc
+++ b/tensorflow/lite/micro/kernels/circular_buffer_common.cc
@@ -49,6 +49,10 @@ TfLiteStatus CircularBufferPrepare(TfLiteContext* context, TfLiteNode* node) {
 
   TF_LITE_ENSURE(context, input != nullptr);
   TF_LITE_ENSURE(context, output != nullptr);
+  // The kernel indexes dims->data[0..3] below; ensure both tensors are rank-4
+  // before any access to avoid an out-of-bounds read on malformed models.
+  TF_LITE_ENSURE_EQ(context, NumDimensions(input), 4);
+  TF_LITE_ENSURE_EQ(context, NumDimensions(output), 4);
   TF_LITE_ENSURE_EQ(context, input->dims->data[0], output->dims->data[0]);
   TF_LITE_ENSURE_EQ(context, 1, input->dims->data[1]);
   TF_LITE_ENSURE_EQ(context, input->dims->data[2], output->dims->data[2]);

--- a/tensorflow/lite/micro/kernels/circular_buffer_common.cc
+++ b/tensorflow/lite/micro/kernels/circular_buffer_common.cc
@@ -51,8 +51,8 @@ TfLiteStatus CircularBufferPrepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE(context, output != nullptr);
   // The kernel indexes dims->data[0..3] below; ensure both tensors are rank-4
   // before any access to avoid an out-of-bounds read on malformed models.
-  TF_LITE_ENSURE_EQ(context, NumDimensions(input), 4);
-  TF_LITE_ENSURE_EQ(context, NumDimensions(output), 4);
+  TF_LITE_ENSURE(context,
+                 NumDimensions(input) == 4 && NumDimensions(output) == 4);
   TF_LITE_ENSURE_EQ(context, input->dims->data[0], output->dims->data[0]);
   TF_LITE_ENSURE_EQ(context, 1, input->dims->data[1]);
   TF_LITE_ENSURE_EQ(context, input->dims->data[2], output->dims->data[2]);


### PR DESCRIPTION
### Problem
CircularBufferPrepare in circular_buffer_common.cc reads input/output dims->data[0] through dims->data[3] without validating the tensors are rank-4. TfLiteIntArray stores dims as a flexible-array member (int data[]) sized to exactly `size` ints, so on a rank<4 tensor, dims->data[3] reads past the end — an out-of-bounds read. The same assumption is in the cycles_max <= 0 branch and the eval path in circular_buffer.cc.

Sibling kernels already guard this way (depth_to_space.cc, batch_to_space_nd.cc, broadcast_to.cc, concatenation.cc, cumsum.cc) via NumDimensions(). This brings CIRCULAR_BUFFER in line.

### Fix
Add NumDimensions(input)==4 and NumDimensions(output)==4 checks before any dims->data[..] access. No new include needed (kernel_util.h already included).

### Refs
Reported via GitHub Security Advisory GHSA-3x72-x298-9pjx and Google OSS VRP issue 523561915.

BUG=523561915

Signed-off-by: Biswajeet Ray <raybiswajeet2@gmail.com>