### PR TITLE
feat(compression): add LUT compression plugin

### DIFF
--- a/tensorflow/lite/micro/compression/BUILD
+++ b/tensorflow/lite/micro/compression/BUILD
@@ -271,6 +271,39 @@ tflm_py_library(
     ],
 )
 
+tflm_py_library(
+    name = "lut",
+    srcs = ["lut.py"],
+    deps = [
+        ":compressor",
+        ":decode",
+        ":model_editor",
+        ":spec",
+        requirement("bitarray"),
+        requirement("numpy"),
+    ],
+)
+
+tflm_py_test(
+    name = "lut_test",
+    size = "small",
+    srcs = ["lut_test.py"],
+    tags = [
+        "noasan",
+        "nomsan",
+        "noubsan",
+    ],
+    deps = [
+        ":compressor",
+        ":decode",
+        ":lut",
+        ":model_editor",
+        ":spec",
+        "//tensorflow/lite/python:schema_py",
+        requirement("numpy"),
+    ],
+)
+
 tflm_py_binary(
     name = "view",
     srcs = [

--- a/tensorflow/lite/micro/compression/lut.py
+++ b/tensorflow/lite/micro/compression/lut.py
@@ -1,0 +1,318 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""LUT (Look-Up Table) compression plugin."""
+
+import sys
+from dataclasses import dataclass, field
+from typing import Optional
+
+import bitarray
+import bitarray.util
+import numpy as np
+
+from tflite_micro.tensorflow.lite.micro.compression import compressor
+from tflite_micro.tensorflow.lite.micro.compression import decode
+from tflite_micro.tensorflow.lite.micro.compression import model_editor
+from tflite_micro.tensorflow.lite.micro.compression import spec
+
+
+@dataclass
+class LutCompressedArray:
+  """Intermediate representation of LUT-compressed data.
+
+  Attributes:
+    compression_axis: The axis along which compression was performed, or None
+                      for per-tensor compression.
+    lookup_tables: List of value lookup tables. One table for per-tensor
+                   compression, or one per channel for per-channel compression.
+    indices: Array of indices into the lookup tables, same shape as original.
+  """
+  compression_axis: Optional[int] = None
+  lookup_tables: list[np.ndarray] = field(default_factory=list)
+  indices: np.ndarray = field(default_factory=lambda: np.array([]))
+
+  @property
+  def index_bitwidth(self) -> int:
+    """Returns the number of bits required to encode the indices."""
+    if self.indices is None or self.indices.size == 0:
+      raise ValueError("No indices to compute bitwidth from")
+    max_index = int(np.max(self.indices))
+    return max_index.bit_length() or 1
+
+
+@dataclass
+class LutAncillaryData:
+  """LUT-specific ancillary data matching C++ decode_state_lut.cc format.
+
+  The LUT ancillary data uses the DCM user_data bytes (4-15) plus value tables:
+    - Byte 4: LUT version (currently 1)
+    - Byte 5: Params (lower 3 bits = bitwidth, 1-7)
+    - Byte 6: Value table channel stride (elements per channel)
+    - Bytes 7-15: Reserved (zeros)
+    - Bytes 16+: Value tables (concatenated, stride elements per channel)
+
+  Attributes:
+    lut_version: LUT format version (currently 1).
+    bitwidth: Number of bits per index (1-7).
+    value_table_stride: Number of elements per channel in value tables.
+    value_tables: Packed value table data following the DCM.
+  """
+  lut_version: int = 1
+  bitwidth: int = 4
+  value_table_stride: int = 16
+  value_tables: bytes = b''
+
+  def __post_init__(self):
+    if not 1 <= self.bitwidth <= 7:
+      raise ValueError(f"bitwidth must be 1-7, got {self.bitwidth}")
+    if not 0 <= self.value_table_stride <= 128:
+      raise ValueError(
+          f"value_table_stride must be 0-128, got {self.value_table_stride}")
+
+  def to_user_data(self) -> bytes:
+    """Serialize to 12-byte user_data for DCM bytes 4-15."""
+    user_data = bytearray(12)
+    user_data[0] = self.lut_version
+    user_data[1] = self.bitwidth & 0x07
+    user_data[2] = self.value_table_stride
+    # Bytes 3-11 (DCM bytes 7-15) remain zero (reserved)
+    return bytes(user_data)
+
+  def to_bytes(self) -> bytes:
+    """Serialize for use as AncillaryDataTensor.ancillary_data."""
+    # This returns the type-specific data that follows the DCM header.
+    # For LUT, that's just the value tables since user_data is in DCM.
+    return self.value_tables
+
+
+def compress_array(tensor: np.ndarray,
+                   axis: Optional[int]) -> LutCompressedArray:
+  """Compresses the given tensor using lookup tables.
+
+  Args:
+    tensor: The tensor to be compressed.
+    axis: The axis along which to compress. If an axis is given, a lookup table
+          is created for each slice along the axis. If axis is None, a single
+          lookup table is used for the entire tensor.
+
+          Compressing a tensor with a lookup table per slice along a particular
+          axis is analogous to quantizing a tensor with different quantization
+          parameters per slice along a particular axis (dimension).
+
+  Returns:
+    LutCompressedArray containing lookup tables and indices.
+  """
+  compressed = LutCompressedArray()
+  compressed.compression_axis = axis
+
+  if axis is None:
+    # Compute unique values and indices for the entire tensor
+    values, indices = np.unique(tensor, return_inverse=True)
+    compressed.lookup_tables.append(values)
+    compressed.indices = indices.reshape(tensor.shape)
+  else:
+    # Iterate over slices along the compression axis
+    slice_indices = []
+    for slice in np.moveaxis(tensor, axis, 0):
+      values, indices = np.unique(slice, return_inverse=True)
+      compressed.lookup_tables.append(values)
+      indices = indices.reshape(slice.shape)
+      slice_indices.append(indices)
+
+    # Reconstruct a tensor of indices from the slices
+    stacked = np.stack(slice_indices, axis=0)
+    compressed.indices = np.moveaxis(stacked, 0, axis)
+
+  return compressed
+
+
+def identify_compression_axis(tensor: model_editor.Tensor) -> Optional[int]:
+  """Determines the axis along which to compress.
+
+  The axis along which to compress is inferred from the tensor's quantization
+  parameters. Unquantized tensors use per-tensor compression.
+
+  Args:
+    tensor: The tensor to analyze.
+
+  Returns:
+    The axis along which to compress, or None to indicate one value table for
+    the entire tensor.
+
+  Raises:
+    CompressionError: If the axis cannot be determined from quantization.
+  """
+  q = tensor.quantization
+  if q is None:
+    return None
+
+  # model_editor wraps quantization, access scales/axis from wrapper
+  scales = q.scales if isinstance(q.scales, list) else [q.scales]
+  quantization_channels = len(scales)
+
+  if quantization_channels == 1:
+    return None
+
+  if q.axis is not None and q.axis < len(tensor.shape):
+    if quantization_channels == tensor.shape[q.axis]:
+      return q.axis
+
+  raise compressor.CompressionError(
+      "Invalid or no quantization parameters from which to "
+      "infer the axis along which tensor should be compressed.")
+
+
+def check_bitwidth(compressed: int, specified: int, tensor_spec: spec.Tensor):
+  """Validates that the specified bitwidth is sufficient.
+
+  It is an error if the bitwidth required to compress a tensor exceeds the
+  specified bitwith, and a warning if the tensor can be compressed in less than
+  the specified bitwidth. The latter is allowed, and is not an error, to permit
+  testing with larger bitwidths without re-binning a model.
+
+  Args:
+    compressed: The bitwidth required by the compressed data.
+    specified: The bitwidth specified in the compression spec.
+    tensor_spec: The tensor spec, for error messages.
+
+  Raises:
+    CompressionError: If specified bitwidth is too small.
+  """
+  if compressed > specified:
+    raise compressor.CompressionError(
+        f"index_bitwidth too small: {compressed} bits needed to "
+        f"enumerate unique values in tensor specified in {tensor_spec}")
+  elif compressed < specified:
+    print(
+        f"warning: index_bitwidth too large: only {compressed} "
+        f"bits needed to enumerate unique values in tensor specified in "
+        f"{tensor_spec}",
+        file=sys.stderr)
+
+
+def pack_indices(indices: np.ndarray, bitwidth: int) -> bytes:
+  """Packs indices into a bytearray using bitwidth-sized fields.
+
+  Args:
+    indices: Array of indices to pack.
+    bitwidth: Number of bits per index.
+
+  Returns:
+    Packed bytes with indices in big-endian bit order.
+  """
+  endianness = "big"
+  bits = bitarray.bitarray(endian=endianness)
+  for i in indices.ravel():
+    bits.extend(
+        bitarray.util.int2ba(int(i), length=bitwidth, endian=endianness))
+  return bits.tobytes()
+
+
+def pack_lookup_tables(tables: list[np.ndarray], table_len: int) -> bytes:
+  """Packs the value tables of a LutCompressedArray.
+
+  Pack the value tables of a LutCompressedArray into a bytes object in the
+  format writable to a value_table buffer in the .tflite flatbuffer. The
+  tables are concatenated.
+
+  Args:
+    tables: List of numpy arrays containing lookup table values.
+    table_len: Length to pad each table to (typically 2**bitwidth).
+
+  Returns:
+    Packed bytes containing all tables concatenated.
+  """
+  buffer = bytearray()
+  for t in tables:
+    padding_needed = table_len - len(t)
+    padded = np.pad(t, (0, padding_needed), mode='constant', constant_values=0)
+    buffer.extend(padded.tobytes())
+  return bytes(buffer)
+
+
+class LutCompressor:
+  """LUT compression plugin implementing the Compressor protocol."""
+
+  @property
+  def decode_type(self) -> decode.DecodeType:
+    """Returns DecodeType.LUT."""
+    return decode.DecodeType.LUT
+
+  def compress(
+      self,
+      tensor: model_editor.Tensor,
+      method: spec.CompressionMethod,
+  ) -> compressor.CompressionResult:
+    """Compress a tensor using LUT compression.
+
+    Args:
+      tensor: The tensor to compress.
+      method: Must be a LookUpTableCompression instance.
+
+    Returns:
+      CompressionResult with packed indices and ancillary data.
+
+    Raises:
+      CompressionError: If compression fails.
+    """
+    if not isinstance(method, spec.LookUpTableCompression):
+      raise compressor.CompressionError(
+          f"LutCompressor requires LookUpTableCompression, got {type(method)}")
+
+    if tensor.array is None:
+      raise compressor.CompressionError("Tensor has no data to compress")
+
+    spec_bitwidth = method.index_bitwidth
+    axis = identify_compression_axis(tensor)
+    compressed = compress_array(tensor.array, axis)
+    # Note: check_bitwidth requires a spec.Tensor but we don't have it here.
+    # We'll do a simpler check.
+    actual_bitwidth = compressed.index_bitwidth
+    if actual_bitwidth > spec_bitwidth:
+      raise compressor.CompressionError(
+          f"index_bitwidth too small: {actual_bitwidth} bits needed, "
+          f"but only {spec_bitwidth} specified")
+    elif actual_bitwidth < spec_bitwidth:
+      print(
+          f"warning: index_bitwidth larger than necessary: only "
+          f"{actual_bitwidth} bits needed, but {spec_bitwidth} specified",
+          file=sys.stderr)
+
+    # Pack indices into bytes
+    encoded_data = pack_indices(compressed.indices, spec_bitwidth)
+
+    # Pack value tables
+    table_len = max(len(t) for t in compressed.lookup_tables)
+    value_tables_bytes = pack_lookup_tables(compressed.lookup_tables,
+                                            table_len)
+
+    # Build ancillary data
+    lut_data = LutAncillaryData(
+        lut_version=1,
+        bitwidth=spec_bitwidth,
+        value_table_stride=table_len,
+        value_tables=value_tables_bytes,
+    )
+
+    # Build complete ancillary data tensor bytes: DCM header + value tables
+    dcm = decode.DecodeCommonMetadata(
+        decode_type=self.decode_type,
+        user_data=lut_data.to_user_data(),
+    )
+    ancillary_data = dcm.to_bytes() + lut_data.to_bytes()
+
+    return compressor.CompressionResult(
+        encoded_data=encoded_data,
+        ancillary_data=ancillary_data,
+    )

--- a/tensorflow/lite/micro/compression/lut_test.py
+++ b/tensorflow/lite/micro/compression/lut_test.py
@@ -1,0 +1,405 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for LUT compression plugin."""
+
+import numpy as np
+import unittest
+
+from tflite_micro.tensorflow.lite.micro.compression import compressor
+from tflite_micro.tensorflow.lite.micro.compression import decode
+from tflite_micro.tensorflow.lite.micro.compression import lut
+from tflite_micro.tensorflow.lite.micro.compression import model_editor
+from tflite_micro.tensorflow.lite.micro.compression import spec
+from tflite_micro.tensorflow.lite.python import schema_py_generated as tflite
+
+
+class TestCompressArray(unittest.TestCase):
+  """Tests for the compress_array function."""
+
+  def test_per_tensor_basic(self):
+    """Per-tensor compression extracts unique values."""
+    array = np.array([1, 2, 1, 2, 3, 3], dtype=np.int8)
+    compressed = lut.compress_array(array, axis=None)
+
+    self.assertIsNone(compressed.compression_axis)
+    self.assertEqual(len(compressed.lookup_tables), 1)
+    np.testing.assert_array_equal(compressed.lookup_tables[0], [1, 2, 3])
+    # Indices should map back to original values
+    reconstructed = compressed.lookup_tables[0][compressed.indices]
+    np.testing.assert_array_equal(reconstructed, array)
+
+  def test_per_tensor_preserves_shape(self):
+    """Indices array has same shape as input."""
+    # yapf: disable
+    array = np.array([[1, 2],
+                      [3, 1],
+                      [2, 3]], dtype=np.int8)
+    # yapf: enable
+    compressed = lut.compress_array(array, axis=None)
+
+    self.assertEqual(compressed.indices.shape, array.shape)
+
+  def test_per_channel_axis0(self):
+    """Per-channel compression along axis 0."""
+    # Each row gets its own value table
+    # yapf: disable
+    array = np.array([[1, 1, 1],
+                      [5, 5, 5],
+                      [9, 9, 9]], dtype=np.int8)
+    # yapf: enable
+    compressed = lut.compress_array(array, axis=0)
+
+    self.assertEqual(compressed.compression_axis, 0)
+    self.assertEqual(len(compressed.lookup_tables), 3)
+    np.testing.assert_array_equal(compressed.lookup_tables[0], [1])
+    np.testing.assert_array_equal(compressed.lookup_tables[1], [5])
+    np.testing.assert_array_equal(compressed.lookup_tables[2], [9])
+
+  def test_per_channel_axis1(self):
+    """Per-channel compression along axis 1."""
+    # Each column gets its own value table
+    # yapf: disable
+    array = np.array([[1, 5],
+                      [1, 5],
+                      [1, 5]], dtype=np.int8)
+    # yapf: enable
+    compressed = lut.compress_array(array, axis=1)
+
+    self.assertEqual(compressed.compression_axis, 1)
+    self.assertEqual(len(compressed.lookup_tables), 2)
+    np.testing.assert_array_equal(compressed.lookup_tables[0], [1])
+    np.testing.assert_array_equal(compressed.lookup_tables[1], [5])
+
+  def test_single_value(self):
+    """Array with single unique value."""
+    array = np.array([7, 7, 7, 7], dtype=np.int8)
+    compressed = lut.compress_array(array, axis=None)
+
+    self.assertEqual(len(compressed.lookup_tables), 1)
+    np.testing.assert_array_equal(compressed.lookup_tables[0], [7])
+    np.testing.assert_array_equal(compressed.indices, [0, 0, 0, 0])
+
+  def test_bitwidth_calculation(self):
+    """Index bitwidth is computed correctly."""
+    # 3 unique values -> 2 bits needed
+    array = np.array([0, 1, 2], dtype=np.int8)
+    compressed = lut.compress_array(array, axis=None)
+    self.assertEqual(compressed.index_bitwidth, 2)
+
+    # 4 unique values -> 2 bits needed
+    array = np.array([0, 1, 2, 3], dtype=np.int8)
+    compressed = lut.compress_array(array, axis=None)
+    self.assertEqual(compressed.index_bitwidth, 2)
+
+    # 5 unique values -> 3 bits needed
+    array = np.array([0, 1, 2, 3, 4], dtype=np.int8)
+    compressed = lut.compress_array(array, axis=None)
+    self.assertEqual(compressed.index_bitwidth, 3)
+
+  def test_bitwidth_single_value(self):
+    """Single unique value requires 1 bit."""
+    array = np.array([42, 42, 42], dtype=np.int8)
+    compressed = lut.compress_array(array, axis=None)
+    self.assertEqual(compressed.index_bitwidth, 1)
+
+
+class TestPackIndices(unittest.TestCase):
+  """Tests for the pack_indices function."""
+
+  def test_4bit_packing(self):
+    """Pack indices into 4-bit fields."""
+    indices = np.array([1, 2, 3, 0])
+    result = lut.pack_indices(indices, bitwidth=4)
+    # Big-endian: 0001 0010 | 0011 0000 = 0x12 0x30
+    self.assertEqual(result, bytes([0x12, 0x30]))
+
+  def test_2bit_packing(self):
+    """Pack indices into 2-bit fields."""
+    indices = np.array([0, 1, 2, 3])
+    result = lut.pack_indices(indices, bitwidth=2)
+    # Big-endian: 00 01 10 11 = 0x1B
+    self.assertEqual(result, bytes([0x1B]))
+
+  def test_3bit_packing(self):
+    """Pack indices into 3-bit fields."""
+    indices = np.array([0, 1, 2, 3, 4, 5, 6, 7])
+    result = lut.pack_indices(indices, bitwidth=3)
+    # 000 001 010 011 | 100 101 110 111
+    # 00000101 | 00111001 | 01110111 = 0x05 0x39 0x77
+    self.assertEqual(result, bytes([0x05, 0x39, 0x77]))
+
+  def test_1bit_packing(self):
+    """Pack indices into 1-bit fields."""
+    indices = np.array([0, 1, 0, 1, 1, 0, 1, 0])
+    result = lut.pack_indices(indices, bitwidth=1)
+    # 0 1 0 1 1 0 1 0 = 0x5A
+    self.assertEqual(result, bytes([0x5A]))
+
+  def test_multidimensional_flattens(self):
+    """Multidimensional indices are flattened row-major."""
+    # yapf: disable
+    indices = np.array([[0, 1],
+                        [2, 3]])
+    # yapf: enable
+    result = lut.pack_indices(indices, bitwidth=4)
+    # 0000 0001 | 0010 0011 = 0x01 0x23
+    self.assertEqual(result, bytes([0x01, 0x23]))
+
+
+class TestPackLookupTables(unittest.TestCase):
+  """Tests for the pack_lookup_tables function."""
+
+  def test_single_table_int8(self):
+    """Pack single INT8 lookup table."""
+    tables = [np.array([10, 20, 30], dtype=np.int8)]
+    result = lut.pack_lookup_tables(tables, table_len=4)
+    # Values: 10, 20, 30, 0 (padding)
+    self.assertEqual(result, bytes([10, 20, 30, 0]))
+
+  def test_multiple_tables(self):
+    """Pack multiple lookup tables."""
+    tables = [
+        np.array([1, 2], dtype=np.int8),
+        np.array([3, 4], dtype=np.int8),
+    ]
+    result = lut.pack_lookup_tables(tables, table_len=4)
+    # Table 1: 1, 2, 0, 0 | Table 2: 3, 4, 0, 0
+    self.assertEqual(result, bytes([1, 2, 0, 0, 3, 4, 0, 0]))
+
+  def test_int16_little_endian(self):
+    """INT16 values are packed in native byte order."""
+    tables = [np.array([0x1234, 0x5678], dtype='<i2')]
+    result = lut.pack_lookup_tables(tables, table_len=2)
+    # Little-endian: 0x34 0x12 0x78 0x56
+    self.assertEqual(result, bytes([0x34, 0x12, 0x78, 0x56]))
+
+  def test_no_padding_needed(self):
+    """Table exactly fills the stride."""
+    tables = [np.array([1, 2, 3, 4], dtype=np.int8)]
+    result = lut.pack_lookup_tables(tables, table_len=4)
+    self.assertEqual(result, bytes([1, 2, 3, 4]))
+
+
+class TestIdentifyCompressionAxis(unittest.TestCase):
+  """Tests for identify_compression_axis function."""
+
+  def test_per_tensor_quantization(self):
+    """Single scale means per-tensor compression."""
+    tensor = model_editor.Tensor(
+        shape=(4, 4),
+        dtype=tflite.TensorType.INT8,
+        quantization=model_editor.Quantization(scales=0.5, zero_points=0),
+    )
+    axis = lut.identify_compression_axis(tensor)
+    self.assertIsNone(axis)
+
+  def test_per_channel_axis0(self):
+    """Multiple scales on axis 0."""
+    tensor = model_editor.Tensor(
+        shape=(4, 8),
+        dtype=tflite.TensorType.INT8,
+        quantization=model_editor.Quantization(
+            scales=[0.1, 0.2, 0.3, 0.4],
+            zero_points=[0, 0, 0, 0],
+            axis=0,
+        ),
+    )
+    axis = lut.identify_compression_axis(tensor)
+    self.assertEqual(axis, 0)
+
+  def test_per_channel_axis1(self):
+    """Multiple scales on axis 1."""
+    tensor = model_editor.Tensor(
+        shape=(4, 8),
+        dtype=tflite.TensorType.INT8,
+        quantization=model_editor.Quantization(
+            scales=[0.1] * 8,
+            zero_points=[0] * 8,
+            axis=1,
+        ),
+    )
+    axis = lut.identify_compression_axis(tensor)
+    self.assertEqual(axis, 1)
+
+  def test_no_quantization_returns_none(self):
+    """Missing quantization returns None for per-tensor compression."""
+    tensor = model_editor.Tensor(
+        shape=(4, 4),
+        dtype=tflite.TensorType.INT8,
+    )
+    axis = lut.identify_compression_axis(tensor)
+    self.assertIsNone(axis)
+
+  def test_single_scale_with_axis_returns_none(self):
+    """Single scale with axis set still returns None (per-tensor compression).
+
+    This handles the edge case where quantized_dimension is set but shape[dim]=1,
+    resulting in only one scale. Use per-tensor compression with one value table.
+    """
+    tensor = model_editor.Tensor(
+        shape=(4, 4, 4, 1),  # shape[3] == 1
+        dtype=tflite.TensorType.INT8,
+        quantization=model_editor.Quantization(
+            scales=[0.5],  # Single scale
+            zero_points=[0],
+            axis=3,  # Axis is set
+        ),
+    )
+    axis = lut.identify_compression_axis(tensor)
+    self.assertIsNone(axis)
+
+
+class TestLutCompressor(unittest.TestCase):
+  """Tests for the LutCompressor class."""
+
+  def test_decode_type(self):
+    """LutCompressor returns DecodeType.LUT."""
+    compressor_instance = lut.LutCompressor()
+    self.assertEqual(compressor_instance.decode_type, decode.DecodeType.LUT)
+
+  def test_compress_basic(self):
+    """Basic compression produces valid result."""
+    tensor = model_editor.Tensor(
+        shape=(4, ),
+        dtype=tflite.TensorType.INT8,
+        data=np.array([1, 2, 1, 2], dtype=np.int8),
+        quantization=model_editor.Quantization(scales=1.0, zero_points=0),
+    )
+    method = spec.LookUpTableCompression(index_bitwidth=4)
+
+    compressor_instance = lut.LutCompressor()
+    result = compressor_instance.compress(tensor, method)
+
+    # Verify we got encoded data and ancillary data
+    self.assertIsInstance(result.encoded_data, bytes)
+    self.assertIsInstance(result.ancillary_data, bytes)
+    self.assertGreater(len(result.encoded_data), 0)
+    # Ancillary data should be at least 16 bytes (DCM header)
+    self.assertGreaterEqual(len(result.ancillary_data), 16)
+
+  def test_compress_ancillary_data_format(self):
+    """Ancillary data matches C++ expected format."""
+    tensor = model_editor.Tensor(
+        shape=(4, ),
+        dtype=tflite.TensorType.INT8,
+        data=np.array([1, 2, 3, 4], dtype=np.int8),
+        quantization=model_editor.Quantization(scales=1.0, zero_points=0),
+    )
+    method = spec.LookUpTableCompression(index_bitwidth=4)
+
+    compressor_instance = lut.LutCompressor()
+    result = compressor_instance.compress(tensor, method)
+
+    # Parse DCM header
+    dcm_bytes = result.ancillary_data[:16]
+    self.assertEqual(dcm_bytes[0], 0)  # decode_type = LUT
+    self.assertEqual(dcm_bytes[1], 1)  # DCM version
+    self.assertEqual(dcm_bytes[4], 1)  # LUT version
+    self.assertEqual(dcm_bytes[5] & 0x07, 4)  # bitwidth = 4
+    self.assertEqual(dcm_bytes[6], 4)  # value_table_stride = num unique values
+
+  def test_value_table_stride_not_padded_to_bitwidth(self):
+    """Value table stride is actual unique count, not 2^bitwidth."""
+    # 3 unique values with bitwidth=4: stride should be 3, not 16
+    tensor = model_editor.Tensor(
+        shape=(6, ),
+        dtype=tflite.TensorType.INT8,
+        data=np.array([1, 2, 3, 1, 2, 3], dtype=np.int8),
+        quantization=model_editor.Quantization(scales=1.0, zero_points=0),
+    )
+    method = spec.LookUpTableCompression(index_bitwidth=4)
+
+    compressor_instance = lut.LutCompressor()
+    result = compressor_instance.compress(tensor, method)
+
+    dcm_bytes = result.ancillary_data[:16]
+    self.assertEqual(dcm_bytes[6], 3)  # stride = 3, NOT 16 (2^4)
+
+  def test_compress_bitwidth_too_small_raises(self):
+    """Specifying too small bitwidth raises error."""
+    # 16 unique values need 4 bits, but we specify 3
+    tensor = model_editor.Tensor(
+        shape=(16, ),
+        dtype=tflite.TensorType.INT8,
+        data=np.array(range(16), dtype=np.int8),
+        quantization=model_editor.Quantization(scales=1.0, zero_points=0),
+    )
+    method = spec.LookUpTableCompression(index_bitwidth=3)
+
+    compressor_instance = lut.LutCompressor()
+    with self.assertRaises(compressor.CompressionError):
+      compressor_instance.compress(tensor, method)
+
+  def test_compress_wrong_method_type_raises(self):
+    """Passing wrong compression method type raises error."""
+    tensor = model_editor.Tensor(
+        shape=(4, ),
+        dtype=tflite.TensorType.INT8,
+        data=np.array([1, 2, 1, 2], dtype=np.int8),
+        quantization=model_editor.Quantization(scales=1.0, zero_points=0),
+    )
+    # Use base CompressionMethod instead of LookUpTableCompression
+    method = spec.CompressionMethod()
+
+    compressor_instance = lut.LutCompressor()
+    with self.assertRaises(compressor.CompressionError):
+      compressor_instance.compress(tensor, method)
+
+  def test_compress_no_data_raises(self):
+    """Tensor without data raises error."""
+    tensor = model_editor.Tensor(
+        shape=(4, ),
+        dtype=tflite.TensorType.INT8,
+        quantization=model_editor.Quantization(scales=1.0, zero_points=0),
+    )
+    method = spec.LookUpTableCompression(index_bitwidth=4)
+
+    compressor_instance = lut.LutCompressor()
+    with self.assertRaises(compressor.CompressionError):
+      compressor_instance.compress(tensor, method)
+
+
+class TestLutAncillaryData(unittest.TestCase):
+  """Tests for LutAncillaryData."""
+
+  def test_to_user_data_format(self):
+    """User data bytes match expected format."""
+    lut_data = lut.LutAncillaryData(
+        lut_version=1,
+        bitwidth=4,
+        value_table_stride=16,
+        value_tables=b'',
+    )
+    user_data = lut_data.to_user_data()
+
+    self.assertEqual(len(user_data), 12)
+    self.assertEqual(user_data[0], 1)  # lut_version
+    self.assertEqual(user_data[1], 4)  # bitwidth
+    self.assertEqual(user_data[2], 16)  # stride
+
+  def test_bitwidth_validation(self):
+    """Bitwidth must be 1-7."""
+    with self.assertRaises(ValueError):
+      lut.LutAncillaryData(bitwidth=0)
+    with self.assertRaises(ValueError):
+      lut.LutAncillaryData(bitwidth=8)
+
+  def test_stride_validation(self):
+    """Stride must be 0-128."""
+    with self.assertRaises(ValueError):
+      lut.LutAncillaryData(value_table_stride=129)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Add `LutCompressor`, a lookup-table compression plugin built on the
`Compressor` protocol. LUT compression replaces tensor values with indices
into a table of unique values, producing packed indices and ancillary data
in the format expected by the TFLM DECODE kernel.

Supports per-tensor and per-channel compression, sizes value tables to the
actual unique-value count, and handles unquantized tensors.

This is additive and Python-only: a new `lut.py` plus its `lut_test.py` and
BUILD targets. No existing code changes.

Part of the DECODE compression-tooling stack.

BUG=#3256
