### PR TITLE
[CI] Fix CI failure after actions/checkout v7 upgrade

### DIFF
--- a/.github/workflows/suite_cortex_m.yml
+++ b/.github/workflows/suite_cortex_m.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - name: Install dependencies
         run: |
           pip3 install Pillow
@@ -63,6 +64,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - name: Test
         uses: docker://ghcr.io/tflm-bot/tflm-ci:0.6.7
         with:
@@ -84,6 +86,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - name: Install dependencies
         run: |
           pip3 install Pillow
@@ -104,6 +107,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - name: Install dependencies
         run: |
           pip3 install Pillow
@@ -123,6 +127,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
@@ -152,6 +157,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'

--- a/.github/workflows/suite_hexagon.yml
+++ b/.github/workflows/suite_hexagon.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - run: rm -rf .git
       - name: Hexagon Build Test
         env:

--- a/.github/workflows/suite_riscv.yml
+++ b/.github/workflows/suite_riscv.yml
@@ -22,6 +22,7 @@ jobs:
     - uses: actions/checkout@v7
       with:
         ref: ${{ inputs.trigger-sha }}
+        allow-unsafe-pr-checkout: true
     - name: Test
       uses: docker://ghcr.io/tflm-bot/tflm-ci:0.6.7
       with:

--- a/.github/workflows/suite_xtensa.yml
+++ b/.github/workflows/suite_xtensa.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - run: rm -rf .git
       - name: Vision P6 Build
         env:
@@ -46,6 +47,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - run: rm -rf .git
       - name: Hifi5 Unit Tests
         env:
@@ -65,6 +67,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - run: rm -rf .git
       - name: Hifi5 Unit Tests with Compression
         env:
@@ -84,6 +87,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - run: rm -rf .git
       - name: Hifi3z Unit Tests
         env:
@@ -103,6 +107,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - run: rm -rf .git
       - name: Hifi3z Unit Tests with Compression
         env:
@@ -124,6 +129,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - run: rm -rf .git
       - name: Fusion F1 Unit Tests
         env:
@@ -143,6 +149,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - run: rm -rf .git
       - name: Vision P6 Unit Tests
         env:
@@ -162,6 +169,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - run: rm -rf .git
       - name: Hifimini Unit Tests
         env:

--- a/.github/workflows/test_bazel.yml
+++ b/.github/workflows/test_bazel.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha || github.ref }}
+          allow-unsafe-pr-checkout: true
       - uses: bazel-contrib/setup-bazel@0.18.0
         with:
           bazelisk-cache: true

--- a/.github/workflows/test_makefile.yml
+++ b/.github/workflows/test_makefile.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha || github.ref }}
+          allow-unsafe-pr-checkout: true
       - name: Test
         run: |
           tensorflow/lite/micro/tools/ci_build/test_makefile.sh

--- a/.github/workflows/test_misc.yml
+++ b/.github/workflows/test_misc.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - name: Check
         run: tensorflow/lite/micro/tools/ci_build/test_code_style.sh
 
@@ -32,6 +33,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha || github.ref }}
+          allow-unsafe-pr-checkout: true
       - uses: bazel-contrib/setup-bazel@0.18.0
         with:
           bazelisk-cache: true
@@ -52,6 +54,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - uses: bazel-contrib/setup-bazel@0.18.0
         with:
           bazelisk-cache: true

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
@@ -54,6 +55,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.trigger-sha }}
+          allow-unsafe-pr-checkout: true
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64


### PR DESCRIPTION
Opt-in to `allow-unsafe-pr-checkout` in workflows triggered by `pull_request_target`. 

This is required by `actions/checkout@v7` when checking out fork PRs. This is safe to enable here because these workflows are gated by the collaborator/label checks in `pr_test.yml` before execution.

BUG=n/a