### PR TITLE
fix(pypi): repair wheel build for bzlmod

### DIFF
--- a/python/tflite_micro/pypi_build.dockerfile
+++ b/python/tflite_micro/pypi_build.dockerfile
@@ -6,7 +6,7 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64
 
 # Install bazel (via bazelisk)
-ENV BAZELISK=https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-amd64
+ENV BAZELISK=https://github.com/bazelbuild/bazelisk/releases/download/v1.29.0/bazelisk-linux-amd64
 ENV BAZEL=/usr/local/bin/bazel
 RUN curl --output $BAZEL --location $BAZELISK && chmod 755 $BAZEL
 

--- a/python/tflite_micro/pypi_build.sh
+++ b/python/tflite_micro/pypi_build.sh
@@ -45,7 +45,7 @@ case "$1" in
 esac
 
 SRCDIR=$(realpath .)
-if ! test -f $SRCDIR/WORKSPACE; then
+if ! test -f $SRCDIR/MODULE.bazel; then
     echo "error: must run from the top of the source tree" >&2
     exit 1
 fi


### PR DESCRIPTION
Repair the nightly PyPI wheel build, broken since the bzlmod
migration deleted the WORKSPACE file. The build script looked for
that file to find the top of the source tree, and died. The build
image's bazelisk, 1.18.0, likewise recognized only WORKSPACE as
the tree-top marker, so it never found .bazelversion and ran the
latest bazel release instead of the pinned 8.7.0.

Find the tree top by the MODULE.bazel file instead, and bump
bazelisk to 1.29.0, which recognizes MODULE.bazel, finds
.bazelversion, and runs the pinned bazel.

BUG=part of #3655
