### PR TITLE
Ensure int64 accumulation for bias-less 16x8 ops

### DIFF
--- a/tensorflow/lite/micro/kernels/cmsis_nn/conv.cc
+++ b/tensorflow/lite/micro/kernels/cmsis_nn/conv.cc
@@ -392,7 +392,7 @@ TfLiteStatus EvalInt16x8(TfLiteContext* context, TfLiteNode* node) {
   }
   const bool requires_int32_accum =
       (bias != nullptr && bias->type == kTfLiteInt32) ||
-      (bias == nullptr && params.quantized_bias_type != kTfLiteInt64);
+      (bias == nullptr && params.quantized_bias_type == kTfLiteInt32);
   if (requires_int32_accum) {
     return EvalQuantizedPerChannel<int16_t, int32_t, kTfLiteInt16>(
         context, node, params, data, input, filter, bias, output);

--- a/tensorflow/lite/micro/kernels/conv.cc
+++ b/tensorflow/lite/micro/kernels/conv.cc
@@ -88,7 +88,7 @@ TfLiteStatus ConvEval(TfLiteContext* context, TfLiteNode* node) {
       }
       const bool requires_int32_accum =
           (bias != nullptr && bias->type == kTfLiteInt32) ||
-          (bias == nullptr && params.quantized_bias_type != kTfLiteInt64);
+          (bias == nullptr && params.quantized_bias_type == kTfLiteInt32);
       if (requires_int32_accum) {
         reference_integer_ops::ConvPerChannel(
             ConvParamsQuantized(params, data),

--- a/tensorflow/lite/micro/kernels/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/fully_connected.cc
@@ -240,7 +240,7 @@ TfLiteStatus FullyConnectedEval(TfLiteContext* context, TfLiteNode* node) {
         case kTfLiteInt8: {
           const bool requires_int32_accum =
               (bias != nullptr && bias->type == kTfLiteInt32) ||
-              (bias == nullptr && params->quantized_bias_type != kTfLiteInt64);
+              (bias == nullptr && params->quantized_bias_type == kTfLiteInt32);
           if (requires_int32_accum) {
             data.is_per_channel
                 ? tflite::reference_integer_ops::FullyConnectedPerChannel(

--- a/tensorflow/lite/micro/kernels/xtensa/conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv.cc
@@ -117,7 +117,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       // implementation, production use-cases should only have int64 bias.
       const bool requires_int32_accum =
           (bias != nullptr && bias->type == kTfLiteInt32) ||
-          (bias == nullptr && params.quantized_bias_type != kTfLiteInt64);
+          (bias == nullptr && params.quantized_bias_type == kTfLiteInt32);
       if (requires_int32_accum) {
         return ConvReferenceEvalInt16(context, node);
       } else {

--- a/tensorflow/lite/micro/kernels/xtensa/conv_int16_reference.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv_int16_reference.cc
@@ -64,7 +64,7 @@ TfLiteStatus ConvReferenceEvalInt16(TfLiteContext* context, TfLiteNode* node) {
   }
   const bool requires_int32_accum =
       (bias != nullptr && bias->type == kTfLiteInt32) ||
-      (bias == nullptr && params.quantized_bias_type != kTfLiteInt64);
+      (bias == nullptr && params.quantized_bias_type == kTfLiteInt32);
 
   if (requires_int32_accum) {
     reference_integer_ops::ConvPerChannel(


### PR DESCRIPTION
When a model is compiled without an explicit bias tensore), the `quantized_bias_type` hint may be missing because of https://github.com/tensorflow/tflite-micro/pull/3597.

Previously, TFLM implicitly checked for this hint (`bias == nullptr` && `params.quantized_bias_type != kTfLiteInt64`). Without the hint, bias-less 16x8 layers silently fell back to a 32-bit accumulator, which overflows and destroys prediction accuracy.

This changes the 16x8 kernel fallback logic in TFLM (`fully_connected`, `conv`) to check `params.quantized_bias_type == kTfLiteInt32` instead. This safely defaults to int64 accumulation for bias-less 16x8 layers, preventing overflow while still respecting explicitly compiled 32-bit requests.

BUG=n/a