### PR TITLE
Add TFLITE_DCHECK for buffer index bounds in GetFlatbufferTensorBuffer

### DIFF
--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -203,6 +203,7 @@ void* GetFlatbufferTensorBuffer(
   // First see if there's any buffer information in the serialized tensor.
   // TODO(b/170379532): Add better unit tests to validate flatbuffer values.
   void* out_buffer = nullptr;
+  TFLITE_DCHECK(flatbuffer_tensor.buffer() < buffers->size());
   if (auto* buffer = (*buffers)[flatbuffer_tensor.buffer()]) {
     // If we've found a buffer, does it have any data?
     if (auto* array = buffer->data()) {


### PR DESCRIPTION
## Summary

`GetFlatbufferTensorBuffer()` uses `flatbuffer_tensor.buffer()` as a direct index into the FlatBuffers `buffers` vector without any validation. FlatBuffers `Vector::operator[]` does not perform bounds checking. A structurally malformed model with a buffer index exceeding the vector size causes an OOB read.

## Fix

Add a `TFLITE_DCHECK` before the vector access:
```cpp
TFLITE_DCHECK(flatbuffer_tensor.buffer() < buffers->size());
```

This replaces the previous PR #3535 which was closed for not following the Error Handling Guide.

## Alignment with Error Handling Guide

Per Section 1 (The FlatBuffer Model - Corrupted FlatBuffer Files):
> "structural checks are considered a 'good-to-have' feature but should exclusively use TFLITE_DCHECK"

Per Section 4 (Fixing Fuzzer Crashes - Corrupted FlatBuffer Files):
> "it is recommended to accept the PR if it exclusively uses TFLITE_DCHECK to catch the out-of-bounds index. This treats the structural check purely as a zero-cost developer aid during debugging."

Note: the compression path at line 391 of the same file already validates `buffer_index >= buffers->size()` with a runtime check. This TFLITE_DCHECK brings the main path in line for debug builds, consistent with the guide's zero-overhead philosophy for structural FlatBuffer validation.

## Testing

Verified with debug build (TFLITE_DCHECK enabled): crafted model with buffer index 100 and only 3 buffers now triggers assertion failure during development, aiding detection of malformed models.

Fixes GHSA-8c4x-xhfq-6wx5

BUG=n/a