### PR TITLE
Add Reset support to CircularBuffer op

### DIFF
--- a/tensorflow/lite/micro/kernels/circular_buffer.cc
+++ b/tensorflow/lite/micro/kernels/circular_buffer.cc
@@ -107,9 +107,19 @@ TfLiteStatus CircularBufferEval(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 }
 
+// Restores period counter (cycles_until_run) on reset. Buffer memory cleanup
+// is not needed here: because the output tensor is a variable tensor.
+// ResetVariableTensors() automatically zero-points its memory upon reset.
+void CircularBufferReset(TfLiteContext* context, void* buffer) {
+  TFLITE_DCHECK(buffer != nullptr);
+  OpDataCircularBuffer* data = static_cast<OpDataCircularBuffer*>(buffer);
+  data->cycles_until_run = data->cycles_max;
+}
+
 TFLMRegistration* Register_CIRCULAR_BUFFER() {
   static TFLMRegistration r = tflite::micro::RegisterOp(
-      CircularBufferInit, CircularBufferPrepare, CircularBufferEval);
+      CircularBufferInit, CircularBufferPrepare, CircularBufferEval,
+      /*free=*/nullptr, CircularBufferReset);
   return &r;
 }
 

--- a/tensorflow/lite/micro/kernels/circular_buffer_test.cc
+++ b/tensorflow/lite/micro/kernels/circular_buffer_test.cc
@@ -238,8 +238,10 @@ TEST(CircularBufferTest, Reset) {
   int8_t in = 0, out[2] = {0};
   int in_dims[] = {4, 1, 1, 1, 1}, out_dims[] = {4, 1, 2, 1, 1};
   TfLiteTensor tensors[] = {
-      tflite::testing::CreateQuantizedTensor(&in, tflite::testing::IntArrayFromInts(in_dims), 1, 0),
-      tflite::testing::CreateQuantizedTensor(out, tflite::testing::IntArrayFromInts(out_dims), 1, 0),
+      tflite::testing::CreateQuantizedTensor(
+          &in, tflite::testing::IntArrayFromInts(in_dims), 1, 0),
+      tflite::testing::CreateQuantizedTensor(
+          out, tflite::testing::IntArrayFromInts(out_dims), 1, 0),
   };
   int ins[] = {1, 0}, outs[] = {1, 1};
   tflite::micro::KernelRunner runner(
@@ -255,4 +257,3 @@ TEST(CircularBufferTest, Reset) {
 }
 
 TF_LITE_MICRO_TESTS_MAIN
-

--- a/tensorflow/lite/micro/kernels/circular_buffer_test.cc
+++ b/tensorflow/lite/micro/kernels/circular_buffer_test.cc
@@ -234,4 +234,25 @@ TEST(CircularBufferTest, OutputTensorLength5) {
   }
 }
 
+TEST(CircularBufferTest, Reset) {
+  int8_t in = 0, out[2] = {0};
+  int in_dims[] = {4, 1, 1, 1, 1}, out_dims[] = {4, 1, 2, 1, 1};
+  TfLiteTensor tensors[] = {
+      tflite::testing::CreateQuantizedTensor(&in, tflite::testing::IntArrayFromInts(in_dims), 1, 0),
+      tflite::testing::CreateQuantizedTensor(out, tflite::testing::IntArrayFromInts(out_dims), 1, 0),
+  };
+  int ins[] = {1, 0}, outs[] = {1, 1};
+  tflite::micro::KernelRunner runner(
+      *tflite::Register_CIRCULAR_BUFFER(), tensors, 2,
+      tflite::testing::IntArrayFromInts(ins),
+      tflite::testing::IntArrayFromInts(outs), nullptr);
+
+  ASSERT_EQ(kTfLiteOk, runner.InitAndPrepare());
+  EXPECT_EQ(tflite::kTfLiteAbort, runner.Invoke());
+  EXPECT_EQ(kTfLiteOk, runner.Reset());
+  EXPECT_EQ(tflite::kTfLiteAbort, runner.Invoke());
+  EXPECT_EQ(kTfLiteOk, runner.Invoke());
+}
+
 TF_LITE_MICRO_TESTS_MAIN
+


### PR DESCRIPTION
This restores the internal period counter (`cycles_until_run`) to  `cycles_max`  when the model is reset, ensuring the stride logic behaves correctly on subsequent runs.

BUG=n/a