### PR TITLE
Re-enable 3D x 2D BatchMatMul dimension collapse for adj_x=true

### DIFF
--- a/tensorflow/lite/micro/kernels/batch_matmul.cc
+++ b/tensorflow/lite/micro/kernels/batch_matmul.cc
@@ -340,37 +340,36 @@ TfLiteStatus EvalInt16(TfLiteContext* context, const OpDataBatchMatmul& data,
   return kTfLiteOk;
 }
 
-void ReshapeToFlattenBatchDimsIfPossible(bool adj_x, RuntimeShape* lhs_shape,
+void ReshapeToFlattenBatchDimsIfPossible(RuntimeShape* lhs_shape,
                                          RuntimeShape* rhs_shape) {
   // Compress BatchMatMul when third from last RHS dimension is one.
   int32_t rhs_dims_count = rhs_shape->DimensionsCount();
   int32_t lhs_dims_count = lhs_shape->DimensionsCount();
 
   // Compress ops where rhs shape is [..., 1, X, Y] and lhs shape is
-  // [..., Q, R, S] which is equivalent to rhs: [..., X, Y] and
-  // lhs: [..., Q * R, S].
+  // [..., Q, R, S].
+  // After shape assignment, rhs shape represents
+  // [..., 1, lhs_rows, accum_depth] and lhs shape represents
+  // [..., batch, accum_depth, rhs_cols].
   //
-  // We can only flatten the dimensions if the physical layout in memory
-  // allows us to treat [Batch, Row, Col] as [Batch * Row, Col].
-  // This requires the 'Row' dimension to be contiguous with the 'Batch'
-  // dimension.
+  // When rhs has a batch dimension of 1, we can collapse the batch dimension
+  // of lhs into rhs_cols, treating [..., batch, accum_depth, rhs_cols] as
+  // [..., accum_depth, batch * rhs_cols].
   //
-  // If adj_x is true, the logical operation is on transposed matrices.
-  // The physical layout is [Batch, Row, Col] but logically we access [Batch,
-  // Col, Row]. Flattening Batch and Row dimensions (physically) results in
-  // [Batch*Row, Col]. This does not match the logical expectation of [Batch,
-  // Col, Row] because the columns of the second batch are not contiguous with
-  // the columns of the first batch in the logical transposed view. Therefore,
-  // we disable this optimization when adj_x is true.
-  if (!adj_x && rhs_dims_count > 2 && lhs_dims_count > 2) {
+  // This works because whether adj_x is false (where orig_lhs is
+  // [batch, rhs_cols, accum_depth]) or adj_x is true (where orig_lhs is
+  // [batch, accum_depth, rhs_cols] but transposed in memory), the underlying
+  // buffer in memory has batch and rhs_cols as contiguous outer dimensions,
+  // which can be physically collapsed into batch * rhs_cols.
+  if (rhs_dims_count > 2 && lhs_dims_count > 2) {
     int rhs_one = rhs_shape->DimsData()[rhs_dims_count - 3];
     if (rhs_one == 1) {
       int32_t* lhs_dims = lhs_shape->DimsData();
       int32_t* rhs_dims = rhs_shape->DimsData();
       RuntimeShape tmp_l(lhs_dims_count - 1, lhs_dims);
-      tmp_l.SetDim(lhs_dims_count - 3,
-                   lhs_dims[lhs_dims_count - 3] * lhs_dims[lhs_dims_count - 2]);
-      tmp_l.SetDim(lhs_dims_count - 2, lhs_dims[lhs_dims_count - 1]);
+      tmp_l.SetDim(lhs_dims_count - 3, lhs_dims[lhs_dims_count - 2]);
+      tmp_l.SetDim(lhs_dims_count - 2,
+                   lhs_dims[lhs_dims_count - 3] * lhs_dims[lhs_dims_count - 1]);
       lhs_shape->ReplaceWith(tmp_l.DimensionsCount(), tmp_l.DimsData());
       RuntimeShape tmp_r(rhs_dims_count - 1, rhs_shape->DimsData());
       tmp_r.SetDim(rhs_dims_count - 3, rhs_dims[rhs_dims_count - 2]);
@@ -403,8 +402,6 @@ TfLiteStatus BatchMatMulEval(TfLiteContext* context, TfLiteNode* node) {
   bool adj_y = op_context.params->adj_y;
   bool adj_x = op_context.params->adj_x;
 
-  ReshapeToFlattenBatchDimsIfPossible(adj_x, &orig_lhs_shape, &orig_rhs_shape);
-
   TfLiteEvalTensor* rhs_tensor = adj_y ? const_cast<TfLiteEvalTensor*>(rhs)
                                        : op_data->rhs_transposed_tensor;
   TfLiteEvalTensor* lhs_tensor = adj_x ? op_data->lhs_transposed_tensor
@@ -426,6 +423,8 @@ TfLiteStatus BatchMatMulEval(TfLiteContext* context, TfLiteNode* node) {
       adj_y ? orig_rhs_shape : SwapRowColumnDims(orig_rhs_shape);
   RuntimeShape lhs_shape =
       adj_x ? orig_lhs_shape : SwapRowColumnDims(orig_lhs_shape);
+
+  ReshapeToFlattenBatchDimsIfPossible(&lhs_shape, &rhs_shape);
 
   switch (lhs->type) {
     case kTfLiteFloat32:

--- a/tensorflow/lite/micro/kernels/batch_matmul_test.cc
+++ b/tensorflow/lite/micro/kernels/batch_matmul_test.cc
@@ -260,9 +260,8 @@ TEST(BatchMatmulTest, BatchMatMulOpTestFloat32Test_FlattenLHSAdjoint) {
   float rhs_input[kRhsInputSize];
   std::iota(std::begin(rhs_input), std::end(rhs_input), 1);
 
-  constexpr float kExpect[] = {118, 134, 150, 140, 160, 180,
-                               294, 342, 390, 316, 368, 420,
-                               470, 550, 630, 492, 576, 660};
+  constexpr float kExpect[] = {118, 134, 150, 140, 160, 180, 294, 342, 390,
+                               316, 368, 420, 470, 550, 630, 492, 576, 660};
   constexpr int kOutputDims[] = {3, 3, 2, 3};
   constexpr int kOutputCount = std::extent<decltype(kExpect)>::value;
   float output_data[kOutputCount];

--- a/tensorflow/lite/micro/kernels/batch_matmul_test.cc
+++ b/tensorflow/lite/micro/kernels/batch_matmul_test.cc
@@ -246,6 +246,38 @@ TEST(BatchMatmulTest, BatchMatMulOpTestFloat32Test_Flatten) {
                                         output_data);
 }
 
+TEST(BatchMatmulTest, BatchMatMulOpTestFloat32Test_FlattenLHSAdjoint) {
+  constexpr int kLhsInputDims[] = {3, 3, 4, 2};
+  constexpr int kRhsInputDims[] = {3, 1, 4, 3};
+  const int* kInputDims[tflite::testing::kNumInputs] = {kLhsInputDims,
+                                                        kRhsInputDims};
+
+  constexpr size_t kLhsInputSize = 24;
+  float lhs_input[kLhsInputSize];
+  std::iota(std::begin(lhs_input), std::end(lhs_input), 1);
+
+  constexpr size_t kRhsInputSize = 12;
+  float rhs_input[kRhsInputSize];
+  std::iota(std::begin(rhs_input), std::end(rhs_input), 1);
+
+  constexpr float kExpect[] = {118, 134, 150, 140, 160, 180,
+                               294, 342, 390, 316, 368, 420,
+                               470, 550, 630, 492, 576, 660};
+  constexpr int kOutputDims[] = {3, 3, 2, 3};
+  constexpr int kOutputCount = std::extent<decltype(kExpect)>::value;
+  float output_data[kOutputCount];
+
+  constexpr TfLiteBatchMatMulParams params = {
+      true,   // adj_x
+      false,  // adj_y
+      false   // asymmetric_quantize_inputs
+  };
+
+  tflite::testing::TestBatchMatMulFloat(params, kInputDims, lhs_input,
+                                        rhs_input, kOutputDims, kExpect,
+                                        output_data);
+}
+
 TEST(BatchMatmulTest, BatchMatMulOpTestFloat32Test_Simple) {
   constexpr int kLhsInputDims[] = {3, 1, 2, 3};
   constexpr int kRhsInputDims[] = {3, 1, 3, 4};

--- a/tensorflow/lite/micro/kernels/cmsis_nn/batch_matmul.cc
+++ b/tensorflow/lite/micro/kernels/cmsis_nn/batch_matmul.cc
@@ -82,41 +82,6 @@ inline TfLiteStatus PopulateEvalData(
     TransposeRowsColumns(*original_lhs_input, *updated_lhs_input);
   }
 
-  // Compress BatchMatMul when third from last RHS dimension is one.
-  int32_t rhs_dims_count = rhs_shape->DimensionsCount();
-  int32_t lhs_dims_count = lhs_shape->DimensionsCount();
-  int32_t out_dims_count = orig_out_shape.DimensionsCount();
-  // Compress ops where rhs shape is [..., 1, X, Y] and lhs shape is
-  // [..., Q, R, S] which is equivalent to rhs: [..., X, Y] and
-  // lhs: [..., Q * R, S].
-  if (!params->adj_x && rhs_dims_count > 2 && lhs_dims_count > 2) {
-    int rhs_one = rhs_shape->DimsData()[rhs_dims_count - 3];
-    if (rhs_one == 1) {
-      int32_t* lhs_dims = lhs_shape->DimsData();
-      int32_t* rhs_dims = rhs_shape->DimsData();
-      int32_t* out_dims = orig_out_shape.DimsData();
-      RuntimeShape tmp_l(lhs_dims_count - 1, lhs_dims);
-      tmp_l.SetDim(lhs_dims_count - 3,
-                   lhs_dims[lhs_dims_count - 3] * lhs_dims[lhs_dims_count - 2]);
-      tmp_l.SetDim(lhs_dims_count - 2, lhs_dims[lhs_dims_count - 1]);
-      lhs_shape->ReplaceWith(tmp_l.DimensionsCount(), tmp_l.DimsData());
-      RuntimeShape tmp_r(rhs_dims_count - 1, rhs_shape->DimsData());
-      tmp_r.SetDim(rhs_dims_count - 3, rhs_dims[rhs_dims_count - 2]);
-      tmp_r.SetDim(rhs_dims_count - 2, rhs_dims[rhs_dims_count - 1]);
-      rhs_shape->ReplaceWith(tmp_r.DimensionsCount(), tmp_r.DimsData());
-      rhs_dims_count = rhs_shape->DimensionsCount();
-      lhs_dims_count = lhs_shape->DimensionsCount();
-
-      RuntimeShape tmp_o(out_dims_count - 1, out_dims);
-      tmp_o.SetDim(out_dims_count - 3, lhs_shape->Dims(lhs_dims_count - 2));
-      tmp_o.SetDim(out_dims_count - 2, orig_out_shape.Dims(out_dims_count - 1));
-      orig_out_shape.ReplaceWith(tmp_o.DimensionsCount(), tmp_o.DimsData());
-      out_dims_count = orig_out_shape.DimensionsCount();
-      data->output_shape =
-          FillVariableShape(out_dims_count, orig_out_shape.DimsData());
-    }
-  }
-
   if (!params->adj_y) {
     RuntimeShape tmp_r = SwapRowColumnDims(*rhs_shape);
     rhs_shape->ReplaceWith(tmp_r.DimensionsCount(), tmp_r.DimsData());
@@ -129,6 +94,51 @@ inline TfLiteStatus PopulateEvalData(
   } else if (params->adj_x && original_lhs_input->type != kTfLiteFloat32) {
     RuntimeShape tmp_l = SwapRowColumnDims(*lhs_shape);
     lhs_shape->ReplaceWith(tmp_l.DimensionsCount(), tmp_l.DimsData());
+  }
+
+  // Compress BatchMatMul when third from last RHS dimension is one.
+  int32_t rhs_dims_count = rhs_shape->DimensionsCount();
+  int32_t lhs_dims_count = lhs_shape->DimensionsCount();
+  int32_t out_dims_count = orig_out_shape.DimensionsCount();
+  // Compress ops where rhs shape is [..., 1, X, Y].
+  if (rhs_dims_count > 2 && lhs_dims_count > 2) {
+    int rhs_one = rhs_shape->DimsData()[rhs_dims_count - 3];
+    if (rhs_one == 1) {
+      int32_t* lhs_dims = lhs_shape->DimsData();
+      int32_t* rhs_dims = rhs_shape->DimsData();
+      int32_t* out_dims = orig_out_shape.DimsData();
+      RuntimeShape tmp_l(lhs_dims_count - 1, lhs_dims);
+
+      if (original_lhs_input->type == kTfLiteFloat32) {
+        tmp_l.SetDim(lhs_dims_count - 3, lhs_dims[lhs_dims_count - 2]);
+        tmp_l.SetDim(lhs_dims_count - 2, lhs_dims[lhs_dims_count - 3] *
+                                             lhs_dims[lhs_dims_count - 1]);
+      } else {
+        tmp_l.SetDim(lhs_dims_count - 3, lhs_dims[lhs_dims_count - 3] *
+                                             lhs_dims[lhs_dims_count - 2]);
+        tmp_l.SetDim(lhs_dims_count - 2, lhs_dims[lhs_dims_count - 1]);
+      }
+      lhs_shape->ReplaceWith(tmp_l.DimensionsCount(), tmp_l.DimsData());
+
+      RuntimeShape tmp_r(rhs_dims_count - 1, rhs_dims);
+      tmp_r.SetDim(rhs_dims_count - 3, rhs_dims[rhs_dims_count - 2]);
+      tmp_r.SetDim(rhs_dims_count - 2, rhs_dims[rhs_dims_count - 1]);
+      rhs_shape->ReplaceWith(tmp_r.DimensionsCount(), tmp_r.DimsData());
+      rhs_dims_count = rhs_shape->DimensionsCount();
+      lhs_dims_count = lhs_shape->DimensionsCount();
+
+      RuntimeShape tmp_o(out_dims_count - 1, out_dims);
+      if (original_lhs_input->type == kTfLiteFloat32) {
+        tmp_o.SetDim(out_dims_count - 3, lhs_shape->Dims(lhs_dims_count - 1));
+      } else {
+        tmp_o.SetDim(out_dims_count - 3, lhs_shape->Dims(lhs_dims_count - 2));
+      }
+      tmp_o.SetDim(out_dims_count - 2, orig_out_shape.Dims(out_dims_count - 1));
+      orig_out_shape.ReplaceWith(tmp_o.DimensionsCount(), tmp_o.DimsData());
+      out_dims_count = orig_out_shape.DimensionsCount();
+      data->output_shape =
+          FillVariableShape(out_dims_count, orig_out_shape.DimsData());
+    }
   }
 
   return kTfLiteOk;


### PR DESCRIPTION
Re-enables the outer dimension collapse optimization (`[B, C, K] -> [B*C, K]`) for 3D x 2D BatchMatMul when `adj_x = true`, removing the workaround from PR #3413.
  
By executing dimension collapse **after** shape assignment, `lhs_shape` is in the correct canonical form to safely collapse `[Batch, Col]` into `[Batch * Col]` across both ReferenceOps and CMSIS-NN. Added unit tests to verify and protect this optimization.

BUG=https://github.com/tensorflow/tflite-micro/issues/3412