### PR TITLE
Add HiFi-optimized reduce operations for Xtensa

### DIFF
--- a/tensorflow/lite/micro/kernels/reduce_common.cc
+++ b/tensorflow/lite/micro/kernels/reduce_common.cc
@@ -1,4 +1,4 @@
-/* Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -28,7 +28,8 @@ limitations under the License.
 
 namespace tflite {
 
-namespace {
+const int kMaxNumberOfAxis = 5;
+const int kMaxNumberOfReducedAxis = 2;
 
 TfLiteStatus PrepareSimple(TfLiteContext* context, TfLiteNode* node,
                            int32_t* multiplier, int* shift) {
@@ -63,6 +64,95 @@ TfLiteStatus PrepareSimple(TfLiteContext* context, TfLiteNode* node,
   return kTfLiteOk;
 }
 
+TfLiteStatus PrepareMaxHelper(TfLiteContext* context, TfLiteNode* node,
+                              OpDataReduce* op_data) {
+  TF_LITE_ENSURE_OK(context, PrepareSimple(context, node, &op_data->multiplier,
+                                           &op_data->shift));
+
+  MicroContext* micro_context = GetMicroContext(context);
+  TfLiteTensor* input = micro_context->AllocateTempInputTensor(node, 0);
+  TfLiteTensor* output = micro_context->AllocateTempOutputTensor(node, 0);
+  TfLiteTensor* axis = micro_context->AllocateTempInputTensor(node, 1);
+
+  op_data->input_zp = input->params.zero_point;
+  op_data->input_scale = input->params.scale;
+  op_data->output_zp = output->params.zero_point;
+  op_data->output_scale = output->params.scale;
+  op_data->num_output_elements = NumElements(output);
+
+  context->RequestScratchBufferInArena(context, sizeof(int) * input->dims->size,
+                                       &op_data->scratch_accumulator_idx);
+  context->RequestScratchBufferInArena(
+      context, sizeof(int) * static_cast<int>(ElementCount(*axis->dims)),
+      &op_data->scratch_resolved_axis_idx);
+
+  micro_context->DeallocateTempTfLiteTensor(input);
+  micro_context->DeallocateTempTfLiteTensor(output);
+  micro_context->DeallocateTempTfLiteTensor(axis);
+  return kTfLiteOk;
+}
+
+TfLiteStatus PrepareMinMaxHelper(TfLiteContext* context, TfLiteNode* node,
+                                 OpDataReduce* op_data) {
+  TF_LITE_ENSURE_OK(context, PrepareSimple(context, node, &op_data->multiplier,
+                                           &op_data->shift));
+
+  MicroContext* micro_context = GetMicroContext(context);
+  TfLiteTensor* input = micro_context->AllocateTempInputTensor(node, 0);
+  TfLiteTensor* output = micro_context->AllocateTempOutputTensor(node, 0);
+  TfLiteTensor* axis = micro_context->AllocateTempInputTensor(node, 1);
+
+  op_data->input_zp = input->params.zero_point;
+  op_data->input_scale = input->params.scale;
+  op_data->output_zp = output->params.zero_point;
+  op_data->output_scale = output->params.scale;
+  op_data->num_output_elements = NumElements(output);
+  context->RequestScratchBufferInArena(context, sizeof(int) * input->dims->size,
+                                       &op_data->scratch_input_iter_idx);
+  context->RequestScratchBufferInArena(
+      context, sizeof(int) * static_cast<int>(ElementCount(*axis->dims)),
+      &op_data->scratch_resolved_axis_idx);
+
+  micro_context->DeallocateTempTfLiteTensor(input);
+  micro_context->DeallocateTempTfLiteTensor(output);
+  micro_context->DeallocateTempTfLiteTensor(axis);
+  return kTfLiteOk;
+}
+
+TfLiteStatus PrepareMeanOrSumHelper(TfLiteContext* context, TfLiteNode* node,
+                                    OpDataReduce* op_data) {
+  MicroContext* micro_context = GetMicroContext(context);
+  TfLiteTensor* input = micro_context->AllocateTempInputTensor(node, 0);
+  TfLiteTensor* output = micro_context->AllocateTempOutputTensor(node, 0);
+  TfLiteTensor* axis = micro_context->AllocateTempInputTensor(node, 1);
+  if (input->type == kTfLiteInt8 || input->type == kTfLiteInt16) {
+    const double real_multiplier = static_cast<double>(input->params.scale) /
+                                   static_cast<double>(output->params.scale);
+    QuantizeMultiplier(real_multiplier, &op_data->multiplier, &op_data->shift);
+  }
+
+  int output_size = NumElements(output);
+  op_data->num_axis = NumElements(axis);
+
+  if (input->type == kTfLiteInt8 || input->type == kTfLiteInt16) {
+    context->RequestScratchBufferInArena(context, output_size * sizeof(int32_t),
+                                         &op_data->scratch_accumulator_idx);
+    op_data->input_zp = input->params.zero_point;
+    op_data->input_scale = input->params.scale;
+    op_data->output_zp = output->params.zero_point;
+    op_data->output_scale = output->params.scale;
+  }
+
+  TF_LITE_ENSURE_OK(
+      context,
+      PrepareSimple(context, node, &(op_data->multiplier), &(op_data->shift)));
+  // TODO(b/144955155): Support uint8_t(b/144955155) and int8_t(b/144955018)
+  micro_context->DeallocateTempTfLiteTensor(input);
+  micro_context->DeallocateTempTfLiteTensor(output);
+  micro_context->DeallocateTempTfLiteTensor(axis);
+  return kTfLiteOk;
+}
+
 void ResolveAxis(const int* axis_data, int axis_count,
                  tflite::MeanParams* op_params) {
   int i = 0;
@@ -77,7 +167,7 @@ void ResolveAxis(const int* axis_data, int axis_count,
 
 template <typename T>
 TfLiteStatus QuantizedMeanOrSum(TfLiteContext* context, TfLiteNode* node,
-                                int* input_iter, int* resolved_axis,
+                                int* temp_index, int* resolved_axis,
                                 int32_t* temp_sum, OpDataReduce* op_data,
                                 bool compute_sum) {
   const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
@@ -93,7 +183,7 @@ TfLiteStatus QuantizedMeanOrSum(TfLiteContext* context, TfLiteNode* node,
       op_data->multiplier, op_data->shift, op_data->output_zp,
       &output->dims->data[0], output->dims->size,
       tflite::micro::GetTensorData<int>(axis), op_data->num_axis,
-      params->keep_dims, input_iter, resolved_axis, temp_sum, compute_sum);
+      params->keep_dims, temp_index, resolved_axis, temp_sum, compute_sum);
   TF_LITE_ENSURE(context, result);
 
   return kTfLiteOk;
@@ -102,11 +192,11 @@ TfLiteStatus QuantizedMeanOrSum(TfLiteContext* context, TfLiteNode* node,
 template <typename integer_type>
 TfLiteStatus EvalIntegerMean(TfLiteContext* context, TfLiteNode* node,
                              int num_axis, OpDataReduce* op_data,
-                             int* input_iter, int* resolved_axis) {
+                             int* temp_index, int* resolved_axis) {
   int32_t* temp_sum = static_cast<int32_t*>(
       context->GetScratchBuffer(context, op_data->scratch_accumulator_idx));
 
-  QuantizedMeanOrSum<integer_type>(context, node, input_iter, resolved_axis,
+  QuantizedMeanOrSum<integer_type>(context, node, temp_index, resolved_axis,
                                    temp_sum, op_data, /*compute_sum=*/false);
 
   return kTfLiteOk;
@@ -191,74 +281,6 @@ TfLiteStatus EvalMinMaxHelper(TfLiteContext* context, TfLiteNode* node,
   return kTfLiteOk;
 }
 
-}  // namespace
-
-TfLiteStatus PrepareMinMaxHelper(TfLiteContext* context, TfLiteNode* node,
-                                 OpDataReduce* op_data) {
-  TF_LITE_ENSURE_OK(context, PrepareSimple(context, node, &op_data->multiplier,
-                                           &op_data->shift));
-
-  MicroContext* micro_context = GetMicroContext(context);
-  TfLiteTensor* input = micro_context->AllocateTempInputTensor(node, 0);
-  TfLiteTensor* output = micro_context->AllocateTempOutputTensor(node, 0);
-  TfLiteTensor* axis = micro_context->AllocateTempInputTensor(node, 1);
-
-  op_data->input_zp = input->params.zero_point;
-  op_data->input_scale = input->params.scale;
-  op_data->output_zp = output->params.zero_point;
-  op_data->output_scale = output->params.scale;
-  op_data->num_output_elements = NumElements(output);
-  context->RequestScratchBufferInArena(context, sizeof(int) * input->dims->size,
-                                       &op_data->scratch_input_iter_idx);
-  context->RequestScratchBufferInArena(
-      context, sizeof(int) * static_cast<int>(ElementCount(*axis->dims)),
-      &op_data->scratch_resolved_axis_idx);
-
-  micro_context->DeallocateTempTfLiteTensor(input);
-  micro_context->DeallocateTempTfLiteTensor(output);
-  micro_context->DeallocateTempTfLiteTensor(axis);
-  return kTfLiteOk;
-}
-
-TfLiteStatus PrepareMeanOrSumHelper(TfLiteContext* context, TfLiteNode* node,
-                                    OpDataReduce* op_data) {
-  MicroContext* micro_context = GetMicroContext(context);
-  TfLiteTensor* input = micro_context->AllocateTempInputTensor(node, 0);
-  TfLiteTensor* output = micro_context->AllocateTempOutputTensor(node, 0);
-  TfLiteTensor* axis = micro_context->AllocateTempInputTensor(node, 1);
-  if (input->type == kTfLiteInt8 || input->type == kTfLiteInt16) {
-    const double real_multiplier = static_cast<double>(input->params.scale) /
-                                   static_cast<double>(output->params.scale);
-    QuantizeMultiplier(real_multiplier, &op_data->multiplier, &op_data->shift);
-  }
-
-  op_data->num_axis = NumElements(axis);
-  op_data->num_output_elements = NumElements(output);
-
-  if (input->type == kTfLiteInt8 || input->type == kTfLiteInt16) {
-    context->RequestScratchBufferInArena(
-        context, sizeof(int32_t) * op_data->num_output_elements,
-        &op_data->scratch_accumulator_idx);
-    op_data->input_zp = input->params.zero_point;
-    op_data->input_scale = input->params.scale;
-    op_data->output_zp = output->params.zero_point;
-    op_data->output_scale = output->params.scale;
-  }
-  context->RequestScratchBufferInArena(context, sizeof(int) * input->dims->size,
-                                       &op_data->scratch_input_iter_idx);
-  context->RequestScratchBufferInArena(context, sizeof(int) * op_data->num_axis,
-                                       &op_data->scratch_resolved_axis_idx);
-
-  TF_LITE_ENSURE_OK(
-      context,
-      PrepareSimple(context, node, &(op_data->multiplier), &(op_data->shift)));
-  // TODO(b/144955155): Support uint8_t(b/144955155) and int8_t(b/144955018)
-  micro_context->DeallocateTempTfLiteTensor(input);
-  micro_context->DeallocateTempTfLiteTensor(output);
-  micro_context->DeallocateTempTfLiteTensor(axis);
-  return kTfLiteOk;
-}
-
 TfLiteStatus PrepareAllHelper(TfLiteContext* context, TfLiteNode* node,
                               OpDataReduce* op_data) {
   MicroContext* micro_context = GetMicroContext(context);
@@ -296,10 +318,8 @@ TfLiteStatus EvalMeanHelper(TfLiteContext* context, TfLiteNode* node,
       reinterpret_cast<TfLiteReducerParams*>(node->builtin_data);
 
   int num_axis = static_cast<int>(ElementCount(*axis->dims));
-  int* input_iter = static_cast<int*>(
-      context->GetScratchBuffer(context, op_data->scratch_input_iter_idx));
-  int* resolved_axis = static_cast<int*>(
-      context->GetScratchBuffer(context, op_data->scratch_resolved_axis_idx));
+  int temp_index[kMaxNumberOfAxis];
+  int resolved_axis[kMaxNumberOfReducedAxis];
 
   switch (input->type) {
     case kTfLiteFloat32: {
@@ -328,19 +348,19 @@ TfLiteStatus EvalMeanHelper(TfLiteContext* context, TfLiteNode* node,
                 input->dims->size, tflite::micro::GetTensorData<float>(output),
                 output->dims->data, output->dims->size,
                 tflite::micro::GetTensorData<int>(axis), num_axis,
-                params->keep_dims, input_iter, resolved_axis,
+                params->keep_dims, temp_index, resolved_axis,
                 tflite::micro::GetTensorData<float>(output)));
       }
     } break;
     case kTfLiteInt8: {
       TF_LITE_ENSURE_OK(
           context, EvalIntegerMean<int8_t>(context, node, num_axis, op_data,
-                                           input_iter, resolved_axis));
+                                           temp_index, resolved_axis));
     } break;
     case kTfLiteInt16: {
       TF_LITE_ENSURE_OK(
           context, EvalIntegerMean<int16_t>(context, node, num_axis, op_data,
-                                            input_iter, resolved_axis));
+                                            temp_index, resolved_axis));
     } break;
     default:
       TF_LITE_ENSURE_MSG(context, false,
@@ -352,7 +372,56 @@ TfLiteStatus EvalMeanHelper(TfLiteContext* context, TfLiteNode* node,
 
 TfLiteStatus EvalMaxHelper(TfLiteContext* context, TfLiteNode* node,
                            OpDataReduce* op_data) {
-  return EvalMinMaxHelper(context, node, op_data, kEvalMax);
+  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+  const TfLiteEvalTensor* axis = tflite::micro::GetEvalInput(context, node, 1);
+  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
+  TfLiteReducerParams* params =
+      static_cast<TfLiteReducerParams*>(node->builtin_data);
+
+  // Interpret an axis tensor with null dimensions as a scalar
+  int num_axis = static_cast<int>(ElementCount(*axis->dims));
+  int* temp_buffer = static_cast<int*>(
+      context->GetScratchBuffer(context, op_data->scratch_accumulator_idx));
+  int* resolved_axis = static_cast<int*>(
+      context->GetScratchBuffer(context, op_data->scratch_resolved_axis_idx));
+  switch (input->type) {
+    case kTfLiteFloat32:
+      TF_LITE_ENSURE(
+          context,
+          reference_ops::ReduceGeneric<float>(
+              tflite::micro::GetTensorData<float>(input), input->dims->data,
+              input->dims->size, tflite::micro::GetTensorData<float>(output),
+              output->dims->data, output->dims->size,
+              tflite::micro::GetTensorData<int>(axis), num_axis,
+              params->keep_dims, temp_buffer, resolved_axis,
+              std::numeric_limits<float>::lowest(),
+              [](const float current, const float in) -> float {
+                return (in > current) ? in : current;
+              }));
+      break;
+    case kTfLiteInt8:
+      TF_LITE_ENSURE_EQ(context, static_cast<double>(op_data->input_scale),
+                        static_cast<double>(op_data->output_scale));
+      TF_LITE_ENSURE_EQ(context, op_data->input_zp, op_data->output_zp);
+      TF_LITE_ENSURE(
+          context,
+          reference_ops::ReduceGeneric<int8_t>(
+              tflite::micro::GetTensorData<int8_t>(input), input->dims->data,
+              input->dims->size, tflite::micro::GetTensorData<int8_t>(output),
+              output->dims->data, output->dims->size,
+              tflite::micro::GetTensorData<int>(axis), num_axis,
+              params->keep_dims, temp_buffer, resolved_axis,
+              std::numeric_limits<int8_t>::lowest(),
+              [](const int8_t current, const int8_t in) -> int8_t {
+                return (in > current) ? in : current;
+              }));
+      break;
+    default:
+      MicroPrintf("Only float32 and int8 types are supported.");
+      return kTfLiteError;
+  }
+  return kTfLiteOk;
 }
 
 TfLiteStatus EvalMinHelper(TfLiteContext* context, TfLiteNode* node,
@@ -371,10 +440,8 @@ TfLiteStatus EvalSumHelper(TfLiteContext* context, TfLiteNode* node,
 
   // Interpret an axis tensor with null dimensions as a scalar.
   int num_axis = static_cast<int>(ElementCount(*axis->dims));
-  int* input_iter = static_cast<int*>(
-      context->GetScratchBuffer(context, op_data->scratch_input_iter_idx));
-  int* resolved_axis = static_cast<int*>(
-      context->GetScratchBuffer(context, op_data->scratch_resolved_axis_idx));
+  int temp_index[kMaxNumberOfAxis];
+  int resolved_axis[kMaxNumberOfReducedAxis];
 
   switch (input->type) {
     case kTfLiteFloat32: {
@@ -385,7 +452,7 @@ TfLiteStatus EvalSumHelper(TfLiteContext* context, TfLiteNode* node,
               input->dims->size, tflite::micro::GetTensorData<float>(output),
               output->dims->data, output->dims->size,
               tflite::micro::GetTensorData<int>(axis), num_axis,
-              params->keep_dims, input_iter, resolved_axis, /*init_value=*/0.f,
+              params->keep_dims, temp_index, resolved_axis, /*init_value=*/0.f,
               [](const float current, const float in) -> float {
                 return in + current;
               }));
@@ -393,13 +460,13 @@ TfLiteStatus EvalSumHelper(TfLiteContext* context, TfLiteNode* node,
     case kTfLiteInt8: {
       int32_t* temp_sum = static_cast<int32_t*>(
           context->GetScratchBuffer(context, op_data->scratch_accumulator_idx));
-      QuantizedMeanOrSum<int8_t>(context, node, input_iter, resolved_axis,
+      QuantizedMeanOrSum<int8_t>(context, node, temp_index, resolved_axis,
                                  temp_sum, op_data, /*compute_sum=*/true);
     } break;
     case kTfLiteInt16: {
       int32_t* temp_sum = static_cast<int32_t*>(
           context->GetScratchBuffer(context, op_data->scratch_accumulator_idx));
-      QuantizedMeanOrSum<int16_t>(context, node, input_iter, resolved_axis,
+      QuantizedMeanOrSum<int16_t>(context, node, temp_index, resolved_axis,
                                   temp_sum, op_data, /*compute_sum=*/true);
     } break;
     default:

--- a/tensorflow/lite/micro/kernels/reduce_common.cc
+++ b/tensorflow/lite/micro/kernels/reduce_common.cc
@@ -28,8 +28,6 @@ limitations under the License.
 
 namespace tflite {
 
-namespace {
-
 TfLiteStatus PrepareSimple(TfLiteContext* context, TfLiteNode* node,
                            int32_t* multiplier, int* shift) {
   MicroContext* micro_context = GetMicroContext(context);
@@ -190,8 +188,6 @@ TfLiteStatus EvalMinMaxHelper(TfLiteContext* context, TfLiteNode* node,
   }
   return kTfLiteOk;
 }
-
-}  // namespace
 
 TfLiteStatus PrepareMinMaxHelper(TfLiteContext* context, TfLiteNode* node,
                                  OpDataReduce* op_data) {

--- a/tensorflow/lite/micro/kernels/reduce_common.cc
+++ b/tensorflow/lite/micro/kernels/reduce_common.cc
@@ -189,34 +189,6 @@ TfLiteStatus EvalMinMaxHelper(TfLiteContext* context, TfLiteNode* node,
   return kTfLiteOk;
 }
 
-TfLiteStatus PrepareMaxHelper(TfLiteContext* context, TfLiteNode* node,
-                              OpDataReduce* op_data) {
-  TF_LITE_ENSURE_OK(context, PrepareSimple(context, node, &op_data->multiplier,
-                                           &op_data->shift));
-
-  MicroContext* micro_context = GetMicroContext(context);
-  TfLiteTensor* input = micro_context->AllocateTempInputTensor(node, 0);
-  TfLiteTensor* output = micro_context->AllocateTempOutputTensor(node, 0);
-  TfLiteTensor* axis = micro_context->AllocateTempInputTensor(node, 1);
-
-  op_data->input_zp = input->params.zero_point;
-  op_data->input_scale = input->params.scale;
-  op_data->output_zp = output->params.zero_point;
-  op_data->output_scale = output->params.scale;
-  op_data->num_output_elements = NumElements(output);
-
-  context->RequestScratchBufferInArena(context, sizeof(int) * input->dims->size,
-                                       &op_data->scratch_accumulator_idx);
-  context->RequestScratchBufferInArena(
-      context, sizeof(int) * static_cast<int>(ElementCount(*axis->dims)),
-      &op_data->scratch_resolved_axis_idx);
-
-  micro_context->DeallocateTempTfLiteTensor(input);
-  micro_context->DeallocateTempTfLiteTensor(output);
-  micro_context->DeallocateTempTfLiteTensor(axis);
-  return kTfLiteOk;
-}
-
 TfLiteStatus PrepareMinMaxHelper(TfLiteContext* context, TfLiteNode* node,
                                  OpDataReduce* op_data) {
   TF_LITE_ENSURE_OK(context, PrepareSimple(context, node, &op_data->multiplier,
@@ -267,6 +239,10 @@ TfLiteStatus PrepareMeanOrSumHelper(TfLiteContext* context, TfLiteNode* node,
     op_data->output_zp = output->params.zero_point;
     op_data->output_scale = output->params.scale;
   }
+  context->RequestScratchBufferInArena(context, sizeof(int) * input->dims->size,
+                                       &op_data->scratch_input_iter_idx);
+  context->RequestScratchBufferInArena(context, sizeof(int) * op_data->num_axis,
+                                       &op_data->scratch_resolved_axis_idx);
 
   TF_LITE_ENSURE_OK(
       context,

--- a/tensorflow/lite/micro/kernels/reduce_common.cc
+++ b/tensorflow/lite/micro/kernels/reduce_common.cc
@@ -28,6 +28,8 @@ limitations under the License.
 
 namespace tflite {
 
+namespace {
+
 TfLiteStatus PrepareSimple(TfLiteContext* context, TfLiteNode* node,
                            int32_t* multiplier, int* shift) {
   MicroContext* micro_context = GetMicroContext(context);
@@ -189,6 +191,8 @@ TfLiteStatus EvalMinMaxHelper(TfLiteContext* context, TfLiteNode* node,
   return kTfLiteOk;
 }
 
+}  // namespace
+
 TfLiteStatus PrepareMinMaxHelper(TfLiteContext* context, TfLiteNode* node,
                                  OpDataReduce* op_data) {
   TF_LITE_ENSURE_OK(context, PrepareSimple(context, node, &op_data->multiplier,
@@ -228,11 +232,12 @@ TfLiteStatus PrepareMeanOrSumHelper(TfLiteContext* context, TfLiteNode* node,
     QuantizeMultiplier(real_multiplier, &op_data->multiplier, &op_data->shift);
   }
 
-  int output_size = NumElements(output);
   op_data->num_axis = NumElements(axis);
+  op_data->num_output_elements = NumElements(output);
 
   if (input->type == kTfLiteInt8 || input->type == kTfLiteInt16) {
-    context->RequestScratchBufferInArena(context, output_size * sizeof(int32_t),
+    context->RequestScratchBufferInArena(
+        context, sizeof(int32_t) * op_data->num_output_elements,
                                          &op_data->scratch_accumulator_idx);
     op_data->input_zp = input->params.zero_point;
     op_data->input_scale = input->params.scale;

--- a/tensorflow/lite/micro/kernels/reduce_common.cc
+++ b/tensorflow/lite/micro/kernels/reduce_common.cc
@@ -28,9 +28,6 @@ limitations under the License.
 
 namespace tflite {
 
-const int kMaxNumberOfAxis = 5;
-const int kMaxNumberOfReducedAxis = 2;
-
 TfLiteStatus PrepareSimple(TfLiteContext* context, TfLiteNode* node,
                            int32_t* multiplier, int* shift) {
   MicroContext* micro_context = GetMicroContext(context);
@@ -61,6 +58,134 @@ TfLiteStatus PrepareSimple(TfLiteContext* context, TfLiteNode* node,
   }
   micro_context->DeallocateTempTfLiteTensor(axis);
   micro_context->DeallocateTempTfLiteTensor(input);
+  return kTfLiteOk;
+}
+
+void ResolveAxis(const int* axis_data, int axis_count,
+                 tflite::MeanParams* op_params) {
+  int i = 0;
+  for (; i < axis_count; ++i) {
+    op_params->axis[i] = static_cast<int16_t>(axis_data[i]);
+  }
+  for (; i < 4; ++i) {
+    op_params->axis[i] = 1;
+  }
+  op_params->axis_count = axis_count;
+}
+
+template <typename T>
+TfLiteStatus QuantizedMeanOrSum(TfLiteContext* context, TfLiteNode* node,
+                                int* input_iter, int* resolved_axis,
+                                int32_t* temp_sum, OpDataReduce* op_data,
+                                bool compute_sum) {
+  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+  const TfLiteEvalTensor* axis = tflite::micro::GetEvalInput(context, node, 1);
+  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+  TfLiteReducerParams* params =
+      static_cast<TfLiteReducerParams*>(node->builtin_data);
+
+  bool result = reference_ops::QuantizedMeanOrSumExtraArgs<T, int32_t>(
+      tflite::micro::GetTensorData<T>(input), op_data->input_zp,
+      op_data->input_scale, &input->dims->data[0], input->dims->size,
+      tflite::micro::GetTensorData<T>(output), op_data->output_scale,
+      op_data->multiplier, op_data->shift, op_data->output_zp,
+      &output->dims->data[0], output->dims->size,
+      tflite::micro::GetTensorData<int>(axis), op_data->num_axis,
+      params->keep_dims, input_iter, resolved_axis, temp_sum, compute_sum);
+  TF_LITE_ENSURE(context, result);
+
+  return kTfLiteOk;
+}
+
+template <typename integer_type>
+TfLiteStatus EvalIntegerMean(TfLiteContext* context, TfLiteNode* node,
+                             int num_axis, OpDataReduce* op_data,
+                             int* input_iter, int* resolved_axis) {
+  int32_t* temp_sum = static_cast<int32_t*>(
+      context->GetScratchBuffer(context, op_data->scratch_accumulator_idx));
+
+  QuantizedMeanOrSum<integer_type>(context, node, input_iter, resolved_axis,
+                                   temp_sum, op_data, /*compute_sum=*/false);
+
+  return kTfLiteOk;
+}
+
+enum MinMaxEvalType { kEvalMin, kEvalMax };
+
+template <typename T>
+struct MinMaxReducerCompare {
+  MinMaxReducerCompare() = delete;
+  MinMaxReducerCompare(MinMaxEvalType evalType) : type_(evalType) {};
+
+  constexpr T initialValue() const {
+    return (type_ == kEvalMin) ? std::numeric_limits<T>::max()
+                               : std::numeric_limits<T>::lowest();
+  }
+
+  // should be able to use "auto" keyword here, but GCC and Clang blow a fuse
+  T (*compare())(const T, const T) {
+    if (type_ == kEvalMin) {
+      return [](const T current, const T in) -> T {
+        return (in < current) ? in : current;
+      };
+    } else {
+      return [](const T current, const T in) -> T {
+        return (in > current) ? in : current;
+      };
+    }
+  }
+
+ private:
+  MinMaxEvalType type_;
+};
+
+TfLiteStatus EvalMinMaxHelper(TfLiteContext* context, TfLiteNode* node,
+                              OpDataReduce* op_data, MinMaxEvalType evalType) {
+  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+  const TfLiteEvalTensor* axis = tflite::micro::GetEvalInput(context, node, 1);
+  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
+  TfLiteReducerParams* params =
+      static_cast<TfLiteReducerParams*>(node->builtin_data);
+
+  // Interpret an axis tensor with null dimensions as a scalar
+  int num_axis = static_cast<int>(ElementCount(*axis->dims));
+  int* input_iter = static_cast<int*>(
+      context->GetScratchBuffer(context, op_data->scratch_input_iter_idx));
+  int* resolved_axis = static_cast<int*>(
+      context->GetScratchBuffer(context, op_data->scratch_resolved_axis_idx));
+  switch (input->type) {
+    case kTfLiteFloat32: {
+      MinMaxReducerCompare<float> reducer(evalType);
+      TF_LITE_ENSURE(
+          context,
+          reference_ops::ReduceGeneric<float>(
+              tflite::micro::GetTensorData<float>(input), input->dims->data,
+              input->dims->size, tflite::micro::GetTensorData<float>(output),
+              output->dims->data, output->dims->size,
+              tflite::micro::GetTensorData<int>(axis), num_axis,
+              params->keep_dims, input_iter, resolved_axis,
+              reducer.initialValue(), reducer.compare()));
+    } break;
+    case kTfLiteInt8: {
+      MinMaxReducerCompare<int8_t> reducer(evalType);
+      TF_LITE_ENSURE_EQ(context, static_cast<double>(op_data->input_scale),
+                        static_cast<double>(op_data->output_scale));
+      TF_LITE_ENSURE_EQ(context, op_data->input_zp, op_data->output_zp);
+      TF_LITE_ENSURE(
+          context,
+          reference_ops::ReduceGeneric<int8_t>(
+              tflite::micro::GetTensorData<int8_t>(input), input->dims->data,
+              input->dims->size, tflite::micro::GetTensorData<int8_t>(output),
+              output->dims->data, output->dims->size,
+              tflite::micro::GetTensorData<int>(axis), num_axis,
+              params->keep_dims, input_iter, resolved_axis,
+              reducer.initialValue(), reducer.compare()));
+    } break;
+    default:
+      MicroPrintf("Only float32 and int8 types are supported.");
+      return kTfLiteError;
+  }
   return kTfLiteOk;
 }
 
@@ -153,134 +278,6 @@ TfLiteStatus PrepareMeanOrSumHelper(TfLiteContext* context, TfLiteNode* node,
   return kTfLiteOk;
 }
 
-void ResolveAxis(const int* axis_data, int axis_count,
-                 tflite::MeanParams* op_params) {
-  int i = 0;
-  for (; i < axis_count; ++i) {
-    op_params->axis[i] = static_cast<int16_t>(axis_data[i]);
-  }
-  for (; i < 4; ++i) {
-    op_params->axis[i] = 1;
-  }
-  op_params->axis_count = axis_count;
-}
-
-template <typename T>
-TfLiteStatus QuantizedMeanOrSum(TfLiteContext* context, TfLiteNode* node,
-                                int* temp_index, int* resolved_axis,
-                                int32_t* temp_sum, OpDataReduce* op_data,
-                                bool compute_sum) {
-  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
-  const TfLiteEvalTensor* axis = tflite::micro::GetEvalInput(context, node, 1);
-  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
-  TfLiteReducerParams* params =
-      static_cast<TfLiteReducerParams*>(node->builtin_data);
-
-  bool result = reference_ops::QuantizedMeanOrSumExtraArgs<T, int32_t>(
-      tflite::micro::GetTensorData<T>(input), op_data->input_zp,
-      op_data->input_scale, &input->dims->data[0], input->dims->size,
-      tflite::micro::GetTensorData<T>(output), op_data->output_scale,
-      op_data->multiplier, op_data->shift, op_data->output_zp,
-      &output->dims->data[0], output->dims->size,
-      tflite::micro::GetTensorData<int>(axis), op_data->num_axis,
-      params->keep_dims, temp_index, resolved_axis, temp_sum, compute_sum);
-  TF_LITE_ENSURE(context, result);
-
-  return kTfLiteOk;
-}
-
-template <typename integer_type>
-TfLiteStatus EvalIntegerMean(TfLiteContext* context, TfLiteNode* node,
-                             int num_axis, OpDataReduce* op_data,
-                             int* temp_index, int* resolved_axis) {
-  int32_t* temp_sum = static_cast<int32_t*>(
-      context->GetScratchBuffer(context, op_data->scratch_accumulator_idx));
-
-  QuantizedMeanOrSum<integer_type>(context, node, temp_index, resolved_axis,
-                                   temp_sum, op_data, /*compute_sum=*/false);
-
-  return kTfLiteOk;
-}
-
-enum MinMaxEvalType { kEvalMin, kEvalMax };
-
-template <typename T>
-struct MinMaxReducerCompare {
-  MinMaxReducerCompare() = delete;
-  MinMaxReducerCompare(MinMaxEvalType evalType) : type_(evalType) {};
-
-  constexpr T initialValue() const {
-    return (type_ == kEvalMin) ? std::numeric_limits<T>::max()
-                               : std::numeric_limits<T>::lowest();
-  }
-
-  // should be able to use "auto" keyword here, but GCC and Clang blow a fuse
-  T (*compare())(const T, const T) {
-    if (type_ == kEvalMin) {
-      return [](const T current, const T in) -> T {
-        return (in < current) ? in : current;
-      };
-    } else {
-      return [](const T current, const T in) -> T {
-        return (in > current) ? in : current;
-      };
-    }
-  }
-
- private:
-  MinMaxEvalType type_;
-};
-
-TfLiteStatus EvalMinMaxHelper(TfLiteContext* context, TfLiteNode* node,
-                              OpDataReduce* op_data, MinMaxEvalType evalType) {
-  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
-  const TfLiteEvalTensor* axis = tflite::micro::GetEvalInput(context, node, 1);
-  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
-  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
-  TfLiteReducerParams* params =
-      static_cast<TfLiteReducerParams*>(node->builtin_data);
-
-  // Interpret an axis tensor with null dimensions as a scalar
-  int num_axis = static_cast<int>(ElementCount(*axis->dims));
-  int* input_iter = static_cast<int*>(
-      context->GetScratchBuffer(context, op_data->scratch_input_iter_idx));
-  int* resolved_axis = static_cast<int*>(
-      context->GetScratchBuffer(context, op_data->scratch_resolved_axis_idx));
-  switch (input->type) {
-    case kTfLiteFloat32: {
-      MinMaxReducerCompare<float> reducer(evalType);
-      TF_LITE_ENSURE(
-          context,
-          reference_ops::ReduceGeneric<float>(
-              tflite::micro::GetTensorData<float>(input), input->dims->data,
-              input->dims->size, tflite::micro::GetTensorData<float>(output),
-              output->dims->data, output->dims->size,
-              tflite::micro::GetTensorData<int>(axis), num_axis,
-              params->keep_dims, input_iter, resolved_axis,
-              reducer.initialValue(), reducer.compare()));
-    } break;
-    case kTfLiteInt8: {
-      MinMaxReducerCompare<int8_t> reducer(evalType);
-      TF_LITE_ENSURE_EQ(context, static_cast<double>(op_data->input_scale),
-                        static_cast<double>(op_data->output_scale));
-      TF_LITE_ENSURE_EQ(context, op_data->input_zp, op_data->output_zp);
-      TF_LITE_ENSURE(
-          context,
-          reference_ops::ReduceGeneric<int8_t>(
-              tflite::micro::GetTensorData<int8_t>(input), input->dims->data,
-              input->dims->size, tflite::micro::GetTensorData<int8_t>(output),
-              output->dims->data, output->dims->size,
-              tflite::micro::GetTensorData<int>(axis), num_axis,
-              params->keep_dims, input_iter, resolved_axis,
-              reducer.initialValue(), reducer.compare()));
-    } break;
-    default:
-      MicroPrintf("Only float32 and int8 types are supported.");
-      return kTfLiteError;
-  }
-  return kTfLiteOk;
-}
-
 TfLiteStatus PrepareAllHelper(TfLiteContext* context, TfLiteNode* node,
                               OpDataReduce* op_data) {
   MicroContext* micro_context = GetMicroContext(context);
@@ -318,8 +315,10 @@ TfLiteStatus EvalMeanHelper(TfLiteContext* context, TfLiteNode* node,
       reinterpret_cast<TfLiteReducerParams*>(node->builtin_data);
 
   int num_axis = static_cast<int>(ElementCount(*axis->dims));
-  int temp_index[kMaxNumberOfAxis];
-  int resolved_axis[kMaxNumberOfReducedAxis];
+  int* input_iter = static_cast<int*>(
+      context->GetScratchBuffer(context, op_data->scratch_input_iter_idx));
+  int* resolved_axis = static_cast<int*>(
+      context->GetScratchBuffer(context, op_data->scratch_resolved_axis_idx));
 
   switch (input->type) {
     case kTfLiteFloat32: {
@@ -348,19 +347,19 @@ TfLiteStatus EvalMeanHelper(TfLiteContext* context, TfLiteNode* node,
                 input->dims->size, tflite::micro::GetTensorData<float>(output),
                 output->dims->data, output->dims->size,
                 tflite::micro::GetTensorData<int>(axis), num_axis,
-                params->keep_dims, temp_index, resolved_axis,
+                params->keep_dims, input_iter, resolved_axis,
                 tflite::micro::GetTensorData<float>(output)));
       }
     } break;
     case kTfLiteInt8: {
       TF_LITE_ENSURE_OK(
           context, EvalIntegerMean<int8_t>(context, node, num_axis, op_data,
-                                           temp_index, resolved_axis));
+                                           input_iter, resolved_axis));
     } break;
     case kTfLiteInt16: {
       TF_LITE_ENSURE_OK(
           context, EvalIntegerMean<int16_t>(context, node, num_axis, op_data,
-                                            temp_index, resolved_axis));
+                                            input_iter, resolved_axis));
     } break;
     default:
       TF_LITE_ENSURE_MSG(context, false,
@@ -372,56 +371,7 @@ TfLiteStatus EvalMeanHelper(TfLiteContext* context, TfLiteNode* node,
 
 TfLiteStatus EvalMaxHelper(TfLiteContext* context, TfLiteNode* node,
                            OpDataReduce* op_data) {
-  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
-  const TfLiteEvalTensor* axis = tflite::micro::GetEvalInput(context, node, 1);
-  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
-  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
-  TfLiteReducerParams* params =
-      static_cast<TfLiteReducerParams*>(node->builtin_data);
-
-  // Interpret an axis tensor with null dimensions as a scalar
-  int num_axis = static_cast<int>(ElementCount(*axis->dims));
-  int* temp_buffer = static_cast<int*>(
-      context->GetScratchBuffer(context, op_data->scratch_accumulator_idx));
-  int* resolved_axis = static_cast<int*>(
-      context->GetScratchBuffer(context, op_data->scratch_resolved_axis_idx));
-  switch (input->type) {
-    case kTfLiteFloat32:
-      TF_LITE_ENSURE(
-          context,
-          reference_ops::ReduceGeneric<float>(
-              tflite::micro::GetTensorData<float>(input), input->dims->data,
-              input->dims->size, tflite::micro::GetTensorData<float>(output),
-              output->dims->data, output->dims->size,
-              tflite::micro::GetTensorData<int>(axis), num_axis,
-              params->keep_dims, temp_buffer, resolved_axis,
-              std::numeric_limits<float>::lowest(),
-              [](const float current, const float in) -> float {
-                return (in > current) ? in : current;
-              }));
-      break;
-    case kTfLiteInt8:
-      TF_LITE_ENSURE_EQ(context, static_cast<double>(op_data->input_scale),
-                        static_cast<double>(op_data->output_scale));
-      TF_LITE_ENSURE_EQ(context, op_data->input_zp, op_data->output_zp);
-      TF_LITE_ENSURE(
-          context,
-          reference_ops::ReduceGeneric<int8_t>(
-              tflite::micro::GetTensorData<int8_t>(input), input->dims->data,
-              input->dims->size, tflite::micro::GetTensorData<int8_t>(output),
-              output->dims->data, output->dims->size,
-              tflite::micro::GetTensorData<int>(axis), num_axis,
-              params->keep_dims, temp_buffer, resolved_axis,
-              std::numeric_limits<int8_t>::lowest(),
-              [](const int8_t current, const int8_t in) -> int8_t {
-                return (in > current) ? in : current;
-              }));
-      break;
-    default:
-      MicroPrintf("Only float32 and int8 types are supported.");
-      return kTfLiteError;
-  }
-  return kTfLiteOk;
+  return EvalMinMaxHelper(context, node, op_data, kEvalMax);
 }
 
 TfLiteStatus EvalMinHelper(TfLiteContext* context, TfLiteNode* node,
@@ -440,8 +390,10 @@ TfLiteStatus EvalSumHelper(TfLiteContext* context, TfLiteNode* node,
 
   // Interpret an axis tensor with null dimensions as a scalar.
   int num_axis = static_cast<int>(ElementCount(*axis->dims));
-  int temp_index[kMaxNumberOfAxis];
-  int resolved_axis[kMaxNumberOfReducedAxis];
+  int* input_iter = static_cast<int*>(
+      context->GetScratchBuffer(context, op_data->scratch_input_iter_idx));
+  int* resolved_axis = static_cast<int*>(
+      context->GetScratchBuffer(context, op_data->scratch_resolved_axis_idx));
 
   switch (input->type) {
     case kTfLiteFloat32: {
@@ -452,7 +404,7 @@ TfLiteStatus EvalSumHelper(TfLiteContext* context, TfLiteNode* node,
               input->dims->size, tflite::micro::GetTensorData<float>(output),
               output->dims->data, output->dims->size,
               tflite::micro::GetTensorData<int>(axis), num_axis,
-              params->keep_dims, temp_index, resolved_axis, /*init_value=*/0.f,
+              params->keep_dims, input_iter, resolved_axis, /*init_value=*/0.f,
               [](const float current, const float in) -> float {
                 return in + current;
               }));
@@ -460,13 +412,13 @@ TfLiteStatus EvalSumHelper(TfLiteContext* context, TfLiteNode* node,
     case kTfLiteInt8: {
       int32_t* temp_sum = static_cast<int32_t*>(
           context->GetScratchBuffer(context, op_data->scratch_accumulator_idx));
-      QuantizedMeanOrSum<int8_t>(context, node, temp_index, resolved_axis,
+      QuantizedMeanOrSum<int8_t>(context, node, input_iter, resolved_axis,
                                  temp_sum, op_data, /*compute_sum=*/true);
     } break;
     case kTfLiteInt16: {
       int32_t* temp_sum = static_cast<int32_t*>(
           context->GetScratchBuffer(context, op_data->scratch_accumulator_idx));
-      QuantizedMeanOrSum<int16_t>(context, node, temp_index, resolved_axis,
+      QuantizedMeanOrSum<int16_t>(context, node, input_iter, resolved_axis,
                                   temp_sum, op_data, /*compute_sum=*/true);
     } break;
     default:

--- a/tensorflow/lite/micro/kernels/xtensa/reduce.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/reduce.cc
@@ -57,6 +57,14 @@ TfLiteStatus XtensaPrepareMax(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 }
 
+TfLiteStatus XtensaPrepareMin(TfLiteContext* context, TfLiteNode* node) {
+  OpDataReduce* op_data =
+      &(static_cast<XtensaReduceOpData*>(node->user_data)->reference_op_data);
+  TF_LITE_ENSURE_OK(context, PrepareMinMaxHelper(context, node, op_data));
+  // P6 FLK library does not support REDUCE_MIN
+  return kTfLiteOk;
+}
+
 TfLiteStatus XtensaPrepareMeanOrSum(TfLiteContext* context, TfLiteNode* node) {
   OpDataReduce* op_data =
       &(static_cast<XtensaReduceOpData*>(node->user_data)->reference_op_data);
@@ -65,6 +73,13 @@ TfLiteStatus XtensaPrepareMeanOrSum(TfLiteContext* context, TfLiteNode* node) {
 #else
   return PrepareMeanOrSumHelper(context, node, op_data);
 #endif
+}
+
+TfLiteStatus XtensaPrepareAll(TfLiteContext* context, TfLiteNode* node) {
+  OpDataReduce* op_data =
+      &(static_cast<XtensaReduceOpData*>(node->user_data)->reference_op_data);
+  TF_LITE_ENSURE_OK(context, PrepareAllHelper(context, node, op_data));
+  return kTfLiteOk;
 }
 
 TfLiteStatus XtensaEvalMean(TfLiteContext* context, TfLiteNode* node) {
@@ -106,10 +121,26 @@ TfLiteStatus XtensaEvalMax(TfLiteContext* context, TfLiteNode* node) {
 #endif  // defined(HIFI5) || defined(HIFI4)
 }
 
+TfLiteStatus XtensaEvalMin(TfLiteContext* context, TfLiteNode* node) {
+  XtensaReduceOpData* op_data_xtensa =
+      static_cast<XtensaReduceOpData*>(node->user_data);
+  OpDataReduce* op_data = &(op_data_xtensa->reference_op_data);
+  // P6 FLK library does not support REDUCE_MIN
+  return EvalMinHelper(context, node, op_data);
+}
+
 TfLiteStatus XtensaEvalSum(TfLiteContext* context, TfLiteNode* node) {
   OpDataReduce* op_data =
       &(static_cast<XtensaReduceOpData*>(node->user_data)->reference_op_data);
   return EvalSumHelper(context, node, op_data);
+}
+
+TfLiteStatus XtensaEvalAll(TfLiteContext* context, TfLiteNode* node) {
+  XtensaReduceOpData* op_data_xtensa =
+      static_cast<XtensaReduceOpData*>(node->user_data);
+  OpDataReduce* op_data = &(op_data_xtensa->reference_op_data);
+  // P6 FLK library does not support REDUCE_MIN
+  return EvalAllHelper(context, node, op_data);
 }
 
 TFLMRegistration Register_MEAN() {
@@ -122,9 +153,19 @@ TFLMRegistration Register_REDUCE_MAX() {
                                    XtensaEvalMax);
 }
 
+TFLMRegistration Register_REDUCE_MIN() {
+  return tflite::micro::RegisterOp(XtensaInitReduce, XtensaPrepareMin,
+                                   XtensaEvalMin);
+}
+
 TFLMRegistration Register_SUM() {
   return tflite::micro::RegisterOp(XtensaInitReduce, XtensaPrepareMeanOrSum,
                                    XtensaEvalSum);
+}
+
+TFLMRegistration Register_REDUCE_ALL() {
+  return tflite::micro::RegisterOp(XtensaInitReduce, XtensaPrepareAll,
+                                   XtensaEvalAll);
 }
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/reduce.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/reduce.cc
@@ -1,4 +1,4 @@
-/* Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -46,46 +46,43 @@ void* XtensaInitReduce(TfLiteContext* context, const char* buffer,
 TfLiteStatus XtensaPrepareMax(TfLiteContext* context, TfLiteNode* node) {
   OpDataReduce* op_data =
       &(static_cast<XtensaReduceOpData*>(node->user_data)->reference_op_data);
-  TF_LITE_ENSURE_OK(context, PrepareMinMaxHelper(context, node, op_data));
+#if defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+  return PrepareMaxHifi(context, node, op_data);
+#else
+  TF_LITE_ENSURE_OK(context, PrepareMaxHelper(context, node, op_data));
 #if defined(VISION_P6)
   TF_LITE_ENSURE_OK(context, ReducePrepareVision(context, node));
 #endif  // VISION_P6
-  return kTfLiteOk;
-}
-
-TfLiteStatus XtensaPrepareMin(TfLiteContext* context, TfLiteNode* node) {
-  OpDataReduce* op_data =
-      &(static_cast<XtensaReduceOpData*>(node->user_data)->reference_op_data);
-  TF_LITE_ENSURE_OK(context, PrepareMinMaxHelper(context, node, op_data));
-  // P6 FLK library does not support REDUCE_MIN
+#endif  // defined(HIFI5) || defined(HIFI4)
   return kTfLiteOk;
 }
 
 TfLiteStatus XtensaPrepareMeanOrSum(TfLiteContext* context, TfLiteNode* node) {
   OpDataReduce* op_data =
       &(static_cast<XtensaReduceOpData*>(node->user_data)->reference_op_data);
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+  return PrepareMeanOrSumHifi(context, node, op_data);
+#else
   return PrepareMeanOrSumHelper(context, node, op_data);
-}
-
-TfLiteStatus XtensaPrepareAll(TfLiteContext* context, TfLiteNode* node) {
-  OpDataReduce* op_data =
-      &(static_cast<XtensaReduceOpData*>(node->user_data)->reference_op_data);
-  TF_LITE_ENSURE_OK(context, PrepareAllHelper(context, node, op_data));
-  return kTfLiteOk;
+#endif
 }
 
 TfLiteStatus XtensaEvalMean(TfLiteContext* context, TfLiteNode* node) {
   OpDataReduce* op_data =
       &(static_cast<XtensaReduceOpData*>(node->user_data)->reference_op_data);
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+  return EvalMeanHifi(context, node, op_data);
+#else
   return EvalMeanHelper(context, node, op_data);
+#endif
 }
 
 TfLiteStatus XtensaEvalMax(TfLiteContext* context, TfLiteNode* node) {
-  XtensaReduceOpData* op_data_xtensa =
-      static_cast<XtensaReduceOpData*>(node->user_data);
-  OpDataReduce* op_data = &(op_data_xtensa->reference_op_data);
-
-#if defined(VISION_P6)
+  OpDataReduce* op_data =
+      &(static_cast<XtensaReduceOpData*>(node->user_data)->reference_op_data);
+#if defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+  return EvalMaxHifi(context, node, op_data);
+#elif defined(VISION_P6)
   const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
   TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
   TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
@@ -106,29 +103,13 @@ TfLiteStatus XtensaEvalMax(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 #else
   return EvalMaxHelper(context, node, op_data);
-#endif
-}
-
-TfLiteStatus XtensaEvalMin(TfLiteContext* context, TfLiteNode* node) {
-  XtensaReduceOpData* op_data_xtensa =
-      static_cast<XtensaReduceOpData*>(node->user_data);
-  OpDataReduce* op_data = &(op_data_xtensa->reference_op_data);
-  // P6 FLK library does not support REDUCE_MIN
-  return EvalMinHelper(context, node, op_data);
+#endif  // defined(HIFI5) || defined(HIFI4)
 }
 
 TfLiteStatus XtensaEvalSum(TfLiteContext* context, TfLiteNode* node) {
   OpDataReduce* op_data =
       &(static_cast<XtensaReduceOpData*>(node->user_data)->reference_op_data);
   return EvalSumHelper(context, node, op_data);
-}
-
-TfLiteStatus XtensaEvalAll(TfLiteContext* context, TfLiteNode* node) {
-  XtensaReduceOpData* op_data_xtensa =
-      static_cast<XtensaReduceOpData*>(node->user_data);
-  OpDataReduce* op_data = &(op_data_xtensa->reference_op_data);
-  // P6 FLK library does not support REDUCE_MIN
-  return EvalAllHelper(context, node, op_data);
 }
 
 TFLMRegistration Register_MEAN() {
@@ -141,19 +122,9 @@ TFLMRegistration Register_REDUCE_MAX() {
                                    XtensaEvalMax);
 }
 
-TFLMRegistration Register_REDUCE_MIN() {
-  return tflite::micro::RegisterOp(XtensaInitReduce, XtensaPrepareMin,
-                                   XtensaEvalMin);
-}
-
 TFLMRegistration Register_SUM() {
   return tflite::micro::RegisterOp(XtensaInitReduce, XtensaPrepareMeanOrSum,
                                    XtensaEvalSum);
-}
-
-TFLMRegistration Register_REDUCE_ALL() {
-  return tflite::micro::RegisterOp(XtensaInitReduce, XtensaPrepareAll,
-                                   XtensaEvalAll);
 }
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/reduce.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/reduce.cc
@@ -49,7 +49,7 @@ TfLiteStatus XtensaPrepareMax(TfLiteContext* context, TfLiteNode* node) {
 #if defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
   return PrepareMaxHifi(context, node, op_data);
 #else
-  TF_LITE_ENSURE_OK(context, PrepareMaxHelper(context, node, op_data));
+  TF_LITE_ENSURE_OK(context, PrepareMinMaxHelper(context, node, op_data));
 #if defined(VISION_P6)
   TF_LITE_ENSURE_OK(context, ReducePrepareVision(context, node));
 #endif  // VISION_P6

--- a/tensorflow/lite/micro/kernels/xtensa/reduce_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/reduce_hifi.cc
@@ -1,0 +1,496 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/integer_ops/mean.h"
+#include "tensorflow/lite/kernels/internal/reference/reduce.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa_reduce.h"
+#include "tensorflow/lite/micro/micro_log.h"
+#include "tensorflow/lite/micro/micro_utils.h"
+
+namespace tflite {
+
+const int kMaxNumberOfAxisHifi = 5;
+const int kMaxNumberOfReducedAxisHifi = 4;
+
+extern TfLiteStatus PrepareSimple(TfLiteContext* context, TfLiteNode* node,
+                           int32_t* multiplier, int* shift);
+extern void ResolveAxis(const int* axis_data, int axis_count,
+                 tflite::MeanParams* op_params);
+
+TfLiteStatus PrepareMaxHifi(TfLiteContext* context, TfLiteNode* node,
+                              OpDataReduce* op_data) {
+  TF_LITE_ENSURE_OK(context, PrepareSimple(context, node, &op_data->multiplier,
+                                           &op_data->shift));
+
+  MicroContext* micro_context = GetMicroContext(context);
+  TfLiteTensor* input = micro_context->AllocateTempInputTensor(node, 0);
+  TfLiteTensor* output = micro_context->AllocateTempOutputTensor(node, 0);
+  TfLiteTensor* axis = micro_context->AllocateTempInputTensor(node, 1);
+
+  op_data->input_scale = input->params.scale;
+  op_data->output_scale = output->params.scale;
+  op_data->num_output_elements = NumElements(output);
+
+  context->RequestScratchBufferInArena(context, sizeof(int) * input->dims->size,
+                                       &op_data->temp_buffer_idx);
+  context->RequestScratchBufferInArena(
+      context, sizeof(int) * static_cast<int>(ElementCount(*axis->dims)),
+      &op_data->resolved_axis_idx);
+#if (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+  XtensaReduceOpData* xt_data =
+          reinterpret_cast<XtensaReduceOpData*>(node->user_data);
+  if((input->dims->size <= 4) && (input->type == kTfLiteInt8))
+  {
+    reduce_ops_t reduce_type = REDUCE_MAX;
+    const TfLiteEvalTensor* eval_axis = tflite::micro::GetEvalInput(context, node, 1);
+    const int *axis_data_ptr  = tflite::micro::GetTensorData<int>(eval_axis);
+    int num_axis = static_cast<int>(ElementCount(*eval_axis->dims));
+    int required_scratch;
+    required_scratch = xa_nn_reduce_getsize_nhwc(-4,
+                                                input->dims->data,
+                                                input->dims->size,
+                                                axis_data_ptr,
+                                                num_axis,
+                                                reduce_type);
+    if (required_scratch <= 0) {
+      TF_LITE_KERNEL_LOG(context,
+                        "reduce_max_4D_asym8: xa_nn_reduce_getsize_nhwc failed");
+      return kTfLiteError;
+    }
+
+    const TfLiteStatus scratch_status = context->RequestScratchBufferInArena(
+        context, required_scratch,
+        &(xt_data->scratch_tensor_index));
+    TF_LITE_ENSURE_OK(context, scratch_status);
+  }
+#endif
+  micro_context->DeallocateTempTfLiteTensor(input);
+  micro_context->DeallocateTempTfLiteTensor(output);
+  micro_context->DeallocateTempTfLiteTensor(axis);
+  return kTfLiteOk;
+}
+
+TfLiteStatus PrepareMeanOrSumHifi(TfLiteContext* context, TfLiteNode* node,
+                                    OpDataReduce* op_data) {
+  MicroContext* micro_context = GetMicroContext(context);
+  TfLiteTensor* input = micro_context->AllocateTempInputTensor(node, 0);
+  TfLiteTensor* output = micro_context->AllocateTempOutputTensor(node, 0);
+  TfLiteTensor* axis = micro_context->AllocateTempInputTensor(node, 1);
+  if (input->type == kTfLiteInt8 || input->type == kTfLiteInt16) {
+    const double real_multiplier = static_cast<double>(input->params.scale) /
+                                   static_cast<double>(output->params.scale);
+    QuantizeMultiplier(real_multiplier, &op_data->multiplier, &op_data->shift);
+  }
+
+  int output_size = NumElements(output);
+  op_data->num_axis = NumElements(axis);
+
+  if (input->type == kTfLiteInt8 || input->type == kTfLiteInt16) {
+    context->RequestScratchBufferInArena(context, output_size * sizeof(int32_t),
+                                         &op_data->temp_buffer_idx);
+    op_data->input_zp = input->params.zero_point;
+    op_data->input_scale = input->params.scale;
+    op_data->output_zp = output->params.zero_point;
+    op_data->output_scale = output->params.scale;
+  }
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+  XtensaReduceOpData* xt_data =
+          reinterpret_cast<XtensaReduceOpData*>(node->user_data);
+  if((input->dims->size <= 4) && (input->type == kTfLiteInt8 || input->type == kTfLiteInt16))
+  {
+    reduce_ops_t reduce_type = REDUCE_MEAN;
+    const TfLiteEvalTensor* eval_axis = tflite::micro::GetEvalInput(context, node, 1);
+    const int *axis_data_ptr  = tflite::micro::GetTensorData<int>(eval_axis);
+    int num_axis = static_cast<int>(ElementCount(*eval_axis->dims));
+    int required_scratch;
+    const TfLiteEvalTensor* eval_input = tflite::micro::GetEvalInput(context, node, 0);
+    int resolved_axis[kMaxNumberOfReducedAxisHifi];
+    int num_resolved_axis = 0;
+    if (!reference_ops::ResolveAxis(eval_input->dims->size, tflite::micro::GetTensorData<int>(eval_axis), num_axis, resolved_axis, &num_resolved_axis)) {
+      TF_LITE_ENSURE(context, false);
+    }
+    int num_elm_in_axis = 1;
+    int axis_itr;
+    
+    for(axis_itr=0; axis_itr < num_resolved_axis; axis_itr++)
+    {
+      num_elm_in_axis *= eval_input->dims->data[resolved_axis[axis_itr]];
+    }
+
+    int shift = 63 - CountLeadingZeros(static_cast<uint64_t>(num_elm_in_axis));
+    shift = std::min(std::min(shift, 32), 31 + op_data->shift);
+    xt_data->updated_multiplier = (num_elm_in_axis > 1) ? (WORD32)(((long long int)(op_data->multiplier) << shift) / num_elm_in_axis) : op_data->multiplier;
+    xt_data->updated_shift = op_data->shift - shift;
+    
+    int inp_precision = -4; /* ASYM8S */ 
+    if(input->type == kTfLiteInt16)
+     inp_precision = -7; /* ASYM16S */ 
+    
+    required_scratch = xa_nn_reduce_getsize_nhwc(inp_precision,
+                                                input->dims->data,
+                                                input->dims->size,
+                                                axis_data_ptr,
+                                                num_axis,
+                                                reduce_type);
+    if (required_scratch <= 0) {
+      TF_LITE_KERNEL_LOG(context,
+                        "reduce_mean_4D_asym8: xa_nn_reduce_getsize_nhwc failed");
+      return kTfLiteError;
+    }
+
+    const TfLiteStatus scratch_status = context->RequestScratchBufferInArena(
+        context, required_scratch,
+        &(xt_data->scratch_tensor_index));
+    TF_LITE_ENSURE_OK(context, scratch_status);
+    micro_context->DeallocateTempTfLiteTensor(input);
+    micro_context->DeallocateTempTfLiteTensor(output);
+    micro_context->DeallocateTempTfLiteTensor(axis);
+    return kTfLiteOk;
+  }
+#endif
+  TF_LITE_ENSURE_OK(
+      context,
+      PrepareSimple(context, node, &(op_data->multiplier), &(op_data->shift)));
+  // TODO(b/144955155): Support uint8_t(b/144955155) and int8_t(b/144955018)
+  micro_context->DeallocateTempTfLiteTensor(input);
+  micro_context->DeallocateTempTfLiteTensor(output);
+  micro_context->DeallocateTempTfLiteTensor(axis);
+  return kTfLiteOk;
+}
+
+template <typename T>
+TfLiteStatus QuantizedMeanOrSum(TfLiteContext* context, TfLiteNode* node,
+                                int* temp_index, int* resolved_axis,
+                                int32_t* temp_sum, OpDataReduce* op_data,
+                                bool compute_sum) {
+  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+  const TfLiteEvalTensor* axis = tflite::micro::GetEvalInput(context, node, 1);
+  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+  TfLiteReducerParams* params =
+      static_cast<TfLiteReducerParams*>(node->builtin_data);
+
+  bool result = reference_ops::QuantizedMeanOrSumExtraArgs<T, int32_t>(
+      tflite::micro::GetTensorData<T>(input), op_data->input_zp,
+      op_data->input_scale, &input->dims->data[0], input->dims->size,
+      tflite::micro::GetTensorData<T>(output), op_data->output_scale,
+      op_data->multiplier, op_data->shift, op_data->output_zp,
+      &output->dims->data[0], output->dims->size,
+      tflite::micro::GetTensorData<int>(axis), op_data->num_axis,
+      params->keep_dims, temp_index, resolved_axis, temp_sum, compute_sum);
+  TF_LITE_ENSURE(context, result);
+
+  return kTfLiteOk;
+}
+
+template <typename T, typename U>
+TfLiteStatus Mean(TfLiteContext* context, TfLiteNode* node,
+                  OpDataReduce* op_data, int* temp_index, int* resolved_axis,
+                  U* temp_sum) {
+  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+  const TfLiteEvalTensor* axis = tflite::micro::GetEvalInput(context, node, 1);
+  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+  TfLiteReducerParams* params =
+      static_cast<TfLiteReducerParams*>(node->builtin_data);
+
+  reference_ops::Mean<T, U>(
+      tflite::micro::GetTensorData<T>(input), &input->dims->data[0],
+      input->dims->size, tflite::micro::GetTensorData<T>(output),
+      &output->dims->data[0], output->dims->size,
+      tflite::micro::GetTensorData<int>(axis), op_data->num_axis,
+      params->keep_dims, temp_index, resolved_axis, temp_sum);
+
+  return kTfLiteOk;
+}
+
+template <typename integer_type>
+TfLiteStatus EvalIntegerMean(TfLiteContext* context, TfLiteNode* node,
+                             int num_axis, OpDataReduce* op_data,
+                             int* temp_index, int* resolved_axis) {
+  int32_t* temp_sum = static_cast<int32_t*>(
+      context->GetScratchBuffer(context, op_data->temp_buffer_idx));
+
+  if (op_data->input_zp == op_data->output_zp &&
+      op_data->input_scale == op_data->output_scale) {
+    Mean<integer_type, int32_t>(context, node, op_data, temp_index,
+                                resolved_axis, temp_sum);
+  } else {
+    QuantizedMeanOrSum<integer_type>(context, node, temp_index, resolved_axis,
+                                     temp_sum, op_data, /*compute_sum=*/false);
+  }
+  return kTfLiteOk;
+}
+
+TfLiteStatus EvalMeanHifi(TfLiteContext* context, TfLiteNode* node,
+                            OpDataReduce* op_data) {
+  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+  const TfLiteEvalTensor* axis = tflite::micro::GetEvalInput(context, node, 1);
+  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+  TfLiteReducerParams* params =
+      reinterpret_cast<TfLiteReducerParams*>(node->builtin_data);
+
+  int num_axis = static_cast<int>(ElementCount(*axis->dims));
+  int temp_index[kMaxNumberOfAxisHifi];
+  int resolved_axis[kMaxNumberOfReducedAxisHifi];
+
+  switch (input->type) {
+    case kTfLiteFloat32: {
+      tflite::MeanParams op_params;
+      ResolveAxis(tflite::micro::GetTensorData<int>(axis), num_axis,
+                  &op_params);
+
+      // Special case mean implementation exists for 4D mean across axes 1
+      // and 2.
+      bool special_case_4d_axes_1_and_2 =
+          input->dims->size == 4 && op_params.axis_count == 2 &&
+          ((op_params.axis[0] == 1 && op_params.axis[1] == 2) ||
+           (op_params.axis[0] == 2 && op_params.axis[1] == 1));
+
+      // Defer to specialized implementation for 4D Mean across axes 1 & 2.
+      if (params->keep_dims && special_case_4d_axes_1_and_2) {
+        reference_ops::Mean(op_params, tflite::micro::GetTensorShape(input),
+                            tflite::micro::GetTensorData<float>(input),
+                            tflite::micro::GetTensorShape(output),
+                            tflite::micro::GetTensorData<float>(output));
+      } else {
+        TF_LITE_ENSURE(
+            context,
+            reference_ops::Mean(
+                tflite::micro::GetTensorData<float>(input), input->dims->data,
+                input->dims->size, tflite::micro::GetTensorData<float>(output),
+                output->dims->data, output->dims->size,
+                tflite::micro::GetTensorData<int>(axis), num_axis,
+                params->keep_dims, temp_index, resolved_axis,
+                tflite::micro::GetTensorData<float>(output)));
+      }
+    } break;
+    case kTfLiteInt8: {
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+      XtensaReduceOpData* xt_data =
+              reinterpret_cast<XtensaReduceOpData*>(node->user_data);
+      const int8_t *input_data_ptr  = tflite::micro::GetTensorData<int8_t>(input);
+      int8_t *output_data_ptr  = tflite::micro::GetTensorData<int8_t>(output);
+      void *p_scratch;
+      int err = 0;
+
+      if(input->dims->size <= 4)
+      {
+        // Resolve axis.
+        int num_resolved_axis = 0;
+        if (!reference_ops::ResolveAxis(input->dims->size, tflite::micro::GetTensorData<int>(axis), num_axis, resolved_axis, &num_resolved_axis)) {
+          TF_LITE_ENSURE(context, false);
+        }
+        p_scratch = static_cast<void*>(
+        context->GetScratchBuffer(context, xt_data->scratch_tensor_index));
+
+        int output_size = output->dims->size;
+        int output_dims_data[1] = {1};
+        int* out_dims_ptr = output->dims->data;
+        if(output_size == 0){
+          output_size = 1;
+          out_dims_ptr = output_dims_data;
+        }
+        err = xa_nn_reduce_mean_4D_asym8s_asym8s(output_data_ptr,
+                                                 out_dims_ptr,
+                                                 input_data_ptr,
+                                                 input->dims->data,
+                                                 resolved_axis,
+                                                 output_size,
+                                                 input->dims->size,
+                                                 num_resolved_axis,
+                                                 op_data->input_zp,
+                                                 xt_data->updated_multiplier,
+                                                 xt_data->updated_shift,
+                                                 op_data->output_zp,
+                                                 p_scratch);
+        TF_LITE_ENSURE(context, err == 0);
+      }
+      else
+      {
+        TF_LITE_ENSURE_OK(
+            context, EvalIntegerMean<int8_t>(context, node, num_axis, op_data,
+                                             temp_index, resolved_axis));
+      }
+#else
+      TF_LITE_ENSURE_OK(
+          context, EvalIntegerMean<int8_t>(context, node, num_axis, op_data,
+                                           temp_index, resolved_axis));
+#endif
+    } break;
+    case kTfLiteInt16: {
+#if (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+      XtensaReduceOpData* xt_data =
+              reinterpret_cast<XtensaReduceOpData*>(node->user_data);
+      const int16_t *input_data_ptr  = tflite::micro::GetTensorData<int16_t>(input);
+      int16_t *output_data_ptr  = tflite::micro::GetTensorData<int16_t>(output);
+      void *p_scratch;
+      int err = 0;
+
+      if(input->dims->size <= 4)
+      {
+        // Resolve axis.
+        int num_resolved_axis = 0;
+        if (!reference_ops::ResolveAxis(input->dims->size, tflite::micro::GetTensorData<int>(axis), num_axis, resolved_axis, &num_resolved_axis)) {
+          TF_LITE_ENSURE(context, false);
+        }
+        p_scratch = static_cast<void*>(
+        context->GetScratchBuffer(context, xt_data->scratch_tensor_index));
+
+        err = xa_nn_reduce_mean_4D_asym16s_asym16s(output_data_ptr,
+                                                 output->dims->data,
+                                                 input_data_ptr,
+                                                 input->dims->data,
+                                                 resolved_axis,
+                                                 output->dims->size,
+                                                 input->dims->size,
+                                                 num_resolved_axis,
+                                                 op_data->input_zp,
+                                                 xt_data->updated_multiplier,
+                                                 xt_data->updated_shift,
+                                                 op_data->output_zp,
+                                                 p_scratch);
+        TF_LITE_ENSURE(context, err == 0);
+      }
+      else
+      {
+        TF_LITE_ENSURE_OK(
+            context, EvalIntegerMean<int16_t>(context, node, num_axis, op_data,
+                                             temp_index, resolved_axis));
+      }
+#else
+      TF_LITE_ENSURE_OK(
+          context, EvalIntegerMean<int16_t>(context, node, num_axis, op_data,
+                                            temp_index, resolved_axis));
+#endif
+    } break;
+    default:
+      TF_LITE_ENSURE_MSG(context, false,
+                         "Currently, only float32, int8 or int16 input type "
+                         "is supported.");
+  }
+  return kTfLiteOk;
+}
+
+TfLiteStatus EvalMaxHifi(TfLiteContext* context, TfLiteNode* node,
+                           OpDataReduce* op_data) {
+  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+  const TfLiteEvalTensor* axis = tflite::micro::GetEvalInput(context, node, 1);
+  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
+  TfLiteReducerParams* params =
+      static_cast<TfLiteReducerParams*>(node->builtin_data);
+
+  // Interpret an axis tensor with null dimensions as a scalar
+  int num_axis = static_cast<int>(ElementCount(*axis->dims));
+  int* temp_buffer = static_cast<int*>(
+      context->GetScratchBuffer(context, op_data->temp_buffer_idx));
+  int* resolved_axis = static_cast<int*>(
+      context->GetScratchBuffer(context, op_data->resolved_axis_idx));
+  switch (input->type) {
+    case kTfLiteFloat32:
+      TF_LITE_ENSURE(
+          context,
+          reference_ops::ReduceGeneric<float>(
+              tflite::micro::GetTensorData<float>(input), input->dims->data,
+              input->dims->size, tflite::micro::GetTensorData<float>(output),
+              output->dims->data, output->dims->size,
+              tflite::micro::GetTensorData<int>(axis), num_axis,
+              params->keep_dims, temp_buffer, resolved_axis,
+              std::numeric_limits<float>::lowest(),
+              [](const float current, const float in) -> float {
+                return (in > current) ? in : current;
+              }));
+      break;
+    case kTfLiteInt8: {
+#if (defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4))
+      XtensaReduceOpData* xt_data =
+              reinterpret_cast<XtensaReduceOpData*>(node->user_data);
+      const int8_t *input_data_ptr  = tflite::micro::GetTensorData<int8_t>(input);
+      int8_t *output_data_ptr  = tflite::micro::GetTensorData<int8_t>(output);
+      void *p_scratch;
+      int err = 0;
+
+      if(input->dims->size <= 4)
+      {
+        // Resolve axis.
+        int num_resolved_axis = 0;
+        if (!reference_ops::ResolveAxis(input->dims->size, tflite::micro::GetTensorData<int>(axis), num_axis, resolved_axis, &num_resolved_axis)) {
+          TF_LITE_ENSURE(context, false);
+        }
+        p_scratch = static_cast<void*>(
+        context->GetScratchBuffer(context, xt_data->scratch_tensor_index));
+
+        err = xa_nn_reduce_max_4D_asym8s_asym8s(output_data_ptr,
+                                                output->dims->data,
+                                                input_data_ptr,
+                                                input->dims->data,
+                                                resolved_axis,
+                                                output->dims->size,
+                                                input->dims->size,
+                                                num_resolved_axis,
+                                                p_scratch);
+        TF_LITE_ENSURE(context, err == 0);
+      }
+      else
+      {
+        TF_LITE_ENSURE_EQ(context, static_cast<double>(op_data->input_scale),
+                          static_cast<double>(op_data->output_scale));
+        TF_LITE_ENSURE_EQ(context, op_data->input_zp, op_data->output_zp);
+        TF_LITE_ENSURE(
+            context,
+            reference_ops::ReduceGeneric<int8_t>(
+                tflite::micro::GetTensorData<int8_t>(input), input->dims->data,
+                input->dims->size, tflite::micro::GetTensorData<int8_t>(output),
+                output->dims->data, output->dims->size,
+                tflite::micro::GetTensorData<int>(axis), num_axis,
+                params->keep_dims, temp_buffer, resolved_axis,
+                std::numeric_limits<int8_t>::lowest(),
+                [](const int8_t current, const int8_t in) -> int8_t {
+                  return (in > current) ? in : current;
+                }));
+      }
+#else
+      TF_LITE_ENSURE_EQ(context, static_cast<double>(op_data->input_scale),
+                        static_cast<double>(op_data->output_scale));
+      TF_LITE_ENSURE_EQ(context, op_data->input_zp, op_data->output_zp);
+      TF_LITE_ENSURE(
+          context,
+          reference_ops::ReduceGeneric<int8_t>(
+              tflite::micro::GetTensorData<int8_t>(input), input->dims->data,
+              input->dims->size, tflite::micro::GetTensorData<int8_t>(output),
+              output->dims->data, output->dims->size,
+              tflite::micro::GetTensorData<int>(axis), num_axis,
+              params->keep_dims, temp_buffer, resolved_axis,
+              std::numeric_limits<int8_t>::lowest(),
+              [](const int8_t current, const int8_t in) -> int8_t {
+                return (in > current) ? in : current;
+              }));
+#endif
+    } break;
+    default:
+      MicroPrintf("Only float32, int8, and int16 types are supported.");
+      return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/reduce_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/reduce_hifi.cc
@@ -113,6 +113,10 @@ TfLiteStatus PrepareMeanOrSumHifi(TfLiteContext* context, TfLiteNode* node,
     op_data->output_zp = output->params.zero_point;
     op_data->output_scale = output->params.scale;
   }
+  context->RequestScratchBufferInArena(context, sizeof(int) * input->dims->size,
+                                       &op_data->scratch_input_iter_idx);
+  context->RequestScratchBufferInArena(context, sizeof(int) * op_data->num_axis,
+                                       &op_data->scratch_resolved_axis_idx);
 #if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
   XtensaReduceOpData* xt_data =
           reinterpret_cast<XtensaReduceOpData*>(node->user_data);

--- a/tensorflow/lite/micro/kernels/xtensa/reduce_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/reduce_hifi.cc
@@ -52,10 +52,10 @@ TfLiteStatus PrepareMaxHifi(TfLiteContext* context, TfLiteNode* node,
   op_data->num_output_elements = NumElements(output);
 
   context->RequestScratchBufferInArena(context, sizeof(int) * input->dims->size,
-                                       &op_data->temp_buffer_idx);
+                                       &op_data->scratch_accumulator_idx);
   context->RequestScratchBufferInArena(
       context, sizeof(int) * static_cast<int>(ElementCount(*axis->dims)),
-      &op_data->resolved_axis_idx);
+      &op_data->scratch_resolved_axis_idx);
 #if (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
   XtensaReduceOpData* xt_data =
           reinterpret_cast<XtensaReduceOpData*>(node->user_data);
@@ -107,7 +107,7 @@ TfLiteStatus PrepareMeanOrSumHifi(TfLiteContext* context, TfLiteNode* node,
 
   if (input->type == kTfLiteInt8 || input->type == kTfLiteInt16) {
     context->RequestScratchBufferInArena(context, output_size * sizeof(int32_t),
-                                         &op_data->temp_buffer_idx);
+                                         &op_data->scratch_accumulator_idx);
     op_data->input_zp = input->params.zero_point;
     op_data->input_scale = input->params.scale;
     op_data->output_zp = output->params.zero_point;
@@ -227,7 +227,7 @@ TfLiteStatus EvalIntegerMean(TfLiteContext* context, TfLiteNode* node,
                              int num_axis, OpDataReduce* op_data,
                              int* temp_index, int* resolved_axis) {
   int32_t* temp_sum = static_cast<int32_t*>(
-      context->GetScratchBuffer(context, op_data->temp_buffer_idx));
+      context->GetScratchBuffer(context, op_data->scratch_accumulator_idx));
 
   if (op_data->input_zp == op_data->output_zp &&
       op_data->input_scale == op_data->output_scale) {
@@ -402,9 +402,9 @@ TfLiteStatus EvalMaxHifi(TfLiteContext* context, TfLiteNode* node,
   // Interpret an axis tensor with null dimensions as a scalar
   int num_axis = static_cast<int>(ElementCount(*axis->dims));
   int* temp_buffer = static_cast<int*>(
-      context->GetScratchBuffer(context, op_data->temp_buffer_idx));
+      context->GetScratchBuffer(context, op_data->scratch_accumulator_idx));
   int* resolved_axis = static_cast<int*>(
-      context->GetScratchBuffer(context, op_data->resolved_axis_idx));
+      context->GetScratchBuffer(context, op_data->scratch_resolved_axis_idx));
   switch (input->type) {
     case kTfLiteFloat32:
       TF_LITE_ENSURE(

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_reduce.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_reduce.h
@@ -23,9 +23,15 @@ limitations under the License.
 
 namespace tflite {
 
+
 struct XtensaReduceOpData {
   OpDataReduce reference_op_data;
 
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+  int scratch_tensor_index;
+  int32_t updated_multiplier;
+  int32_t updated_shift;
+#endif
 #if defined(VISION_P6)
   uint8_t* p_context;  // persistent lib context for this instance saved here
   uint32_t context_size;
@@ -39,6 +45,16 @@ TfLiteStatus ReducePrepareVision(TfLiteContext* context, TfLiteNode* node);
 TfLiteStatus ReduceEvalVision(const XtensaReduceOpData& data,
                               const TfLiteEvalTensor* input,
                               TfLiteEvalTensor* output);
+
+#elif defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+
+TfLiteStatus PrepareMeanOrSumHifi(TfLiteContext* context, TfLiteNode* node, OpDataReduce* op_data);
+
+TfLiteStatus PrepareMaxHifi(TfLiteContext* context, TfLiteNode* node, OpDataReduce* op_data);
+
+TfLiteStatus EvalMeanHifi(TfLiteContext* context, TfLiteNode* node, OpDataReduce* op_data);
+
+TfLiteStatus EvalMaxHifi(TfLiteContext* context, TfLiteNode* node, OpDataReduce* op_data);
 
 #endif  // VISION_P6
 

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -1,5 +1,46 @@
 
+# Explicitly add kernel sources specific to the Xtensa optimized
+# implementations.
+MICROLITE_CC_KERNEL_SRCS += \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/add_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_common_xtensa.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int16_reference.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int8_reference.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_common_xtensa.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_int8.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/pad_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/pooling_int8.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/pooling_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/reduce_hifi.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/reduce_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/reshape_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/softmax_int8_int16.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/softmax_vision.cc
+
+# Temporarily disabled: source files not yet added on this branch.
+# Re-enable each entry when its corresponding kernel PR lands.
+#  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_common_xtensa.cc
+#  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_float32_reference.cc
+#  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int8_int16_float32.cc
+#  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_int16_float32.cc
+#  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_reference.cc
+#  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int16_reference.cc
+#  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_float32_reference.cc
+#  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_int16.cc
+#  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_float32.cc
+#  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/pooling_int16.cc
+
 ifeq ($(TARGET_ARCH), hifimini)
+  # hifimini optimizations are implemented in the TFLM repository itself.
+  THIRD_PARTY_KERNEL_CC_SRCS += \
+    $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/hifimini/svdf.cc \
+    $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/hifimini/fully_connected.cc
+
   FFT_PATH := $(MAKEFILE_DIR)/downloads/hifi_fft
   INCLUDES += -I$(FFT_PATH)/
 
@@ -7,6 +48,36 @@ ifeq ($(TARGET_ARCH), hifimini)
     $(shell find $(FFT_PATH)/hifi2_fft -name "*.c")
   THIRD_PARTY_CC_HDRS += \
     $(shell find $(FFT_PATH)/hifi2_fft -name "*.h")
+
+else ifeq ($(TARGET_ARCH), hifi_iq)
+
+  PLATFORM_FLAGS = \
+    -Wno-shadow\
+
+  CCFLAGS += $(PLATFORM_FLAGS)
+  CXXFLAGS += $(PLATFORM_FLAGS)
+
+  NNLIB_PATH := $(MAKEFILE_DIR)/downloads/xa_nnlib_hifi_iq
+
+  THIRD_PARTY_KERNEL_CC_SRCS += \
+    $(shell find $(NNLIB_PATH) -name "*.c")
+
+  EXCLUDED_NNLIB_SRCS = \
+    $(NNLIB_PATH)/algo/layers/cnn/src/xa_nn_cnn_api.c \
+    $(NNLIB_PATH)/algo/layers/gru/src/xa_nn_gru_api.c \
+    $(NNLIB_PATH)/algo/layers/lstm/src/xa_nn_lstm_api.c \
+
+  THIRD_PARTY_KERNEL_CC_SRCS := $(filter-out $(EXCLUDED_NNLIB_SRCS), $(THIRD_PARTY_KERNEL_CC_SRCS))
+
+  THIRD_PARTY_CC_HDRS += \
+    $(shell find $(NNLIB_PATH) -name "*.h") \
+
+  INCLUDES += \
+    -I$(NNLIB_PATH)/ \
+    -I$(NNLIB_PATH)/algo/kernels/ \
+    -I$(NNLIB_PATH)/include/nnlib/ \
+    -I$(NNLIB_PATH)/include/ \
+    -I$(NNLIB_PATH)/algo/common/include/ \
 
 else ifeq ($(TARGET_ARCH), hifi5)
   DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/xtensa_download.sh ${DOWNLOADS_DIR} hifi5 $(TENSORFLOW_ROOT))
@@ -23,8 +94,12 @@ else ifeq ($(TARGET_ARCH), hifi5)
   # not have separate cflags (or the concept of modular build targets) with the
   # Makefile, -Wno-shadow will be used for everything.
 
+  # TODO: Adding HIFI_SIMD_WIDTH here to avoid error in ndsp lib compilation,
+  # once ndsp headers are removed from NNLib, this won't be needed
+
   PLATFORM_FLAGS = \
     -DNNLIB_HIFI5 \
+    -DHIFI_SIMD_WIDTH=16 \
     -Wno-shadow
 
   CCFLAGS += $(PLATFORM_FLAGS)
@@ -61,9 +136,11 @@ else ifeq ($(TARGET_ARCH), hifi5)
     -I$(NNLIB_PATH)/include/nnlib/ \
     -I$(NNLIB_PATH)/include/ \
     -I$(NNLIB_PATH)/algo/common/include/ \
+    -I$(NNLIB_PATH)/algo/ndsp/hifi5/include/ \
     -I$(NDSPLIB_PATH)/library/include/ \
     -I$(NDSPLIB_PATH)/library/include_private/
-else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi3 hifi4))
+
+else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi4 hifi4_internal hifi3 hifi3z fusion_f1 hifi1))
   # NNLib hifi4 also supports hifi3
   DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/xtensa_download.sh ${DOWNLOADS_DIR} hifi4 $(TENSORFLOW_ROOT))
   ifneq ($(DOWNLOAD_RESULT), SUCCESS)
@@ -78,9 +155,13 @@ else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi3 hifi4))
   # TODO(b/161489252): -Wno-shadow is only needed for xannlib. But since we do
   # not have separate cflags (or the concept of modular build targets) with the
   # Makefile, -Wno-shadow will be used for everything.
+  
+  # TODO: Adding HIFI_SIMD_WIDTH here to avoid error in ndsp lib compilation,
+  # once ndsp headers are removed from NNLib, this won't be needed
 
   PLATFORM_FLAGS = \
     -DNNLIB_V2 \
+    -DHIFI_SIMD_WIDTH=8 \
     -Wno-shadow
 
   CCFLAGS += $(PLATFORM_FLAGS)
@@ -104,7 +185,7 @@ else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi3 hifi4))
   EXCLUDED_NNLIB_SRCS = \
     $(NNLIB_PATH)/algo/layers/cnn/src/xa_nn_cnn_api.c \
     $(NNLIB_PATH)/algo/layers/gru/src/xa_nn_gru_api.c \
-    $(NNLIB_PATH)/algo/layers/lstm/src/xa_nn_lstm_api.c
+    $(NNLIB_PATH)/algo/layers/lstm/src/xa_nn_lstm_api.c 
 
   ifeq ($(TARGET_ARCH), hifi3)
     EXCLUDED_NNLIB_SRCS += \
@@ -116,7 +197,6 @@ else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi3 hifi4))
   
   ifeq ($(TARGET_ARCH), hifi4)
     EXCLUDED_NNLIB_SRCS += \
-      $(NNLIB_PATH)/algo/kernels/activations/hifi4/xa_nn_activations_asym8_asym8.c \
       $(NNLIB_PATH)/algo/kernels/norm/hifi4/xa_nn_norm3D_16.c
   endif
 
@@ -132,6 +212,7 @@ else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi3 hifi4))
     -I$(NNLIB_PATH)/include/nnlib/ \
     -I$(NNLIB_PATH)/include/ \
     -I$(NNLIB_PATH)/algo/common/include/ \
+    -I$(NNLIB_PATH)/algo/ndsp/hifi4/include/ \
     -I$(NDSPLIB_PATH)/library/include/ \
     -I$(NDSPLIB_PATH)/library/include_private/
 
@@ -167,4 +248,22 @@ else ifeq ($(TARGET_ARCH), vision_p6)
   LDFLAGS += -lidma
 else
   $(error Unsupported TARGET_ARCH=$(TARGET_ARCH))
+endif
+
+FFT_PATH := $(MAKEFILE_DIR)/downloads/hifi_fft
+
+INCLUDES += -I$(FFT_PATH)/
+
+ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi3 hifi3z hifi4 hifi4_internal hifi5 hifi1))
+THIRD_PARTY_KERNEL_CC_SRCS += \
+    $(shell find $(FFT_PATH)/hifi3_fft -name "*.c")
+
+THIRD_PARTY_CC_HDRS += \
+    $(shell find $(FFT_PATH)/hifi3_fft -name "*.h")
+else ifeq ($(TARGET_ARCH), hifimini)
+THIRD_PARTY_KERNEL_CC_SRCS += \
+    $(shell find $(FFT_PATH)/hifi2_fft -name "*.c")
+
+THIRD_PARTY_CC_HDRS += \
+    $(shell find $(FFT_PATH)/hifi2_fft -name "*.h")
 endif


### PR DESCRIPTION
1. Add HiFi3/4/5-optimized REDUCE_MEAN and REDUCE_MAX kernels using xa_nn_reduce_* NNLib APIs. 
2. Supports int8, int16, and float32 types. 
3. Removes anonymous namespace in reduce_common.cc to expose PrepareSimple/ResolveAxis helpers to reduce_hifi.cc

@cad-audio @joshih-cad