### PR TITLE
Fix integer overflow in BytesRequiredForTensor and TfLiteEvalTensorByteLength

### DIFF
--- a/tensorflow/lite/micro/memory_helpers.cc
+++ b/tensorflow/lite/micro/memory_helpers.cc
@@ -106,12 +106,18 @@ TfLiteStatus TfLiteTypeSizeOf(TfLiteType type, size_t* size) {
 
 TfLiteStatus BytesRequiredForTensor(const tflite::Tensor& flatbuffer_tensor,
                                     size_t* bytes, size_t* type_size) {
-  int element_count = 1;
-  // If flatbuffer_tensor.shape == nullptr, then flatbuffer_tensor is a scalar
-  // so has 1 element.
+  size_t element_count = 1;
   if (flatbuffer_tensor.shape() != nullptr) {
     for (size_t n = 0; n < flatbuffer_tensor.shape()->size(); ++n) {
-      element_count *= flatbuffer_tensor.shape()->Get(n);
+      int dim = flatbuffer_tensor.shape()->Get(n);
+      if (dim <= 0) {
+        return kTfLiteError;
+      }
+      size_t prev = element_count;
+      element_count *= static_cast<size_t>(dim);
+      if (element_count / static_cast<size_t>(dim) != prev) {
+        return kTfLiteError;
+      }
     }
   }
 
@@ -119,7 +125,11 @@ TfLiteStatus BytesRequiredForTensor(const tflite::Tensor& flatbuffer_tensor,
   TF_LITE_ENSURE_STATUS(
       ConvertTensorType(flatbuffer_tensor.type(), &tf_lite_type));
   TF_LITE_ENSURE_STATUS(TfLiteTypeSizeOf(tf_lite_type, type_size));
+  size_t prev = element_count;
   *bytes = element_count * (*type_size);
+  if (*type_size != 0 && *bytes / (*type_size) != prev) {
+    return kTfLiteError;
+  }
   return kTfLiteOk;
 }
 
@@ -127,16 +137,27 @@ TfLiteStatus TfLiteEvalTensorByteLength(const TfLiteEvalTensor* eval_tensor,
                                         size_t* out_bytes) {
   TFLITE_DCHECK(out_bytes != nullptr);
 
-  int element_count = 1;
-  // If eval_tensor->dims == nullptr, then tensor is a scalar so has 1 element.
+  size_t element_count = 1;
   if (eval_tensor->dims != nullptr) {
     for (int n = 0; n < eval_tensor->dims->size; ++n) {
-      element_count *= eval_tensor->dims->data[n];
+      int dim = eval_tensor->dims->data[n];
+      if (dim <= 0) {
+        return kTfLiteError;
+      }
+      size_t prev = element_count;
+      element_count *= static_cast<size_t>(dim);
+      if (element_count / static_cast<size_t>(dim) != prev) {
+        return kTfLiteError;
+      }
     }
   }
   size_t type_size;
   TF_LITE_ENSURE_STATUS(TfLiteTypeSizeOf(eval_tensor->type, &type_size));
+  size_t prev = element_count;
   *out_bytes = element_count * type_size;
+  if (type_size != 0 && *out_bytes / type_size != prev) {
+    return kTfLiteError;
+  }
   return kTfLiteOk;
 }
 


### PR DESCRIPTION
## Summary

`BytesRequiredForTensor()` and `TfLiteEvalTensorByteLength()` compute tensor byte size using `int element_count`, which overflows when model-supplied dimensions are large (e.g., 65536 x 65536 wraps int32 to 0). The undersized allocation leads to heap buffer overflow when kernels later write tensor data using the actual dimensions.

## Fix

- Change `element_count` from `int` to `size_t`
- Add overflow detection via division check after each multiplication
- Return `kTfLiteError` on overflow or non-positive dimensions
- Both functions run during Setup (model loading), consistent with the Error Handling Guide's recommendation to validate model-provided parameters early

This replaces the previous PR #3533 which was closed for not following the Error Handling Guide.

## Alignment with Error Handling Guide

Per Section 2 (Phase 1: Setup & Initialization):
> "Model-provided parameters: Check the number of inputs/outputs, tensor types, and tensor shapes."

These functions are called during `InitializeTfLiteTensorFromFlatbuffer` (Setup phase). The fix uses `kTfLiteError` return which callers propagate via `TF_LITE_ENSURE_STATUS`, keeping ROM cost low (no additional string literals).

## Testing

Verified with ASan-enabled build: crafted model with shape [65536, 65536] now returns `kTfLiteError` instead of allocating 0 bytes and overflowing.

Fixes GHSA-7rx3-jmhh-gq5m

BUG=n/a