### PR TITLE
Fix integer overflow in ElementCount() by using size_t with overflow checks

### DIFF
--- a/tensorflow/lite/micro/micro_utils.cc
+++ b/tensorflow/lite/micro/micro_utils.cc
@@ -27,9 +27,14 @@ limitations under the License.
 
 namespace tflite {
 
-int ElementCount(const TfLiteIntArray& dims) {
-  int result = 1;
+size_t ElementCount(const TfLiteIntArray& dims) {
+  size_t result = 1;
   for (int i = 0; i < dims.size; ++i) {
+    // Check for overflow before multiplication
+    if (dims.data[i] > 0 && result > SIZE_MAX / dims.data[i]) {
+      // Overflow would occur – return 0 to indicate error
+      return 0;
+    }
     result *= dims.data[i];
   }
   return result;

--- a/tensorflow/lite/micro/micro_utils.h
+++ b/tensorflow/lite/micro/micro_utils.h
@@ -27,7 +27,7 @@ namespace tflite {
 
 // Returns number of elements in the shape array.
 
-int ElementCount(const TfLiteIntArray& dims);
+size_t ElementCount(const TfLiteIntArray& dims);
 
 size_t EvalTensorBytes(const TfLiteEvalTensor* tensor);
 


### PR DESCRIPTION
## Fix integer overflow in ElementCount()

### Issue
ElementCount() previously used a 32-bit signed integer (int) to multiply tensor dimensions. When large dimensions were provided (e.g., [65536, 65536]), the product overflowed to 0. This led to undersized buffer allocation and memory corruption (SEGV).

### Fix
- Changed return type from int to size_t
- Added overflow checks before multiplication

### Testing
- Tested with ASan and UBSan
- Verified with a fuzzing harness
- All tests pass locally

**Verification output:**
`Shape: [65536, 65536]
Element count: 4294967296
Total bytes: 17179869184
Expected bytes: 17179869184
No overflow.`

### Report
https://issuetracker.google.com/issues/544992926

### Signed-off-by
Aser Ahmed <aserhello5@gmail.com>

BUG=544992926