### PR TITLE
Fix benchmark tool alternate profiler

### DIFF
--- a/tensorflow/lite/micro/tools/benchmarking/generic_model_benchmark.cc
+++ b/tensorflow/lite/micro/tools/benchmarking/generic_model_benchmark.cc
@@ -259,6 +259,15 @@ int Benchmark(const uint8_t* model_data, tflite::PrettyPrintType print_type) {
   profiler.EndEvent(event_handle);
 #endif  // USE_ALT_DECOMPRESSION_MEM
 
+  if (using_compression) {
+    MicroPrintf("profiler2 %p", &profiler2);
+    status = interpreter.SetAlternateProfiler(&profiler2);
+    if (status != kTfLiteOk) {
+      MicroPrintf("tflite::MicroInterpreter::SetAlternateProfiler failed");
+      return -1;
+    }
+  }
+
   event_handle =
       profiler.BeginEvent("tflite::MicroInterpreter::AllocateTensors");
   status = interpreter.AllocateTensors();
@@ -270,14 +279,6 @@ int Benchmark(const uint8_t* model_data, tflite::PrettyPrintType print_type) {
 
   profiler.LogTicksPerTagCsv();
   profiler.ClearEvents();
-
-  if (using_compression) {
-    status = interpreter.SetAlternateProfiler(&profiler2);
-    if (status != kTfLiteOk) {
-      MicroPrintf("tflite::MicroInterpreter::SetAlternateProfiler failed");
-      return -1;
-    }
-  }
 
   MicroPrintf("");  // null MicroPrintf serves as a newline.
 


### PR DESCRIPTION
@tensorflow/micro

Set the alternate profiler in the benchmark tool prior to the `Prepare` phase (before calling `MicroInterpreter::AllocateTensors`).  This is because the DECODE operator requires the alternate `MicroProfilerInterface` to already be initialized during the `Prepare` phase.

Previously the alternate profiler was only required during the `Eval` phase with the legacy compression code.  This fix does not change the functionality of the benchmark tool with respect to the legacy compression.

bug=fixes #3628