### PR TITLE
Fix typos in micro_interpreter.h and micro_mutable_op_resolver.h

### DIFF
--- a/tensorflow/lite/micro/micro_interpreter.h
+++ b/tensorflow/lite/micro/micro_interpreter.h
@@ -148,9 +148,9 @@ class MicroInterpreter {
   // arena_used_bytes() + 16.
   size_t arena_used_bytes() const { return allocator_.used_bytes(); }
 
-  // Returns True if all Tensors are being preserves
+  // Returns True if all Tensors are being preserved
   // TODO(b/297106074) : revisit making C++ example or test for
-  // preserve_all_tesnors
+  // preserve_all_tensors
   bool preserve_all_tensors() const {
     return allocator_.preserves_all_tensor();
   }

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -79,8 +79,8 @@ class MicroMutableOpResolver : public MicroOpResolver {
 
   TfLiteBridgeBuiltinParseFunction GetOpDataParser(
       BuiltinOperator op) const override {
-    TFLITE_DCHECK(num_buitin_ops_ <= tOpCount);
-    for (unsigned int i = 0; i < num_buitin_ops_; ++i) {
+    TFLITE_DCHECK(num_builtin_ops_ <= tOpCount);
+    for (unsigned int i = 0; i < num_builtin_ops_; ++i) {
       if (builtin_codes_[i] == op) return builtin_parsers_[i];
     }
     return nullptr;
@@ -758,9 +758,9 @@ class MicroMutableOpResolver : public MicroOpResolver {
     registrations_[registrations_len_].builtin_code = op;
     registrations_len_++;
 
-    builtin_codes_[num_buitin_ops_] = op;
-    builtin_parsers_[num_buitin_ops_] = parser;
-    num_buitin_ops_++;
+    builtin_codes_[num_builtin_ops_] = op;
+    builtin_parsers_[num_builtin_ops_] = parser;
+    num_builtin_ops_++;
 
     return kTfLiteOk;
   }
@@ -772,7 +772,7 @@ class MicroMutableOpResolver : public MicroOpResolver {
   // parse functions as these are registered with the Op Resolver.
   BuiltinOperator builtin_codes_[tOpCount];
   TfLiteBridgeBuiltinParseFunction builtin_parsers_[tOpCount];
-  unsigned int num_buitin_ops_ = 0;
+  unsigned int num_builtin_ops_ = 0;
 };
 
 };  // namespace tflite


### PR DESCRIPTION
Fix two categories of typos found in TFLM header files.

**micro_interpreter.h**
- `are being preserves` -> `are being preserved`
- TODO comment `preserve_all_tesnors` -> `preserve_all_tensors`

**micro_mutable_op_resolver.h**
- Private member variable `num_buitin_ops_` misspells `builtin` as `buitin`. Renamed to `num_builtin_ops_` across all 6 occurrences. This is a private member and does not affect the public API.

BUG=#3620