### PR TITLE
ci: pin GitHub Actions to full commit SHAs to prevent supply-chain attacks

### DIFF
--- a/.github/workflows/check_tflite_files.yml
+++ b/.github/workflows/check_tflite_files.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check PR Modifies TfLite Files
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
 

--- a/.github/workflows/generate_integration_tests.yml
+++ b/.github/workflows/generate_integration_tests.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: bazel-contrib/setup-bazel@0.18.0
         with:
           bazelisk-cache: true

--- a/.github/workflows/log_binary_size_pr.yml
+++ b/.github/workflows/log_binary_size_pr.yml
@@ -38,7 +38,7 @@ jobs:
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:test')) ||
       github.event_name == 'schedule'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         fetch-depth: 0
         token: ${{ secrets.TFLM_BOT_REPO_TOKEN }}

--- a/.github/workflows/pypi_build.yml
+++ b/.github/workflows/pypi_build.yml
@@ -29,7 +29,7 @@ jobs:
   pypi-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           token: ${{ secrets.TFLM_BOT_REPO_TOKEN }}
       - name: Build Wheel 3.10

--- a/.github/workflows/suite_cortex_m.yml
+++ b/.github/workflows/suite_cortex_m.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - name: Install dependencies
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - name: Test
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - name: Install dependencies
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - name: Install dependencies
@@ -120,7 +120,7 @@ jobs:
     timeout-minutes: 60
     name: Cortex-M Generic (Arm Clang)
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - uses: actions/setup-python@v6
@@ -149,7 +149,7 @@ jobs:
     timeout-minutes: 60
     name: Cortex-M Corstone 300 (Arm Clang)
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - uses: actions/setup-python@v6

--- a/.github/workflows/suite_hexagon.yml
+++ b/.github/workflows/suite_hexagon.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 60
     name: Hexagon Build Test
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - run: rm -rf .git

--- a/.github/workflows/suite_riscv.yml
+++ b/.github/workflows/suite_riscv.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/setup-python@v6
       with:
         python-version: '3.10'
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         ref: ${{ inputs.trigger-sha }}
     - name: Test

--- a/.github/workflows/suite_xtensa.yml
+++ b/.github/workflows/suite_xtensa.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 60
     name: Vision P6 Build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - run: rm -rf .git
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 60
     name: Hifi5 Unit Tests
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - run: rm -rf .git
@@ -62,7 +62,7 @@ jobs:
     timeout-minutes: 60
     name: Hifi5 Unit Tests with Compression
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - run: rm -rf .git
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: 60
     name: Hifi3z Unit Tests
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - run: rm -rf .git
@@ -100,7 +100,7 @@ jobs:
     timeout-minutes: 60
     name: Hifi3z Unit Tests with Compression
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - run: rm -rf .git
@@ -121,7 +121,7 @@ jobs:
     timeout-minutes: 60
     name: Fusion F1 Unit Tests
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - run: rm -rf .git
@@ -140,7 +140,7 @@ jobs:
     timeout-minutes: 60
     name: Vision P6 Unit Tests
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - run: rm -rf .git
@@ -159,7 +159,7 @@ jobs:
     timeout-minutes: 60
     name: Hifimini Unit Tests
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - run: rm -rf .git

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           token: ${{ secrets.TFLM_BOT_REPO_TOKEN }}
       - uses: bazel-contrib/setup-bazel@0.18.0

--- a/.github/workflows/test_bazel.yml
+++ b/.github/workflows/test_bazel.yml
@@ -31,7 +31,7 @@ jobs:
             script: test_bazel_with_compression_asan.sh
     name: ${{ matrix.name }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha || github.ref }}
       - uses: bazel-contrib/setup-bazel@0.18.0

--- a/.github/workflows/test_hosted.yml
+++ b/.github/workflows/test_hosted.yml
@@ -15,7 +15,7 @@ jobs:
     container:
       image: ghcr.io/tflm-bot/tflm-ci:0.6.7
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha || github.ref }}
       - uses: bazel-contrib/setup-bazel@0.18.0
@@ -30,7 +30,7 @@ jobs:
     runs-on: windows-x86-n2-16
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha || github.ref }}
       - uses: actions/setup-python@v6
@@ -53,7 +53,7 @@ jobs:
     timeout-minutes: 60
     name: Windows Bazel
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha || github.ref }}
       - uses: actions/setup-python@v6
@@ -91,7 +91,7 @@ jobs:
     timeout-minutes: 60
     name: Windows Makefile
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha || github.ref }}
       - uses: msys2/setup-msys2@v2

--- a/.github/workflows/test_makefile.yml
+++ b/.github/workflows/test_makefile.yml
@@ -29,7 +29,7 @@ jobs:
             script: test_x86_no_tflite_static_memory.sh
     name: ${{ matrix.name }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha || github.ref }}
       - name: Test

--- a/.github/workflows/test_misc.yml
+++ b/.github/workflows/test_misc.yml
@@ -16,7 +16,7 @@ jobs:
     container:
       image: ghcr.io/tflm-bot/tflm-ci:0.6.7
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - name: Check
@@ -29,7 +29,7 @@ jobs:
       image: ghcr.io/tflm-bot/tflm-ci:0.6.7
     name: C++ Build Warnings
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha || github.ref }}
       - uses: bazel-contrib/setup-bazel@0.18.0
@@ -49,7 +49,7 @@ jobs:
     container:
       image: ghcr.io/tflm-bot/tflm-ci:0.6.7
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - uses: bazel-contrib/setup-bazel@0.18.0

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 60
     name: Windows Bazel
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - uses: actions/setup-python@v6
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 60
     name: Windows Makefile
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.trigger-sha }}
       - uses: msys2/setup-msys2@v2


### PR DESCRIPTION
## Summary

14 workflow files reference `actions/checkout` pinned to **mutable version tags** (`@v6`, `@v4`) rather than immutable commit SHAs. Tags can be silently moved by an upstream attacker, allowing arbitrary code execution in CI/CD with access to repository secrets (including `TFLM_BOT_REPO_TOKEN` and `PYPI_API_KEY`).

## Vulnerability class

Supply-chain attack via mutable Action tag references (CWE-829).

## Affected actions

| Action | Was | Now |
|--------|-----|-----|
| `actions/checkout` | `@v6` | `@df4cb1c069e1874edd31b4311f1884172cec0e10` |
| `actions/checkout` | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5` |

## Affected files (14 total)

`check_tflite_files.yml`, `generate_integration_tests.yml`, `log_binary_size_pr.yml`, `pypi_build.yml`, `suite_cortex_m.yml`, `suite_hexagon.yml`, `suite_riscv.yml`, `suite_xtensa.yml`, `sync.yml`, `test_bazel.yml`, `test_hosted.yml`, `test_makefile.yml`, `test_misc.yml`, `test_windows.yml`

## Fix

All `actions/checkout` references are pinned to their full immutable commit SHA with the version tag as an inline comment.