### PR TITLE
feat(compression): add Huffman and Pruning compression support

### DIFF
--- a/tensorflow/lite/micro/compression/BUILD
+++ b/tensorflow/lite/micro/compression/BUILD
@@ -304,6 +304,28 @@ tflm_py_test(
     ],
 )
 
+tflm_py_library(
+    name = "huffman",
+    srcs = ["huffman.py"],
+    deps = [
+        ":compressor",
+        ":decode",
+        ":model_editor",
+        ":spec",
+    ],
+)
+
+tflm_py_library(
+    name = "pruning",
+    srcs = ["pruning.py"],
+    deps = [
+        ":compressor",
+        ":decode",
+        ":model_editor",
+        ":spec",
+    ],
+)
+
 tflm_py_binary(
     name = "view",
     srcs = [

--- a/tensorflow/lite/micro/compression/huffman.py
+++ b/tensorflow/lite/micro/compression/huffman.py
@@ -1,0 +1,60 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Huffman compression plugin (stub).
+
+This module provides a placeholder for Huffman compression using Xtensa-format
+decode tables. The actual implementation is not yet available.
+
+Supported tensor types (when implemented): INT8, INT16
+"""
+
+from tflite_micro.tensorflow.lite.micro.compression import compressor
+from tflite_micro.tensorflow.lite.micro.compression import decode
+from tflite_micro.tensorflow.lite.micro.compression import model_editor
+from tflite_micro.tensorflow.lite.micro.compression import spec
+
+
+class HuffmanCompressor:
+  """Huffman compression plugin (stub).
+
+  This stub exists to validate the plugin architecture. The actual Huffman
+  compression algorithm using Xtensa-format decode tables is not yet
+  implemented.
+  """
+
+  @property
+  def decode_type(self) -> decode.DecodeType:
+    """Returns DecodeType.HUFFMAN."""
+    return decode.DecodeType.HUFFMAN
+
+  def compress(
+      self,
+      tensor: model_editor.Tensor,
+      method: spec.CompressionMethod,
+  ) -> compressor.CompressionResult:
+    """Compress a tensor using Huffman encoding.
+
+    Args:
+      tensor: The tensor to compress.
+      method: Must be a HuffmanCompression instance.
+
+    Returns:
+      CompressionResult (not implemented).
+
+    Raises:
+      CompressionError: Always, since this is a stub.
+    """
+    raise compressor.CompressionError(
+        "Huffman compression not yet implemented. "
+        "This stub exists to validate the plugin architecture.")

--- a/tensorflow/lite/micro/compression/pruning.py
+++ b/tensorflow/lite/micro/compression/pruning.py
@@ -1,0 +1,59 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pruning compression plugin (stub).
+
+This module provides a placeholder for pruning (sparsity) compression.
+The actual implementation is not yet available.
+
+Supported tensor types (when implemented): All TFLM tensor types
+"""
+
+from tflite_micro.tensorflow.lite.micro.compression import compressor
+from tflite_micro.tensorflow.lite.micro.compression import decode
+from tflite_micro.tensorflow.lite.micro.compression import model_editor
+from tflite_micro.tensorflow.lite.micro.compression import spec
+
+
+class PruningCompressor:
+  """Pruning compression plugin (stub).
+
+  This stub exists to validate the plugin architecture. The actual pruning
+  compression algorithm for sparse tensors is not yet implemented.
+  """
+
+  @property
+  def decode_type(self) -> decode.DecodeType:
+    """Returns DecodeType.PRUNING."""
+    return decode.DecodeType.PRUNING
+
+  def compress(
+      self,
+      tensor: model_editor.Tensor,
+      method: spec.CompressionMethod,
+  ) -> compressor.CompressionResult:
+    """Compress a tensor using pruning (sparsity) encoding.
+
+    Args:
+      tensor: The tensor to compress.
+      method: Must be a PruningCompression instance.
+
+    Returns:
+      CompressionResult (not implemented).
+
+    Raises:
+      CompressionError: Always, since this is a stub.
+    """
+    raise compressor.CompressionError(
+        "Pruning compression not yet implemented. "
+        "This stub exists to validate the plugin architecture.")


### PR DESCRIPTION
Add spec types, YAML parser support, and plugin stubs for the Huffman and
Pruning compression methods. Both plugins raise `CompressionError` when
invoked; they exist to validate the plugin architecture and will be replaced
with working implementations later.

Changes are Python-only: new `huffman.py` and `pruning.py` stubs, parser and
spec-type support in `spec.py`, and the corresponding BUILD targets.

Part of the DECODE compression-tooling stack.

BUG=#3256
