### PR TITLE
Fix OOB read in Gather kernel via runtime bounds check on coordinate indices

### DIFF
--- a/tensorflow/lite/micro/kernels/gather.cc
+++ b/tensorflow/lite/micro/kernels/gather.cc
@@ -82,14 +82,16 @@ TfLiteStatus Gather(const TfLiteGatherParams* params,
   for (int batch = 0; batch < batch_size; ++batch) {
     for (int outer = 0; outer < outer_size; ++outer) {
       for (int coord = 0; coord < coord_size; ++coord) {
-        TFLITE_DCHECK_GE(coords_data[coord], 0);
-        TFLITE_DCHECK_LT(coords_data[coord], axis_size);
+        const CoordsT idx = coords_data[batch * coord_size + coord];
+        if (idx < 0 || idx >= axis_size) {
+          return kTfLiteError;
+        }
         std::memcpy(output_data +
                         (((batch * outer_size) + outer) * coord_size + coord) *
                             inner_size,
-                    input_data + (((batch * outer_size) + outer) * axis_size +
-                                  coords_data[batch * coord_size + coord]) *
-                                     inner_size,
+                    input_data +
+                        (((batch * outer_size) + outer) * axis_size + idx) *
+                            inner_size,
                     sizeof(InputT) * inner_size);
       }
     }


### PR DESCRIPTION
## Summary

The Gather kernel uses `TFLITE_DCHECK_GE`/`TFLITE_DCHECK_LT` to validate coordinate indices, but these compile to no-ops in release builds (NDEBUG). This allows attacker-controlled indices from an input tensor to cause an out-of-bounds read from heap memory.

## Fix

Replace the TFLITE_DCHECK pair at lines 85-86 with a runtime bounds check:
```cpp
const CoordsT idx = coords_data[batch * coord_size + coord];
if (idx < 0 || idx >= axis_size) {
  return kTfLiteError;
}
```

This replaces the previous PR #3534 which was closed for not following the Error Handling Guide.

## Alignment with Error Handling Guide

Per Section 2 (Phase 2: Execution - Eval):
> "Out-of-bounds Memory Access: If an input tensor contains indices or offsets generated at runtime (e.g., in GATHER, STRIDED_SLICE), these should be bounds-checked at runtime using a raw `if (!valid) return kTfLiteError;`."

Per Section 4 (Preventing Buffer Overflows in Eval):
> "If the overflow comes from invalid control data (like an input tensor providing indices), it should be validated in Eval to prevent memory corruption. Use raw returns."

The guide explicitly names GATHER as an example. The sibling `gather_nd.cc` (line 155) already validates bounds at runtime with a proper error return.

## Testing

Verified with ASan-enabled build: crafted model with out-of-range gather index now returns `kTfLiteError` instead of reading past the input buffer.

Fixes GHSA-cpmh-q338-mv33

BUG=n/a