### PR TITLE
Use SafeCast for float-to-integer conversions in CAST kernel

### DIFF
--- a/tensorflow/lite/micro/kernels/cast.cc
+++ b/tensorflow/lite/micro/kernels/cast.cc
@@ -13,7 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <algorithm>
+#include <type_traits>
+
 #include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
@@ -44,10 +48,20 @@ TfLiteStatus CastPrepare(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 }
 
+template <typename ToT, typename FromT>
+ToT CastValue(FromT a) {
+  if constexpr (std::is_floating_point_v<FromT> && std::is_integral_v<ToT> &&
+                !std::is_same_v<ToT, bool>) {
+    return tflite::SafeCast<ToT>(a);
+  } else {
+    return static_cast<ToT>(a);
+  }
+}
+
 template <typename FromT, typename ToT>
 void copyCast(const FromT* in, ToT* out, int num_elements) {
   std::transform(in, in + num_elements, out,
-                 [](FromT a) { return static_cast<ToT>(a); });
+                 [](FromT a) { return CastValue<ToT>(a); });
 }
 
 template <typename FromT>
@@ -68,6 +82,9 @@ TfLiteStatus copyToTensor(TfLiteContext* context, const FromT* in,
       break;
     case kTfLiteFloat32:
       copyCast(in, tflite::micro::GetTensorData<float>(out), num_elements);
+      break;
+    case kTfLiteBool:
+      copyCast(in, tflite::micro::GetTensorData<bool>(out), num_elements);
       break;
     default:
       // Unsupported type.

--- a/tensorflow/lite/micro/kernels/cast_test.cc
+++ b/tensorflow/lite/micro/kernels/cast_test.cc
@@ -13,6 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <initializer_list>
+#include <limits>
+#include <memory>
+
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
@@ -23,18 +27,20 @@ namespace tflite {
 namespace testing {
 namespace {
 
-template <typename inputT, typename outputT>
-void TestCast(int* input_dims_data, const inputT* input_data,
-              const outputT* expected_output_data, outputT* output_data) {
-  TfLiteIntArray* input_dims = IntArrayFromInts(input_dims_data);
-  TfLiteIntArray* output_dims = IntArrayFromInts(input_dims_data);
-  const int output_dims_count = ElementCount(*output_dims);
-  constexpr int inputs_size = 1;
-  constexpr int outputs_size = 1;
-  constexpr int tensors_size = inputs_size + outputs_size;
+template <typename InputT, typename OutputT>
+void TestCast(std::initializer_list<InputT> input,
+              std::initializer_list<OutputT> golden) {
+  auto input_data = std::make_unique<InputT[]>(input.size());
+  auto output_data = std::make_unique<OutputT[]>(golden.size());
+  std::copy(input.begin(), input.end(), input_data.get());
+
+  int dims_data[] = {1, static_cast<int>(input.size())};
+  TfLiteIntArray* dims = IntArrayFromInts(dims_data);
+
+  constexpr int tensors_size = 2;
   TfLiteTensor tensors[tensors_size] = {
-      CreateTensor(input_data, input_dims),
-      CreateTensor(output_data, output_dims),
+      CreateTensor(input_data.get(), dims),
+      CreateTensor(output_data.get(), dims),
   };
 
   int inputs_array_data[] = {1, 0};
@@ -44,15 +50,29 @@ void TestCast(int* input_dims_data, const inputT* input_data,
 
   const TFLMRegistration registration = Register_CAST();
   micro::KernelRunner runner(registration, tensors, tensors_size, inputs_array,
-                             outputs_array,
-                             /*builtin_data=*/nullptr);
+                             outputs_array, /*builtin_data=*/nullptr);
 
   EXPECT_EQ(kTfLiteOk, runner.InitAndPrepare());
   EXPECT_EQ(kTfLiteOk, runner.Invoke());
 
-  for (int i = 0; i < output_dims_count; ++i) {
-    EXPECT_EQ(expected_output_data[i], output_data[i]);
+  size_t i = 0;
+  for (OutputT val : golden) {
+    EXPECT_EQ(val, output_data[i++]);
   }
+}
+
+template <typename IntT>
+void TestFloatToInt(float pos_overflow, float neg_overflow) {
+  constexpr bool is_signed = std::numeric_limits<IntT>::is_signed;
+  TestCast<float, IntT>(
+      {100.f, 1.0f, 0.f, 0.4f, 1.999f, 1.1f, -1.0f, -100.f, pos_overflow,
+       neg_overflow, std::numeric_limits<float>::infinity(),
+       -std::numeric_limits<float>::infinity(),
+       std::numeric_limits<float>::quiet_NaN()},
+      {100, 1, 0, 0, 1, 1, is_signed ? static_cast<IntT>(-1) : IntT{0},
+       is_signed ? static_cast<IntT>(-100) : IntT{0},
+       std::numeric_limits<IntT>::max(), std::numeric_limits<IntT>::min(),
+       std::numeric_limits<IntT>::max(), std::numeric_limits<IntT>::min(), 0});
 }
 
 }  // namespace
@@ -60,79 +80,61 @@ void TestCast(int* input_dims_data, const inputT* input_data,
 }  // namespace tflite
 
 TEST(CastTest, CastFloatToInt8) {
-  int8_t output_data[6];
-  int input_dims[] = {2, 3, 2};
-
-  // TODO(b/178391195): Test negative and out-of-range numbers.
-  const float input_values[] = {100.f, 1.0f, 0.f, 0.4f, 1.999f, 1.1f};
-  const int8_t golden[] = {100, 1, 0, 0, 1, 1};
-  tflite::testing::TestCast(input_dims, input_values, golden, output_data);
+  tflite::testing::TestFloatToInt<int8_t>(200.f, -200.f);
 }
 
 TEST(CastTest, CastFloatToInt16) {
-  int16_t output_data[6];
-  int input_dims[] = {2, 3, 2};
+  tflite::testing::TestFloatToInt<int16_t>(40000.f, -40000.f);
+}
 
-  // TODO(b/178391195): Test negative and out-of-range numbers.
-  const float input_values[] = {100.f, 1.0f, 0.f, 0.4f, 1.999f, 1.1f};
-  const int16_t golden[] = {100, 1, 0, 0, 1, 1};
-  tflite::testing::TestCast(input_dims, input_values, golden, output_data);
+TEST(CastTest, CastFloatToInt32) {
+  tflite::testing::TestFloatToInt<int32_t>(1e15f, -1e15f);
+}
+
+TEST(CastTest, CastFloatToUInt32) {
+  tflite::testing::TestFloatToInt<uint32_t>(1e15f, -1e15f);
+}
+
+TEST(CastTest, CastFloatToBool) {
+  tflite::testing::TestCast<float, bool>(
+      {1.0f, 0.0f, -1.0f, 0.001f, std::numeric_limits<float>::infinity(),
+       std::numeric_limits<float>::quiet_NaN()},
+      {true, false, true, true, true, true});
 }
 
 TEST(CastTest, CastInt8ToFloat) {
-  float output_data[6];
-  int input_dims[] = {2, 3, 2};
-  const int8_t input_values[] = {123, 0, 1, 2, 3, 4};
-  const float golden[] = {123.f, 0.f, 1.f, 2.f, 3.f, 4.f};
-  tflite::testing::TestCast(input_dims, input_values, golden, output_data);
+  tflite::testing::TestCast<int8_t, float>({123, 0, 1, 2, 3, 4},
+                                           {123.f, 0.f, 1.f, 2.f, 3.f, 4.f});
 }
 
 TEST(CastTest, CastInt16ToFloat) {
-  float output_data[6];
-  int input_dims[] = {2, 3, 2};
-  const int16_t input_values[] = {123, 0, 1, 2, 3, 4};
-  const float golden[] = {123.f, 0.f, 1.f, 2.f, 3.f, 4.f};
-  tflite::testing::TestCast(input_dims, input_values, golden, output_data);
+  tflite::testing::TestCast<int16_t, float>({123, 0, 1, 2, 3, 4},
+                                            {123.f, 0.f, 1.f, 2.f, 3.f, 4.f});
 }
 
 TEST(CastTest, CastInt16ToInt32) {
-  int32_t output_data[6];
-  int input_dims[] = {2, 3, 2};
-  const int16_t input_values[] = {123, 0, 1, 2, 3, 4};
-  const int32_t golden[] = {123, 0, 1, 2, 3, 4};
-  tflite::testing::TestCast(input_dims, input_values, golden, output_data);
+  tflite::testing::TestCast<int16_t, int32_t>({123, 0, 1, 2, 3, 4},
+                                              {123, 0, 1, 2, 3, 4});
 }
 
 TEST(CastTest, CastInt32ToInt16) {
-  int16_t output_data[6];
-  int input_dims[] = {2, 3, 2};
-  const int32_t input_values[] = {123, 0, 1, 2, 3, 4};
-  const int16_t golden[] = {123, 0, 1, 2, 3, 4};
-  tflite::testing::TestCast(input_dims, input_values, golden, output_data);
+  tflite::testing::TestCast<int32_t, int16_t>({123, 0, 1, 2, 3, 4},
+                                              {123, 0, 1, 2, 3, 4});
 }
 
 TEST(CastTest, CastUInt32ToInt32) {
-  int32_t output_data[6];
-  int input_dims[] = {2, 2, 3};
-  const uint32_t input_values[] = {100, 200, 300, 400, 500, 600};
-  const int32_t golden[] = {100, 200, 300, 400, 500, 600};
-  tflite::testing::TestCast(input_dims, input_values, golden, output_data);
+  tflite::testing::TestCast<uint32_t, int32_t>({100, 200, 300, 400, 500, 600},
+                                               {100, 200, 300, 400, 500, 600});
 }
 
 TEST(CastTest, CastInt32ToUInt32) {
-  uint32_t output_data[6];
-  int input_dims[] = {2, 2, 3};
-  const int32_t input_values[] = {100, 200, 300, 400, 500, 600};
-  const uint32_t golden[] = {100, 200, 300, 400, 500, 600};
-  tflite::testing::TestCast(input_dims, input_values, golden, output_data);
+  tflite::testing::TestCast<int32_t, uint32_t>({100, 200, 300, 400, 500, 600},
+                                               {100, 200, 300, 400, 500, 600});
 }
 
 TEST(CastTest, CastBoolToFloat) {
-  float output_data[6];
-  int input_dims[] = {2, 2, 3};
-  const bool input_values[] = {true, true, false, true, false, true};
-  const float golden[] = {1.f, 1.0f, 0.f, 1.0f, 0.0f, 1.0f};
-  tflite::testing::TestCast(input_dims, input_values, golden, output_data);
+  tflite::testing::TestCast<bool, float>({true, true, false, true, false, true},
+                                         {1.f, 1.0f, 0.f, 1.0f, 0.0f, 1.0f});
 }
 
 TF_LITE_MICRO_TESTS_MAIN

--- a/tensorflow/lite/micro/kernels/cast_test.cc
+++ b/tensorflow/lite/micro/kernels/cast_test.cc
@@ -13,9 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include <initializer_list>
+#include <cstddef>
+#include <cstdint>
 #include <limits>
-#include <memory>
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
@@ -27,20 +27,17 @@ namespace tflite {
 namespace testing {
 namespace {
 
-template <typename InputT, typename OutputT>
-void TestCast(std::initializer_list<InputT> input,
-              std::initializer_list<OutputT> golden) {
-  auto input_data = std::make_unique<InputT[]>(input.size());
-  auto output_data = std::make_unique<OutputT[]>(golden.size());
-  std::copy(input.begin(), input.end(), input_data.get());
+template <typename InputT, typename OutputT, size_t N>
+void TestCast(const InputT (&input)[N], const OutputT (&golden)[N]) {
+  OutputT output_data[N];
 
-  int dims_data[] = {1, static_cast<int>(input.size())};
+  int dims_data[] = {1, static_cast<int>(N)};
   TfLiteIntArray* dims = IntArrayFromInts(dims_data);
 
   constexpr int tensors_size = 2;
   TfLiteTensor tensors[tensors_size] = {
-      CreateTensor(input_data.get(), dims),
-      CreateTensor(output_data.get(), dims),
+      CreateTensor(input, dims),
+      CreateTensor(output_data, dims),
   };
 
   int inputs_array_data[] = {1, 0};
@@ -55,24 +52,41 @@ void TestCast(std::initializer_list<InputT> input,
   EXPECT_EQ(kTfLiteOk, runner.InitAndPrepare());
   EXPECT_EQ(kTfLiteOk, runner.Invoke());
 
-  size_t i = 0;
-  for (OutputT val : golden) {
-    EXPECT_EQ(val, output_data[i++]);
+  for (size_t i = 0; i < N; ++i) {
+    EXPECT_EQ(golden[i], output_data[i]);
   }
 }
 
 template <typename IntT>
 void TestFloatToInt(float pos_overflow, float neg_overflow) {
   constexpr bool is_signed = std::numeric_limits<IntT>::is_signed;
-  TestCast<float, IntT>(
-      {100.f, 1.0f, 0.f, 0.4f, 1.999f, 1.1f, -1.0f, -100.f, pos_overflow,
-       neg_overflow, std::numeric_limits<float>::infinity(),
-       -std::numeric_limits<float>::infinity(),
-       std::numeric_limits<float>::quiet_NaN()},
-      {100, 1, 0, 0, 1, 1, is_signed ? static_cast<IntT>(-1) : IntT{0},
-       is_signed ? static_cast<IntT>(-100) : IntT{0},
-       std::numeric_limits<IntT>::max(), std::numeric_limits<IntT>::min(),
-       std::numeric_limits<IntT>::max(), std::numeric_limits<IntT>::min(), 0});
+  const float input[] = {100.f,
+                         1.0f,
+                         0.f,
+                         0.4f,
+                         1.999f,
+                         1.1f,
+                         -1.0f,
+                         -100.f,
+                         pos_overflow,
+                         neg_overflow,
+                         std::numeric_limits<float>::infinity(),
+                         -std::numeric_limits<float>::infinity(),
+                         std::numeric_limits<float>::quiet_NaN()};
+  const IntT golden[] = {100,
+                         1,
+                         0,
+                         0,
+                         1,
+                         1,
+                         is_signed ? static_cast<IntT>(-1) : IntT{0},
+                         is_signed ? static_cast<IntT>(-100) : IntT{0},
+                         std::numeric_limits<IntT>::max(),
+                         std::numeric_limits<IntT>::min(),
+                         std::numeric_limits<IntT>::max(),
+                         std::numeric_limits<IntT>::min(),
+                         0};
+  TestCast(input, golden);
 }
 
 }  // namespace
@@ -96,45 +110,56 @@ TEST(CastTest, CastFloatToUInt32) {
 }
 
 TEST(CastTest, CastFloatToBool) {
-  tflite::testing::TestCast<float, bool>(
-      {1.0f, 0.0f, -1.0f, 0.001f, std::numeric_limits<float>::infinity(),
-       std::numeric_limits<float>::quiet_NaN()},
-      {true, false, true, true, true, true});
+  const float input[] = {1.0f,
+                         0.0f,
+                         -1.0f,
+                         0.001f,
+                         std::numeric_limits<float>::infinity(),
+                         std::numeric_limits<float>::quiet_NaN()};
+  const bool golden[] = {true, false, true, true, true, true};
+  tflite::testing::TestCast(input, golden);
 }
 
 TEST(CastTest, CastInt8ToFloat) {
-  tflite::testing::TestCast<int8_t, float>({123, 0, 1, 2, 3, 4},
-                                           {123.f, 0.f, 1.f, 2.f, 3.f, 4.f});
+  const int8_t input[] = {123, 0, 1, 2, 3, 4};
+  const float golden[] = {123.f, 0.f, 1.f, 2.f, 3.f, 4.f};
+  tflite::testing::TestCast(input, golden);
 }
 
 TEST(CastTest, CastInt16ToFloat) {
-  tflite::testing::TestCast<int16_t, float>({123, 0, 1, 2, 3, 4},
-                                            {123.f, 0.f, 1.f, 2.f, 3.f, 4.f});
+  const int16_t input[] = {123, 0, 1, 2, 3, 4};
+  const float golden[] = {123.f, 0.f, 1.f, 2.f, 3.f, 4.f};
+  tflite::testing::TestCast(input, golden);
 }
 
 TEST(CastTest, CastInt16ToInt32) {
-  tflite::testing::TestCast<int16_t, int32_t>({123, 0, 1, 2, 3, 4},
-                                              {123, 0, 1, 2, 3, 4});
+  const int16_t input[] = {123, 0, 1, 2, 3, 4};
+  const int32_t golden[] = {123, 0, 1, 2, 3, 4};
+  tflite::testing::TestCast(input, golden);
 }
 
 TEST(CastTest, CastInt32ToInt16) {
-  tflite::testing::TestCast<int32_t, int16_t>({123, 0, 1, 2, 3, 4},
-                                              {123, 0, 1, 2, 3, 4});
+  const int32_t input[] = {123, 0, 1, 2, 3, 4};
+  const int16_t golden[] = {123, 0, 1, 2, 3, 4};
+  tflite::testing::TestCast(input, golden);
 }
 
 TEST(CastTest, CastUInt32ToInt32) {
-  tflite::testing::TestCast<uint32_t, int32_t>({100, 200, 300, 400, 500, 600},
-                                               {100, 200, 300, 400, 500, 600});
+  const uint32_t input[] = {100, 200, 300, 400, 500, 600};
+  const int32_t golden[] = {100, 200, 300, 400, 500, 600};
+  tflite::testing::TestCast(input, golden);
 }
 
 TEST(CastTest, CastInt32ToUInt32) {
-  tflite::testing::TestCast<int32_t, uint32_t>({100, 200, 300, 400, 500, 600},
-                                               {100, 200, 300, 400, 500, 600});
+  const int32_t input[] = {100, 200, 300, 400, 500, 600};
+  const uint32_t golden[] = {100, 200, 300, 400, 500, 600};
+  tflite::testing::TestCast(input, golden);
 }
 
 TEST(CastTest, CastBoolToFloat) {
-  tflite::testing::TestCast<bool, float>({true, true, false, true, false, true},
-                                         {1.f, 1.0f, 0.f, 1.0f, 0.0f, 1.0f});
+  const bool input[] = {true, true, false, true, false, true};
+  const float golden[] = {1.f, 1.0f, 0.f, 1.0f, 0.0f, 1.0f};
+  tflite::testing::TestCast(input, golden);
 }
 
 TF_LITE_MICRO_TESTS_MAIN


### PR DESCRIPTION
To align TFLM's CAST kernel with LiteRT, which already uses SafeCast for floating-point to integral conversions.

BUG=n/a