### PR TITLE
Fix missing quantizedBiasType setting for 16x8 requantization

### DIFF
--- a/tensorflow/lite/micro/tools/requantize_flatbuffer_utils.py
+++ b/tensorflow/lite/micro/tools/requantize_flatbuffer_utils.py
@@ -264,6 +264,8 @@ def requantize_fully_connected(tensors, buffers, op):
     bias_tensor = tensors[op.inputs[2]]
     set_bias_type_int64(buffers, input_tensor, weight_tensor, bias_tensor)
 
+  op.builtinOptions.quantizedBiasType = TENSOR_TYPE_CODE[np.int64]
+
 
 def requantize_unidirectional_sequence_lstm(tensors, buffers, op):
   """Requantize the unidirectonal sequance lstm op from int8 to int16 """
@@ -323,3 +325,5 @@ def requantize_transpose_conv(tensors, buffers, op):
     if op.inputs[3] != -1:
       bias_tensor = tensors[op.inputs[3]]
       set_bias_type_int64(buffers, input_tensor, weight_tensor, bias_tensor)
+
+  op.builtinOptions.quantizedBiasType = TENSOR_TYPE_CODE[np.int64]


### PR DESCRIPTION
When a model is compiled without explicit bias tensors, `requantize_flatbuffer_utils` previously skipped the bias upgrade logic entirely. As a result, the `quantizedBiasType` hint in the operator's options was not updated. This caused TFLM to fall back to a 32-bit accumulator for these layers, which overflows.

This change explicitly injects `op.builtinOptions.quantizedBiasType` = int64 directly into the operator options for supported operators, fixing precision loss for bias-less layers running 16x8 kernels.

BUG=n/a