### PR TITLE
Update CMSIS-NN download

### DIFF
--- a/tensorflow/lite/micro/kernels/cmsis_nn/unidirectional_sequence_lstm.cc
+++ b/tensorflow/lite/micro/kernels/cmsis_nn/unidirectional_sequence_lstm.cc
@@ -1,4 +1,4 @@
-/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -284,13 +284,15 @@ TfLiteStatus CMSIS_NN_EvalInteger8x8_16Lstm(
       tflite::micro::GetTensorData<int8_t>(kernel_content.output_tensor);
 
   // Create lstm buffer struct
-  cmsis_nn_lstm_context cmsis_buffers;
+  cmsis_nn_lstm_context cmsis_buffers = {};
   cmsis_buffers.temp1 = reinterpret_cast<int16_t*>(buffers.buffer0);
   cmsis_buffers.temp2 = reinterpret_cast<int16_t*>(buffers.buffer1);
   cmsis_buffers.cell_state = reinterpret_cast<int16_t*>(buffers.buffer2);
 
-  arm_lstm_unidirectional_s8(input, output, &op_data.params_cmsis_nn,
-                             &cmsis_buffers);
+  if (arm_lstm_unidirectional_s8(input, output, &op_data.params_cmsis_nn,
+                                 &cmsis_buffers) != ARM_CMSIS_NN_SUCCESS) {
+    return kTfLiteError;
+  }
 
   return kTfLiteOk;
 }
@@ -310,13 +312,15 @@ TfLiteStatus CMSIS_NN_EvalInteger16x8_16Lstm(
       tflite::micro::GetTensorData<int16_t>(kernel_content.output_tensor);
 
   // Create lstm buffer struct
-  cmsis_nn_lstm_context cmsis_buffers;
+  cmsis_nn_lstm_context cmsis_buffers = {};
   cmsis_buffers.temp1 = reinterpret_cast<int16_t*>(buffers.buffer0);
   cmsis_buffers.temp2 = reinterpret_cast<int16_t*>(buffers.buffer1);
   cmsis_buffers.cell_state = reinterpret_cast<int16_t*>(buffers.buffer2);
 
-  arm_lstm_unidirectional_s16(input, output, &op_data.params_cmsis_nn,
-                              &cmsis_buffers);
+  if (arm_lstm_unidirectional_s16(input, output, &op_data.params_cmsis_nn,
+                                  &cmsis_buffers) != ARM_CMSIS_NN_SUCCESS) {
+    return kTfLiteError;
+  }
 
   return kTfLiteOk;
 }

--- a/tensorflow/lite/micro/tools/make/ext_libs/cmsis_nn.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/cmsis_nn.inc
@@ -31,8 +31,36 @@ ifeq ($(CMSIS_NN_PATH), $(CMSIS_NN_DEFAULT_DOWNLOAD_PATH))
   endif
 endif
 
+# TODO: Support float
+ARM_NN_ENABLE_F16 ?= 0
+ARM_NN_ENABLE_F32 ?= 0
+
+ifeq (,$(filter $(ARM_NN_ENABLE_F16),0 1))
+  $(error ARM_NN_ENABLE_F16 must be 0 or 1)
+endif
+ifeq (,$(filter $(ARM_NN_ENABLE_F32),0 1))
+  $(error ARM_NN_ENABLE_F32 must be 0 or 1)
+endif
+
+CXXFLAGS += \
+  -DARM_NN_ENABLE_F16=$(ARM_NN_ENABLE_F16) \
+  -DARM_NN_ENABLE_F32=$(ARM_NN_ENABLE_F32)
+CCFLAGS += \
+  -DARM_NN_ENABLE_F16=$(ARM_NN_ENABLE_F16) \
+  -DARM_NN_ENABLE_F32=$(ARM_NN_ENABLE_F32)
+
 ifeq (,$(CMSIS_NN_LIBS))
-  THIRD_PARTY_KERNEL_CC_SRCS += $(shell find $(CMSIS_NN_PATH)/Source -name "*.c")
+  CMSIS_NN_CC_SRCS := $(shell find $(CMSIS_NN_PATH)/Source -name "*.c")
+  ifeq ($(ARM_NN_ENABLE_F16),0)
+    CMSIS_NN_CC_SRCS := $(filter-out %_f16.c,$(CMSIS_NN_CC_SRCS))
+  endif
+  ifeq ($(ARM_NN_ENABLE_F32),0)
+    CMSIS_NN_CC_SRCS := $(filter-out %_f32.c,$(CMSIS_NN_CC_SRCS))
+  endif
+  ifeq ($(ARM_NN_ENABLE_F16)$(ARM_NN_ENABLE_F32),00)
+    CMSIS_NN_CC_SRCS := $(filter-out %/arm_nntables_flt.c,$(CMSIS_NN_CC_SRCS))
+  endif
+  THIRD_PARTY_KERNEL_CC_SRCS += $(CMSIS_NN_CC_SRCS)
 else
   MICROLITE_LIBS += $(CMSIS_NN_LIBS)
 endif

--- a/tensorflow/lite/micro/tools/make/ext_libs/cmsis_nn_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/cmsis_nn_download.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,9 +38,9 @@ source ${TENSORFLOW_ROOT}tensorflow/lite/micro/tools/make/bash_helpers.sh
 DOWNLOADS_DIR=${1}
 DOWNLOADED_CMSIS_NN_PATH=${DOWNLOADS_DIR}/cmsis_nn
 
-ZIP_PREFIX_NN="6d9d61d8a586c39160d0c1ba58f6948e4cf61ad0"
+ZIP_PREFIX_NN="4ab83cc3cc98fb85ed6dafb55e8ca02f1628dcae"
 CMSIS_NN_URL="http://github.com/ARM-software/CMSIS-NN/archive/${ZIP_PREFIX_NN}.zip"
-CMSIS_NN_MD5="22809f7d194c057529ff1e9649f0e914"
+CMSIS_NN_MD5="c960031e7d10cf31c477fb34ef460106"
 
 should_download=$(check_should_download ${DOWNLOADS_DIR})
 


### PR DESCRIPTION
Because of recent updates in CMSIS-NN the following is needed:

- Adapt build logic to not build float support since TFLM does not use the CMSIS-NN CMake path.

- Zero-initialize the cmsis_nn_lstm_context used by the int8 and int16 unidirectional sequence LSTM paths so optional fields such as hidden_state do not contain stack garbage.

BUG=N/A
