### PR TITLE
gather: bounds-check runtime position values in Eval

### DIFF
--- a/tensorflow/lite/micro/kernels/gather.cc
+++ b/tensorflow/lite/micro/kernels/gather.cc
@@ -82,13 +82,22 @@ TfLiteStatus Gather(const TfLiteGatherParams* params,
   for (int batch = 0; batch < batch_size; ++batch) {
     for (int outer = 0; outer < outer_size; ++outer) {
       for (int coord = 0; coord < coord_size; ++coord) {
-        TFLITE_DCHECK_GE(coords_data[coord], 0);
-        TFLITE_DCHECK_LT(coords_data[coord], axis_size);
+        // The positions tensor is a runtime input, so its values are control
+        // data that has to be bounds-checked here rather than in Prepare. A
+        // raw branch is used instead of TF_LITE_ENSURE so no error string is
+        // placed in .rodata. The previous TFLITE_DCHECKs compiled out in
+        // release builds, and they also read coords_data[coord] while the
+        // memcpy below indexes coords_data[batch * coord_size + coord], so
+        // they did not guard the value actually used once batch_size > 1.
+        const CoordsT coord_value = coords_data[batch * coord_size + coord];
+        if (coord_value < 0 || coord_value >= axis_size) {
+          return kTfLiteError;
+        }
         std::memcpy(output_data +
                         (((batch * outer_size) + outer) * coord_size + coord) *
                             inner_size,
                     input_data + (((batch * outer_size) + outer) * axis_size +
-                                  coords_data[batch * coord_size + coord]) *
+                                  coord_value) *
                                      inner_size,
                     sizeof(InputT) * inner_size);
       }

--- a/tensorflow/lite/micro/kernels/gather_test.cc
+++ b/tensorflow/lite/micro/kernels/gather_test.cc
@@ -68,6 +68,39 @@ void TestGather(int* input_dims, const InType* input_data, int* positions_dims,
   }
 }
 
+// Runs GATHER with an out-of-range value in the positions tensor and checks
+// that Invoke() returns an error instead of indexing the input tensor out of
+// bounds. Prepare() does not inspect position values, so it still succeeds.
+template <typename InType, typename PosType>
+void TestGatherOutOfRangePosition(int* input_dims, const InType* input_data,
+                                  int* positions_dims,
+                                  const PosType* positions_data,
+                                  int* output_dims, InType* output_data,
+                                  const int axis = 0,
+                                  const int batch_dims = 0) {
+  TfLiteIntArray* in_dims = IntArrayFromInts(input_dims);
+  TfLiteIntArray* pos_dims = IntArrayFromInts(positions_dims);
+  TfLiteIntArray* out_dims = IntArrayFromInts(output_dims);
+  TfLiteGatherParams params = {axis, batch_dims};
+
+  constexpr int tensors_size = 3;
+  TfLiteTensor tensors[tensors_size] = {
+      CreateTensor(input_data, in_dims),
+      CreateTensor(positions_data, pos_dims),
+      CreateTensor(output_data, out_dims, true),
+  };
+  int inputs_array_data[] = {2, 0, 1};
+  TfLiteIntArray* inputs_array = IntArrayFromInts(inputs_array_data);
+  int outputs_array_data[] = {1, 2};
+  TfLiteIntArray* outputs_array = IntArrayFromInts(outputs_array_data);
+
+  const TFLMRegistration registration = Register_GATHER();
+  micro::KernelRunner runner(registration, tensors, tensors_size, inputs_array,
+                             outputs_array, &params);
+  EXPECT_EQ(kTfLiteOk, runner.InitAndPrepare());
+  EXPECT_EQ(kTfLiteError, runner.Invoke());
+}
+
 }  // namespace
 }  // namespace testing
 }  // namespace tflite
@@ -456,6 +489,51 @@ TEST(GatherTest, GatherOp_BatchDimsEqualIndexDims) {
   tflite::testing::TestGather<int8_t, int32_t>(
       input_dims, input_data, positions_dims, positions_data, output_dims,
       output_data, golden_dims, golden_data, axis, batch_dims);
+}
+
+TEST(GatherTest, GatherOp_PositionAboveAxisSizeReturnsError) {
+  // Axis 0 has size 3, so position 3 is out of range and must be rejected
+  // rather than read past the end of the input tensor.
+  int input_dims[] = {2, 3, 4};
+  const float input_data[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+  int positions_dims[] = {1, 1};
+  const int32_t positions_data[] = {3};
+  float output_data[4];
+  int output_dims[] = {2, 0, 0};
+  tflite::testing::TestGatherOutOfRangePosition<float, int32_t>(
+      input_dims, input_data, positions_dims, positions_data, output_dims,
+      output_data);
+}
+
+TEST(GatherTest, GatherOp_NegativePositionReturnsError) {
+  // A negative position must be rejected rather than read before the start of
+  // the input tensor.
+  int input_dims[] = {2, 3, 4};
+  const float input_data[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+  int positions_dims[] = {1, 1};
+  const int32_t positions_data[] = {-1};
+  float output_data[4];
+  int output_dims[] = {2, 0, 0};
+  tflite::testing::TestGatherOutOfRangePosition<float, int32_t>(
+      input_dims, input_data, positions_dims, positions_data, output_dims,
+      output_data);
+}
+
+TEST(GatherTest, GatherOp_OutOfRangePositionInSecondBatchReturnsError) {
+  // With batch_dims = 1 the offending value sits in the second batch, at
+  // coords_data[batch * coord_size + coord]. The previous DCHECKs only read
+  // coords_data[coord], so this case was unguarded even in debug builds.
+  const int axis = 1;
+  const int batch_dims = 1;
+  int input_dims[] = {3, 2, 2, 2};
+  const float input_data[] = {0, 1, 2, 3, 4, 5, 6, 7};
+  int positions_dims[] = {2, 2, 1};
+  const int32_t positions_data[] = {0, 2};
+  float output_data[4];
+  int output_dims[] = {3, 0, 0, 0};
+  tflite::testing::TestGatherOutOfRangePosition<float, int32_t>(
+      input_dims, input_data, positions_dims, positions_data, output_dims,
+      output_data, axis, batch_dims);
 }
 
 TF_LITE_MICRO_TESTS_MAIN


### PR DESCRIPTION
BUG=GATHER kernel reads out of bounds on out-of-range runtime position values (memory safety)

This reworks #3593 to follow the Error Handling & Defensive Programming Guide, which was the reason that PR was closed.

### Problem

`Gather()` copies each output slice with

```cpp
input_data + (((batch * outer_size) + outer) * axis_size +
              coords_data[batch * coord_size + coord]) * inner_size
```

The position values come from the `positions` input tensor. They are guarded only by

```cpp
TFLITE_DCHECK_GE(coords_data[coord], 0);
TFLITE_DCHECK_LT(coords_data[coord], axis_size);
```

There are two problems with that guard.

1. `TFLITE_DCHECK` compiles out under `-DNDEBUG`, so in a release build an out-of-range position is used directly as an offset into `input_data` and the `memcpy` reads outside the input tensor.

2. The guard reads `coords_data[coord]`, but the `memcpy` indexes `coords_data[batch * coord_size + coord]`. Once `batch_size > 1` these are different elements, so the value actually used as the offset is not the value being checked, even in a debug build.

`Prepare` cannot cover this. It validates `axis`, `batch_dims` and the tensor shapes, but the position values are only known at invoke time.

### Approach

The guide, section 2, Phase 2, lists this case directly:

> **Out-of-bounds Memory Access:** If an input tensor contains indices or offsets generated at runtime (e.g., in `GATHER`, `STRIDED_SLICE`), these **should** be bounds-checked at runtime using a raw `if (!valid) return kTfLiteError;`.

So the check stays in `Eval`, but as a raw branch rather than `TF_LITE_ENSURE`. Per the macro cheat sheet, `TF_LITE_ENSURE` in `Eval` should be avoided for signal data out-of-bounds because each invocation embeds `__FILE__`, `__LINE__` and the stringified condition in `.rodata`. The raw branch adds no string data.

This is the difference from #3593, which used `TF_LITE_ENSURE` and also added an `axis` re-check in `Eval` that duplicated the existing `TF_LITE_ENSURE` in `Prepare`. That duplicate is dropped here, since `Prepare` already guarantees it and the existing `TFLITE_DCHECK`s on `axis` are the correct choice under the guide.

### Change

`gather.cc`: read the position value once into `coord_value`, reject it with a raw branch if it falls outside `[0, axis_size)`, and use that same value in the `memcpy`. This also removes the mismatch in 2 above, because the value checked and the value used are now the same expression.

Cost in release is one compare and branch per copied slice, with no added `.rodata`.

`gather_test.cc`: three tests, all asserting `InitAndPrepare()` still returns `kTfLiteOk` and `Invoke()` returns `kTfLiteError`.

* `GatherOp_PositionAboveAxisSizeReturnsError`, position 3 against axis size 3.
* `GatherOp_NegativePositionReturnsError`, position -1.
* `GatherOp_OutOfRangePositionInSecondBatchReturnsError`, `batch_dims = 1` with the bad value at `coords_data[1]`. This is the case the old DCHECK never read, so it fails on the unpatched kernel in a debug build as well as a release build.

### Testing

```
gmake -f tensorflow/lite/micro/tools/make/Makefile test_kernel_gather_test
gmake -f tensorflow/lite/micro/tools/make/Makefile BUILD_TYPE=release_with_logs test_kernel_gather_test
```

Run on macOS arm64. Note that the host `make` there is 3.81 and the Makefile requires 3.82 or later, so `gmake` is needed.

Both builds pass with this change, 21 tests in each. To confirm the new tests actually exercise the defect, I also ran them against the unpatched kernel:

| Build | Kernel | Result |
| :-- | :-- | :-- |
| default | patched | 21 passed |
| default | unpatched | aborts, exit code 134, on the first new test when the DCHECK fires |
| `release_with_logs` | patched | 21 passed |
| `release_with_logs` | unpatched | 18 passed, the 3 new tests fail |

The last row is the case that matters. With `-DNDEBUG` the DCHECKs are gone, so the unpatched kernel does not abort. It uses the out-of-range position as an offset, reads outside the input tensor, and still returns `kTfLiteOk`. That is the behaviour this change removes.
