### PR TITLE
Add Xtensa HiFi activation kernels

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/activations.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/activations.cc
@@ -1,0 +1,206 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/micro/kernels/activations.h"
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/op_macros.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
+#include "tensorflow/lite/micro/micro_utils.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+
+namespace tflite {
+namespace {
+
+void* ReluInit(TfLiteContext* context, const char* buffer, size_t length) {
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+  return context->AllocatePersistentBuffer(context, sizeof(ReluOpData));
+}
+
+TfLiteStatus ReluEval(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const ReluOpData& data = *(static_cast<const ReluOpData*>(node->user_data));
+
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kActivationsInputTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kActivationsOutputTensor);
+
+  switch (input->type) {
+    case kTfLiteFloat32: {
+#if defined(INCLUDE_FLOAT_OPT) && (defined(HIFI4) || defined(HIFI5))
+      int err;
+      const float* inp_data_ptr;
+      float* out_data_ptr;
+      const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+      const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+      const int flat_size = MatchingFlatSize(input_shape, output_shape);
+
+      inp_data_ptr = tflite::micro::GetTensorData<float>(input);
+      out_data_ptr = tflite::micro::GetTensorData<float>(output);
+
+      err = xa_nn_vec_relu_std_f32_f32(out_data_ptr, inp_data_ptr, flat_size);
+      TF_LITE_ENSURE(context, err == 0);
+#else
+      ReluFloat(tflite::micro::GetTensorShape(input),
+                tflite::micro::GetTensorData<float>(input),
+                tflite::micro::GetTensorShape(output),
+                tflite::micro::GetTensorData<float>(output));
+#endif // defined(INCLUDE_FLOAT_OPT) && (defined(HIFI4) || defined(HIFI5))
+      return kTfLiteOk;
+    }
+    case kTfLiteInt8: {
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+      int err;
+      const int8_t* inp_data_ptr;
+      int8_t* out_data_ptr;
+      const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+      const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+      const int flat_size = MatchingFlatSize(input_shape, output_shape);
+
+      inp_data_ptr = tflite::micro::GetTensorData<int8_t>(input);
+      out_data_ptr = tflite::micro::GetTensorData<int8_t>(output);
+
+      err = xa_nn_vec_relu_asym8s_asym8s(out_data_ptr,
+                                         inp_data_ptr,
+                                         data.params.input_offset,
+                                         data.params.output_multiplier,
+                                         data.params.output_shift,
+                                         data.params.output_offset,
+                                         data.params.quantized_activation_min,
+                                         data.params.quantized_activation_max,
+                                         flat_size);
+
+      TF_LITE_ENSURE(context, err == 0);
+#else
+      tflite::ReluQuantized(data, tflite::micro::GetTensorShape(input),
+                            tflite::micro::GetTensorShape(output),
+                            tflite::micro::GetTensorData<int8_t>(input),
+                            tflite::micro::GetTensorData<int8_t>(output));
+#endif // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+      return kTfLiteOk;
+    }
+    case kTfLiteInt16: {
+      tflite::ReluQuantized<int16_t>(
+          data, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int16_t>(input),
+          tflite::micro::GetTensorData<int16_t>(output));
+      return kTfLiteOk;
+    }
+    default: {
+      MicroPrintf("Only float32/int8/int16 is supported currently, got %s",
+                  TfLiteTypeGetName(input->type));
+      return kTfLiteError;
+    }
+  }
+}
+
+void* Relu6Init(TfLiteContext* context, const char* buffer, size_t length) {
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+  return context->AllocatePersistentBuffer(context, sizeof(Relu6OpData));
+}
+
+TfLiteStatus Relu6Eval(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const Relu6OpData& data = *(static_cast<const Relu6OpData*>(node->user_data));
+
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kActivationsInputTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kActivationsOutputTensor);
+
+  switch (input->type) {
+    case kTfLiteFloat32: {
+#if defined(INCLUDE_FLOAT_OPT) && (defined(HIFI4) || defined(HIFI5))
+      int err;
+      const float* inp_data_ptr;
+      float* out_data_ptr;
+      const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+      const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+      const int flat_size = MatchingFlatSize(input_shape, output_shape);
+
+      inp_data_ptr = tflite::micro::GetTensorData<float>(input);
+      out_data_ptr = tflite::micro::GetTensorData<float>(output);
+
+      err = xa_nn_vec_relu6_f32_f32(out_data_ptr, inp_data_ptr, flat_size);
+      TF_LITE_ENSURE(context, err == 0);
+#else
+      Relu6Float(tflite::micro::GetTensorShape(input),
+                 tflite::micro::GetTensorData<float>(input),
+                 tflite::micro::GetTensorShape(output),
+                 tflite::micro::GetTensorData<float>(output));
+#endif // defined(INCLUDE_FLOAT_OPT) && (defined(HIFI4) || defined(HIFI5))
+
+      return kTfLiteOk;
+    }
+    case kTfLiteInt8: {
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+      int err;
+      const int8_t* inp_data_ptr;
+      int8_t* out_data_ptr;
+      const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+      const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+      const int flat_size = MatchingFlatSize(input_shape, output_shape);
+
+      inp_data_ptr = tflite::micro::GetTensorData<int8_t>(input);
+      out_data_ptr = tflite::micro::GetTensorData<int8_t>(output);
+
+      err = xa_nn_vec_activation_min_max_8_8(out_data_ptr, inp_data_ptr,
+                                                     data.zero, data.six, flat_size);
+      TF_LITE_ENSURE(context, err == 0);
+#else
+      Relu6Quantized<int8_t>(data.zero, data.six,
+                             tflite::micro::GetTensorShape(input),
+                             tflite::micro::GetTensorData<int8_t>(input),
+                             tflite::micro::GetTensorShape(output),
+                             tflite::micro::GetTensorData<int8_t>(output));
+#endif // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+      return kTfLiteOk;
+    }
+    case kTfLiteInt16: {
+      Relu6Quantized<int16_t>(data.zero, data.six,
+                              tflite::micro::GetTensorShape(input),
+                              tflite::micro::GetTensorData<int16_t>(input),
+                              tflite::micro::GetTensorShape(output),
+                              tflite::micro::GetTensorData<int16_t>(output));
+      return kTfLiteOk;
+    }
+    default: {
+      MicroPrintf("Only float32/int8/int16 is supported currently, got %s",
+                  TfLiteTypeGetName(input->type));
+      return kTfLiteError;
+    }
+  }
+}
+
+}  // namespace
+
+TFLMRegistration Register_RELU() {
+  return tflite::micro::RegisterOp(ReluInit, ReluPrepare, ReluEval);
+}
+
+TFLMRegistration Register_RELU6() {
+  return tflite::micro::RegisterOp(Relu6Init, Relu6Prepare, Relu6Eval);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/hard_swish.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/hard_swish.cc
@@ -1,0 +1,93 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/kernels/internal/reference/hard_swish.h"
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/op_macros.h"
+#include "tensorflow/lite/micro/kernels/hard_swish.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
+#include "tensorflow/lite/micro/micro_utils.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+
+namespace tflite {
+namespace {
+void* HardSwishInit(TfLiteContext* context, const char* buffer, size_t length) {
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+  return context->AllocatePersistentBuffer(context, sizeof(HardSwishParams));
+}
+
+TfLiteStatus HardSwishEval(TfLiteContext* context, TfLiteNode* node) {
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kHardSwishInputTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kHardSwishOutputTensor);
+  HardSwishParams* params = static_cast<HardSwishParams*>(node->user_data);
+
+  switch (input->type) {
+    case kTfLiteFloat32: {
+      tflite::reference_ops::HardSwish<float>(
+          tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<float>(input),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<float>(output));
+    } break;
+    case kTfLiteInt8: {
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+      int err = 0;
+      const int flat_size = MatchingFlatSize(tflite::micro::GetTensorShape(input), tflite::micro::GetTensorShape(output));
+      err = xa_nn_vec_hard_swish_asym8s_asym8s(
+          tflite::micro::GetTensorData<int8_t>(output),
+          tflite::micro::GetTensorData<int8_t>(input),
+          params->input_zero_point,
+          params->reluish_multiplier_fixedpoint_int16,
+          params->reluish_multiplier_exponent,
+          params->output_multiplier_fixedpoint_int16,
+          params->output_multiplier_exponent,
+          params->output_zero_point,
+          flat_size);
+
+      TF_LITE_ENSURE(context, err == 0);
+#else
+      tflite::reference_ops::HardSwish<int8_t>(
+          *params, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int8_t>(input),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int8_t>(output));
+#endif // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+    } break;
+    default: {
+      MicroPrintf("Unsupported type %s", TfLiteTypeGetName(input->type));
+      return kTfLiteError;
+    }
+  }
+  return kTfLiteOk;
+}
+
+}  // namespace
+
+TFLMRegistration Register_HARD_SWISH() {
+  return tflite::micro::RegisterOp(HardSwishInit, tflite::HardSwishPrepare,
+                                   HardSwishEval);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/prelu.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/prelu.cc
@@ -1,0 +1,142 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/kernels/internal/reference/prelu.h"
+
+#include <cstdint>
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/prelu.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa_prelu.h"
+#endif
+
+namespace tflite {
+
+void* PreluInit(TfLiteContext* context, const char* buffer, size_t length) {
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+  return context->AllocatePersistentBuffer(context, sizeof(XtensaPreluData));
+#else
+  return context->AllocatePersistentBuffer(context, sizeof(PreluParams));
+#endif  
+}
+
+TfLiteStatus PreluEval(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const PreluParams& params =
+      *(static_cast<const PreluParams*>(node->user_data));
+
+  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+  const TfLiteEvalTensor* alpha = tflite::micro::GetEvalInput(context, node, 1);
+  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+
+  switch (input->type) {
+    case kTfLiteFloat32: {
+      BroadcastPrelu4DSlowFloat(tflite::micro::GetTensorShape(input),
+                                tflite::micro::GetTensorData<float>(input),
+                                tflite::micro::GetTensorShape(alpha),
+                                tflite::micro::GetTensorData<float>(alpha),
+                                tflite::micro::GetTensorShape(output),
+                                tflite::micro::GetTensorData<float>(output));
+      return kTfLiteOk;
+    } break;
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+    case kTfLiteInt8: {
+      const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+      const RuntimeShape& alpha_shape = tflite::micro::GetTensorShape(alpha);
+      const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+      const RuntimeShape extended_alpha_shape = RuntimeShape::ExtendedShape(output_shape.DimensionsCount(), alpha_shape);
+      
+      XtensaPreluData* data = static_cast<XtensaPreluData*>(node->user_data);
+      const int8_t *alpha_data = tflite::micro::GetTensorData<int8_t>(alpha);
+      int8_t *alpha_broadcasted;
+      if(!(alpha_shape == output_shape) && input_shape == output_shape){
+        alpha_broadcasted = (int8_t *)context->GetScratchBuffer(context, data->scratch_tensor_index);
+        xa_nn_broadcast_8_8(alpha_broadcasted, output_shape.DimsData(), tflite::micro::GetTensorData<int8_t>(alpha), extended_alpha_shape.DimsData(), extended_alpha_shape.DimensionsCount());
+        alpha_data = alpha_broadcasted;
+      } 
+
+      if(input_shape == output_shape)
+      {
+        int err = 0;
+        const int flat_size = MatchingFlatSize(input_shape, output_shape);
+        err = xa_nn_vec_prelu_asym8s_asym8s(
+          tflite::micro::GetTensorData<int8_t>(output),
+          tflite::micro::GetTensorData<int8_t>(input),
+          alpha_data,
+          params.input_offset,
+          params.alpha_offset,
+          params.output_multiplier_2,
+          params.output_shift_2,
+          params.output_multiplier_1,
+          params.output_shift_1,
+          params.output_offset,
+	  flat_size);
+
+    TF_LITE_ENSURE(context, err == 0);
+      }
+      else
+      {
+        reference_ops::BroadcastPrelu4DSlow(
+          params, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int8_t>(input),
+          tflite::micro::GetTensorShape(alpha),
+          tflite::micro::GetTensorData<int8_t>(alpha),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int8_t>(output));
+      }
+      return kTfLiteOk;
+    } break;
+#else
+    case kTfLiteInt8: {
+      reference_ops::BroadcastPrelu4DSlow(
+          params, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int8_t>(input),
+          tflite::micro::GetTensorShape(alpha),
+          tflite::micro::GetTensorData<int8_t>(alpha),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int8_t>(output));
+      return kTfLiteOk;
+    } break;
+#endif // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+    case kTfLiteInt16: {
+      reference_ops::BroadcastPrelu4DSlow(
+          params, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int16_t>(input),
+          tflite::micro::GetTensorShape(alpha),
+          tflite::micro::GetTensorData<int8_t>(alpha),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int16_t>(output));
+      return kTfLiteOk;
+    } break;
+    default:
+      TF_LITE_KERNEL_LOG(
+          context, "Only float32 and uint8_t are supported currently, got %d.",
+          TfLiteTypeGetName(input->type));
+      return kTfLiteError;
+  }
+}
+
+TFLMRegistration Register_PRELU() {
+  return tflite::micro::RegisterOp(PreluInit, PreluPrepare, PreluEval);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/prelu_common.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/prelu_common.cc
@@ -1,0 +1,127 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/prelu.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/prelu.h"
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ) 
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa_prelu.h"
+#endif
+namespace tflite {
+
+TfLiteStatus CalculatePreluParams(const TfLiteTensor* input,
+                                  const TfLiteTensor* alpha,
+                                  TfLiteTensor* output, PreluParams* params) {
+  if (output->type == kTfLiteInt8 || output->type == kTfLiteInt16) {
+    double real_multiplier_1 = static_cast<double>(input->params.scale) /
+                               static_cast<double>(output->params.scale);
+    double real_multiplier_2 = static_cast<double>(input->params.scale) *
+                               static_cast<double>(alpha->params.scale) /
+                               static_cast<double>(output->params.scale);
+    QuantizeMultiplier(real_multiplier_1, &params->output_multiplier_1,
+                       &params->output_shift_1);
+    QuantizeMultiplier(real_multiplier_2, &params->output_multiplier_2,
+                       &params->output_shift_2);
+
+    params->input_offset = -input->params.zero_point;
+    params->alpha_offset = -alpha->params.zero_point;
+    params->output_offset = output->params.zero_point;
+  }
+
+  return kTfLiteOk;
+}
+
+void BroadcastPrelu4DSlowFloat(const RuntimeShape& unextended_input1_shape,
+                               const float* input1_data,
+                               const RuntimeShape& unextended_input2_shape,
+                               const float* input2_data,
+                               const RuntimeShape& unextended_output_shape,
+                               float* output_data) {
+  TFLITE_DCHECK_LE(unextended_input1_shape.DimensionsCount(), 4);
+  TFLITE_DCHECK_LE(unextended_input2_shape.DimensionsCount(), 4);
+  TFLITE_DCHECK_LE(unextended_output_shape.DimensionsCount(), 4);
+  const RuntimeShape output_shape =
+      RuntimeShape::ExtendedShape(4, unextended_output_shape);
+
+  NdArrayDesc<4> desc1;
+  NdArrayDesc<4> desc2;
+  NdArrayDescsForElementwiseBroadcast(unextended_input1_shape,
+                                      unextended_input2_shape, &desc1, &desc2);
+
+  for (int b = 0; b < output_shape.Dims(0); ++b) {
+    for (int y = 0; y < output_shape.Dims(1); ++y) {
+      for (int x = 0; x < output_shape.Dims(2); ++x) {
+        for (int c = 0; c < output_shape.Dims(3); ++c) {
+          auto out_idx = Offset(output_shape, b, y, x, c);
+          auto in1_idx = SubscriptToIndex(desc1, b, y, x, c);
+          auto in2_idx = SubscriptToIndex(desc2, b, y, x, c);
+          auto in1_val = input1_data[in1_idx];
+          auto in2_val = input2_data[in2_idx];
+          output_data[out_idx] = in1_val >= 0.0f ? in1_val : in1_val * in2_val;
+        }
+      }
+    }
+  }
+}
+
+TfLiteStatus PreluPrepare(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  PreluParams* params = static_cast<PreluParams*>(node->user_data);
+
+  MicroContext* micro_context = GetMicroContext(context);
+
+  TfLiteTensor* input = micro_context->AllocateTempInputTensor(node, 0);
+  TF_LITE_ENSURE(context, input != nullptr);
+  TfLiteTensor* alpha = micro_context->AllocateTempInputTensor(node, 1);
+  TF_LITE_ENSURE(context, alpha != nullptr);
+  TfLiteTensor* output = micro_context->AllocateTempOutputTensor(node, 0);
+  TF_LITE_ENSURE(context, output != nullptr);
+
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ) 
+  TfLiteEvalTensor* output_eval = tflite::micro::GetEvalOutput(context, node, 0);
+  const TfLiteEvalTensor* alpha_eval = tflite::micro::GetEvalInput(context, node, 1);
+  const TfLiteEvalTensor* input_eval = tflite::micro::GetEvalInput(context, node, 0);
+  const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output_eval);
+  const RuntimeShape& alpha_shape = tflite::micro::GetTensorShape(alpha_eval);
+  const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input_eval);
+  XtensaPreluData* data = static_cast<XtensaPreluData*>(node->user_data);
+  if(!(alpha_shape == output_shape) && input_shape == output_shape){
+    int required_scratch = 1;
+    for(int i=0; i< output_shape.DimensionsCount(); i++){
+      required_scratch *= output_shape.DimsData()[i];
+    }  
+    TF_LITE_ENSURE(context, required_scratch > 0);
+    TF_LITE_ENSURE_OK(
+        context, context->RequestScratchBufferInArena(
+                    context, required_scratch, &data->scratch_tensor_index));   
+  }
+#endif 
+
+  TF_LITE_ENSURE_OK(context,
+                    CalculatePreluParams(input, alpha, output, params));
+
+  micro_context->DeallocateTempTfLiteTensor(input);
+  micro_context->DeallocateTempTfLiteTensor(alpha);
+  micro_context->DeallocateTempTfLiteTensor(output);
+  return kTfLiteOk;
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_prelu.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_prelu.h
@@ -1,0 +1,32 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_LITE_MICRO_KERNELS_XTENSA_XTENSA_PRELU_H_
+#define TENSORFLOW_LITE_MICRO_KERNELS_XTENSA_XTENSA_PRELU_H_
+
+#include <cstdint>
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+#include "tensorflow/lite/micro/kernels/prelu.h"
+
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+namespace tflite {
+struct XtensaPreluData {
+  PreluParams reference_op_data;
+  int scratch_tensor_index;
+};
+}  // namespace tflite
+#endif
+#endif  // TENSORFLOW_LITE_MICRO_KERNELS_XTENSA_XTENSA_PRELU_H_


### PR DESCRIPTION
Adds Xtensa optimized activation kernels: relu (int8 + float32), hard_swish (int8), and PReLU (int8). Includes shared prelu_common prepare helper and xtensa_prelu.h declarations.

@cad-audio @joshih-cad