### PR TITLE
Fix OOB buffer index in GetFlatbufferTensorBuffer

### DIFF
--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -203,7 +203,17 @@ void* GetFlatbufferTensorBuffer(
   // First see if there's any buffer information in the serialized tensor.
   // TODO(b/170379532): Add better unit tests to validate flatbuffer values.
   void* out_buffer = nullptr;
-  if (auto* buffer = (*buffers)[flatbuffer_tensor.buffer()]) {
+  // Reject out-of-range buffer indices. The compression-metadata path in this
+  // file already checks `buffer_index >= buffers->size()`; apply the same guard
+  // here so attacker-controlled tensor.buffer() cannot OOB-index the vector.
+  if (buffers == nullptr) {
+    return nullptr;
+  }
+  const uint32_t buffer_index = flatbuffer_tensor.buffer();
+  if (buffer_index >= buffers->size()) {
+    return nullptr;
+  }
+  if (auto* buffer = (*buffers)[buffer_index]) {
     // If we've found a buffer, does it have any data?
     if (auto* array = buffer->data()) {
       // If it has any data, is the data size larger than zero?


### PR DESCRIPTION
## Summary
- Add a bounds check on attacker-controlled `tensor.buffer()` before indexing the model `buffers` vector in `GetFlatbufferTensorBuffer`.
- Mirrors the existing guard used by the compression-metadata path in the same file (`buffer_index >= buffers->size()`).
- Prevents out-of-bounds reads via `flatbuffers::Vector::operator[]` during `MicroInterpreter::AllocateTensors()` when loading a crafted `.tflite`.

## Test plan
- [ ] Existing TFLM unit / integration tests still pass
- [ ] Crafted model with `buffers.size()==2` and `tensor.buffer()==65535` no longer reaches an OOB index (returns null buffer / fails allocation cleanly instead of reading past the vector)
- [ ] Valid models with in-range `tensor.buffer()` indices still allocate and invoke successfully


Made with [Cursor](https://cursor.com)