### PR TITLE
docs: fix trailing whitespace in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,4 @@ The following resources may also be useful:
 1. [Pre-allocated tensors](tensorflow/lite/micro/docs/rfc/001_preallocated_tensors.md)
 1. [TensorFlow Lite for Microcontrollers Port of 16x8 Quantized Operators](tensorflow/lite/micro/docs/rfc/002_16x8_quantization_port.md)
 
+# 

--- a/README.md
+++ b/README.md
@@ -96,3 +96,4 @@ The following resources may also be useful:
 
 1. [Pre-allocated tensors](tensorflow/lite/micro/docs/rfc/001_preallocated_tensors.md)
 1. [TensorFlow Lite for Microcontrollers Port of 16x8 Quantized Operators](tensorflow/lite/micro/docs/rfc/002_16x8_quantization_port.md)
+


### PR DESCRIPTION
BUG=n/a\nMinor whitespace cleanup.