### PR TITLE
perf(pypi): build the wheel in opt mode

### DIFF
--- a/python/tflite_micro/pypi_build.sh
+++ b/python/tflite_micro/pypi_build.sh
@@ -106,11 +106,13 @@ docker run \
     # Build the wheel via bazel, using the Python compatibility tag matching the
     # build environment. Enable compression support for the official package.
     call_bazel build //python/tflite_micro:whl.dist \
+        --compilation_mode=opt \
         --//python/tflite_micro:compatibility_tag=\$PY_COMPATIBILITY \
         --//:with_compression=true
 
-    # Test, in the container environment.
+    # Test in the container environment. Use the same options as the build.
     call_bazel test //python/tflite_micro:whl_test \
+            --compilation_mode=opt \
             --//python/tflite_micro:compatibility_tag=\$PY_COMPATIBILITY \
             --//:with_compression=true
 EOF


### PR DESCRIPTION
Build and test the PyPI wheel in bazel's opt compilation mode.
The build formerly used the default fastbuild mode, which leaves
C++ optimization off. Inference through a fastbuild wheel runs
several times slower than through an optimized one. Opt mode
compiles with -O2 and defines NDEBUG, the conventional
configuration for released binary wheels.

BUG=fixes #3258
