### PR TITLE
fix: Use Keras native format (.keras) for model serialization

### DIFF
--- a/tensorflow/lite/micro/examples/hello_world/train.py
+++ b/tensorflow/lite/micro/examples/hello_world/train.py
@@ -120,8 +120,11 @@ def train_model(epochs, x_values, y_values):
             verbose=2)
 
   if FLAGS.save_tf_model:
-    model.save(FLAGS.save_dir, save_format="tf")
-    logging.info("TF model saved to %s", FLAGS.save_dir)
+    save_path = os.path.join(FLAGS.save_dir, "model.keras")
+    if not os.path.exists(FLAGS.save_dir):
+      os.makedirs(FLAGS.save_dir)
+    model.save(save_path)
+    logging.info("TF model saved to %s", save_path)
 
   return model
 


### PR DESCRIPTION
BUG=3623

## Summary

Fixes model serialization issues in the hello_world example by switching from TensorFlow SavedModel format to the Keras native format (.keras).

## Problem

The training script fails with Keras 3 due to the `save_format` argument being deprecated:

ValueError: The save_format argument is deprecated in Keras 3.
Please remove this argument and pass a file path with either .keras or .h5 extension.
Received: save_format=tf

## Solution

- Changed model saving to use the `.keras` format (Keras native)
- Added directory creation logic to handle cases where the output directory doesn't exist
- Updated logging to reflect the actual file path being saved

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing

The change was tested with the hello_world training script and model serialization now works correctly with Keras 3.