### PR TITLE
Validate output size in FILTER_BANK_LOG kernel

### DIFF
--- a/signal/micro/kernels/filter_bank_log.cc
+++ b/signal/micro/kernels/filter_bank_log.cc
@@ -78,6 +78,12 @@ TfLiteStatus FilterBankLogPrepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_TYPES_EQ(context, input->type, kTfLiteUInt32);
   TF_LITE_ENSURE_TYPES_EQ(context, output->type, kTfLiteInt16);
 
+  // FilterbankLog writes ElementCount(input) (num_channels, taken from the
+  // input tensor) elements to the output, so the output must be at least as
+  // large or it is written out of bounds.
+  TF_LITE_ENSURE(context,
+                 ElementCount(*output->dims) >= ElementCount(*input->dims));
+
   micro_context->DeallocateTempTfLiteTensor(input);
   micro_context->DeallocateTempTfLiteTensor(output);
   return kTfLiteOk;

--- a/signal/micro/kernels/filter_bank_log.cc
+++ b/signal/micro/kernels/filter_bank_log.cc
@@ -78,9 +78,10 @@ TfLiteStatus FilterBankLogPrepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_TYPES_EQ(context, input->type, kTfLiteUInt32);
   TF_LITE_ENSURE_TYPES_EQ(context, output->type, kTfLiteInt16);
 
-  // FilterbankLog writes ElementCount(input) (num_channels, taken from the
-  // input tensor) elements to the output, so the output must be at least as
-  // large or it is written out of bounds.
+  // FilterbankLog writes one output element per input channel
+  // (ElementCount(input)). Validate here in Prepare that the output tensor is at
+  // least that large, so a model with an inconsistent output shape is rejected
+  // during preparation instead of during Eval.
   TF_LITE_ENSURE(context,
                  ElementCount(*output->dims) >= ElementCount(*input->dims));
 

--- a/signal/micro/kernels/filter_bank_log_test.cc
+++ b/signal/micro/kernels/filter_bank_log_test.cc
@@ -109,4 +109,25 @@ TEST(FilterBankLogTest, FilterBankLogTest16Channel) {
                 output));
 }
 
+
+// PoC: input declares 32 channels but the output tensor is sized 1. FilterBankLogPrepare
+// does not check the output element count against the input, and FilterbankLog writes
+// num_channels (= input size = 32) elements to the 1-element output buffer => OOB write.
+TEST(FilterBankLogTest, FilterBankLogOutputTooSmallOob) {
+  int input_shape[] = {1, 32};
+  int output_shape[] = {1, 1};
+  const uint32_t input[] = {29, 21, 29, 40, 19, 11, 13, 23, 13, 11, 25,
+                            17, 5,  4,  46, 14, 17, 14, 20, 14, 10, 10,
+                            15, 11, 17, 12, 15, 16, 19, 18, 6,  2};
+  const int16_t golden[] = {0};
+  int16_t output[1];
+  // With the fix, Prepare rejects the mismatch (kTfLiteError) and no OOB occurs.
+  EXPECT_EQ(kTfLiteError,
+            tflite::testing::TestFilterBankLog(
+                input_shape, input, output_shape, golden,
+                g_gen_data_filter_bank_log_scale_1600_correction_bits_3,
+                g_gen_data_size_filter_bank_log_scale_1600_correction_bits_3,
+                output));
+}
+
 TF_LITE_MICRO_TESTS_MAIN

--- a/signal/micro/kernels/filter_bank_log_test.cc
+++ b/signal/micro/kernels/filter_bank_log_test.cc
@@ -110,10 +110,10 @@ TEST(FilterBankLogTest, FilterBankLogTest16Channel) {
 }
 
 
-// PoC: input declares 32 channels but the output tensor is sized 1. FilterBankLogPrepare
-// does not check the output element count against the input, and FilterbankLog writes
-// num_channels (= input size = 32) elements to the 1-element output buffer => OOB write.
-TEST(FilterBankLogTest, FilterBankLogOutputTooSmallOob) {
+// A model whose output tensor (1 element) is smaller than the input channel
+// count (32) is an inconsistent topology. FilterBankLogPrepare must reject it with
+// kTfLiteError during preparation rather than proceeding to Eval.
+TEST(FilterBankLogTest, FilterBankLogRejectsUndersizedOutput) {
   int input_shape[] = {1, 32};
   int output_shape[] = {1, 1};
   const uint32_t input[] = {29, 21, 29, 40, 19, 11, 13, 23, 13, 11, 25,
@@ -121,7 +121,7 @@ TEST(FilterBankLogTest, FilterBankLogOutputTooSmallOob) {
                             15, 11, 17, 12, 15, 16, 19, 18, 6,  2};
   const int16_t golden[] = {0};
   int16_t output[1];
-  // With the fix, Prepare rejects the mismatch (kTfLiteError) and no OOB occurs.
+  // Prepare rejects the inconsistent output shape with kTfLiteError.
   EXPECT_EQ(kTfLiteError,
             tflite::testing::TestFilterBankLog(
                 input_shape, input, output_shape, golden,


### PR DESCRIPTION
BUG=out-of-bounds write in FILTER_BANK_LOG kernel from unchecked output size

### What

`FilterBankLogEval` takes `num_channels` from the **input** tensor
(`num_channels = input->dims->data[0]`) and `FilterbankLog` writes `num_channels`
elements to the output:

```cpp
for (int i = 0; i < num_channels; ++i) { output[i] = ...; }
```

`FilterBankLogPrepare` validated only the rank and type of the input and output
tensors — never that the output is at least as large as the input. A model whose
`FILTER_BANK_LOG` output tensor is smaller than its input therefore causes an
out-of-bounds **write** (e.g. input of 32 elements, output of 1), confirmed with
AddressSanitizer:

```
ERROR: AddressSanitizer: stack-buffer-overflow  WRITE of size 2
  #0 tflite::tflm_signal::FilterbankLog(...)  signal/src/filter_bank_log.cc
  #1 tflite::FilterBankLogEval(...)           signal/micro/kernels/filter_bank_log.cc:97
  #2 tflite::micro::KernelRunner::Invoke()
```

### Change

- `filter_bank_log.cc`: `FilterBankLogPrepare` now requires
  `ElementCount(output) >= ElementCount(input)`.
- `filter_bank_log_test.cc`: regression test that the mismatched model is rejected.

No change for valid models.
