### PR TITLE
fix: update model save format to .keras for Keras 3 compatibility

### DIFF
--- a/tensorflow/lite/micro/examples/hello_world/train.py
+++ b/tensorflow/lite/micro/examples/hello_world/train.py
@@ -120,7 +120,7 @@ def train_model(epochs, x_values, y_values):
             verbose=2)
 
   if FLAGS.save_tf_model:
-    model.save(FLAGS.save_dir, save_format="tf")
+    model.save(os.path.join(FLAGS.save_dir, "model.keras"))
     logging.info("TF model saved to %s", FLAGS.save_dir)
 
   return model


### PR DESCRIPTION
Resolves a `ValueError` in the `hello_world` training script caused by the deprecation of the `save_format='tf'` argument in Keras 3. 

Updated the script to use the native Keras 3 archive format (`.keras`) by removing the deprecated argument and ensuring the output file uses the correct extension.

Fixes #3623
BUG=#3623