### PR TITLE
Add Xtensa HiFi optimizations for elementwise, logical, mul, and squared_difference kernels

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/comparisons.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/comparisons.cc
@@ -1,0 +1,794 @@
+/* Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/kernels/internal/reference/comparisons.h"
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+
+namespace tflite {
+
+namespace {
+
+struct OpData {
+  ComparisonParams params;
+};
+
+constexpr int kInputTensor1 = 0;
+constexpr int kInputTensor2 = 1;
+constexpr int kOutputTensor = 0;
+
+TfLiteStatus EqualEval(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const OpData* data = static_cast<const OpData*>(node->user_data);
+
+  const TfLiteEvalTensor* input1 =
+      tflite::micro::GetEvalInput(context, node, kInputTensor1);
+  const TfLiteEvalTensor* input2 =
+      tflite::micro::GetEvalInput(context, node, kInputTensor2);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+
+  RuntimeShape input1_shape = tflite::micro::GetTensorShape(input1);
+  RuntimeShape input2_shape = tflite::micro::GetTensorShape(input2);
+  RuntimeShape output_shape = tflite::micro::GetTensorShape(output);
+  bool* output_data = tflite::micro::GetTensorData<bool>(output);
+
+  bool requires_broadcast = !tflite::micro::HaveSameShapes(input1, input2);
+  switch (input1->type) {
+    case kTfLiteBool:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<bool>(input1), input2_shape,
+                tflite::micro::GetTensorData<bool>(input2), output_shape,
+                output_data)
+          : reference_ops::EqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<bool>(input1), input2_shape,
+                tflite::micro::GetTensorData<bool>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteFloat32:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<float>(input1), input2_shape,
+                tflite::micro::GetTensorData<float>(input2), output_shape,
+                output_data)
+          : reference_ops::EqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<float>(input1), input2_shape,
+                tflite::micro::GetTensorData<float>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteInt32:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int32_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int32_t>(input2), output_shape,
+                output_data)
+          : reference_ops::EqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int32_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int32_t>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteInt64:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int64_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int64_t>(input2), output_shape,
+                output_data)
+          : reference_ops::EqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int64_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int64_t>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteInt8:
+      if(requires_broadcast)
+      {
+        reference_ops::Broadcast4DSlowEqualWithScaling(
+            data->params, input1_shape,
+            tflite::micro::GetTensorData<int8_t>(input1), input2_shape,
+            tflite::micro::GetTensorData<int8_t>(input2), output_shape,
+            output_data);
+      }
+      else
+      {
+#if defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+        int err;
+        const int8_t *input1_data_ptr, *input2_data_ptr;
+        int8_t *output_data_ptr;
+        const int flat_size = MatchingFlatSize(input1_shape, input2_shape, output_shape);
+
+        input1_data_ptr  = tflite::micro::GetTensorData<int8_t>(input1);
+        input2_data_ptr  = tflite::micro::GetTensorData<int8_t>(input2);
+        output_data_ptr  = tflite::micro::GetTensorData<int8_t>(output);
+
+        err = xa_nn_elm_equal_asym8sxasym8s(output_data_ptr,
+                                            input1_data_ptr,
+                                            data->params.input1_offset,
+                                            data->params.input1_shift,
+                                            data->params.input1_multiplier,
+                                            input2_data_ptr,
+                                            data->params.input2_offset,
+                                            data->params.input2_shift,
+                                            data->params.input2_multiplier,
+                                            data->params.left_shift,
+                                            flat_size);
+        TF_LITE_ENSURE(context, err == 0);
+#else
+        reference_ops::EqualWithScaling(
+            data->params, input1_shape,
+            tflite::micro::GetTensorData<int8_t>(input1), input2_shape,
+            tflite::micro::GetTensorData<int8_t>(input2), output_shape,
+            output_data);
+#endif // defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+      }
+      break;
+    default:
+      MicroPrintf("Type %s (%d) not supported.",
+                  TfLiteTypeGetName(input1->type), input1->type);
+      return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+// TODO(renjieliu): Refactor the logic to avoid duplications.
+TfLiteStatus NotEqualEval(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const OpData* data = static_cast<const OpData*>(node->user_data);
+
+  const TfLiteEvalTensor* input1 =
+      tflite::micro::GetEvalInput(context, node, kInputTensor1);
+  const TfLiteEvalTensor* input2 =
+      tflite::micro::GetEvalInput(context, node, kInputTensor2);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+
+  RuntimeShape input1_shape = tflite::micro::GetTensorShape(input1);
+  RuntimeShape input2_shape = tflite::micro::GetTensorShape(input2);
+  RuntimeShape output_shape = tflite::micro::GetTensorShape(output);
+  bool* output_data = tflite::micro::GetTensorData<bool>(output);
+
+  bool requires_broadcast = !tflite::micro::HaveSameShapes(input1, input2);
+  switch (input1->type) {
+    case kTfLiteBool:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowNotEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<bool>(input1), input2_shape,
+                tflite::micro::GetTensorData<bool>(input2), output_shape,
+                output_data)
+          : reference_ops::NotEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<bool>(input1), input2_shape,
+                tflite::micro::GetTensorData<bool>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteFloat32:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowNotEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<float>(input1), input2_shape,
+                tflite::micro::GetTensorData<float>(input2), output_shape,
+                output_data)
+          : reference_ops::NotEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<float>(input1), input2_shape,
+                tflite::micro::GetTensorData<float>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteInt32:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowNotEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int32_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int32_t>(input2), output_shape,
+                output_data)
+          : reference_ops::NotEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int32_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int32_t>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteInt64:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowNotEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int64_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int64_t>(input2), output_shape,
+                output_data)
+          : reference_ops::NotEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int64_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int64_t>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteInt8:
+      if(requires_broadcast)
+      {
+        reference_ops::Broadcast4DSlowNotEqualWithScaling(
+            data->params, input1_shape,
+            tflite::micro::GetTensorData<int8_t>(input1), input2_shape,
+            tflite::micro::GetTensorData<int8_t>(input2), output_shape,
+            output_data);
+      }
+      else
+      {
+#if defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+        int err;
+        const int8_t *input1_data_ptr, *input2_data_ptr;
+        int8_t *output_data_ptr;
+        const int flat_size = MatchingFlatSize(input1_shape, input2_shape, output_shape);
+
+        input1_data_ptr  = tflite::micro::GetTensorData<int8_t>(input1);
+        input2_data_ptr  = tflite::micro::GetTensorData<int8_t>(input2);
+        output_data_ptr  = tflite::micro::GetTensorData<int8_t>(output);
+
+        err = xa_nn_elm_notequal_asym8sxasym8s(output_data_ptr,
+                                            input1_data_ptr,
+                                            data->params.input1_offset,
+                                            data->params.input1_shift,
+                                            data->params.input1_multiplier,
+                                            input2_data_ptr,
+                                            data->params.input2_offset,
+                                            data->params.input2_shift,
+                                            data->params.input2_multiplier,
+                                            data->params.left_shift,
+                                            flat_size);
+        TF_LITE_ENSURE(context, err == 0);
+#else
+        reference_ops::NotEqualWithScaling(
+            data->params, input1_shape,
+            tflite::micro::GetTensorData<int8_t>(input1), input2_shape,
+            tflite::micro::GetTensorData<int8_t>(input2), output_shape,
+            output_data);
+#endif // defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+      }
+      break;
+    default:
+      MicroPrintf("Type %s (%d) not supported.",
+                  TfLiteTypeGetName(input1->type), input1->type);
+      return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+TfLiteStatus GreaterEval(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const OpData* data = static_cast<const OpData*>(node->user_data);
+
+  const TfLiteEvalTensor* input1 =
+      tflite::micro::GetEvalInput(context, node, kInputTensor1);
+  const TfLiteEvalTensor* input2 =
+      tflite::micro::GetEvalInput(context, node, kInputTensor2);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+
+  RuntimeShape input1_shape = tflite::micro::GetTensorShape(input1);
+  RuntimeShape input2_shape = tflite::micro::GetTensorShape(input2);
+  RuntimeShape output_shape = tflite::micro::GetTensorShape(output);
+  bool* output_data = tflite::micro::GetTensorData<bool>(output);
+
+  bool requires_broadcast = !tflite::micro::HaveSameShapes(input1, input2);
+  switch (input1->type) {
+    case kTfLiteFloat32:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowGreaterNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<float>(input1), input2_shape,
+                tflite::micro::GetTensorData<float>(input2), output_shape,
+                output_data)
+          : reference_ops::GreaterNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<float>(input1), input2_shape,
+                tflite::micro::GetTensorData<float>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteInt32:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowGreaterNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int32_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int32_t>(input2), output_shape,
+                output_data)
+          : reference_ops::GreaterNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int32_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int32_t>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteInt64:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowGreaterNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int64_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int64_t>(input2), output_shape,
+                output_data)
+          : reference_ops::GreaterNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int64_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int64_t>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteInt8:
+      if(requires_broadcast)
+      {
+        reference_ops::Broadcast4DSlowGreaterWithScaling(
+            data->params, input1_shape,
+            tflite::micro::GetTensorData<int8_t>(input1), input2_shape,
+            tflite::micro::GetTensorData<int8_t>(input2), output_shape,
+            output_data);
+      }
+      else
+      {
+#if defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+        int err;
+        const int8_t *input1_data_ptr, *input2_data_ptr;
+        int8_t *output_data_ptr;
+        const int flat_size = MatchingFlatSize(input1_shape, input2_shape, output_shape);
+
+        input1_data_ptr  = tflite::micro::GetTensorData<int8_t>(input1);
+        input2_data_ptr  = tflite::micro::GetTensorData<int8_t>(input2);
+        output_data_ptr  = tflite::micro::GetTensorData<int8_t>(output);
+
+        err = xa_nn_elm_greater_asym8sxasym8s(output_data_ptr,
+                                            input1_data_ptr,
+                                            data->params.input1_offset,
+                                            data->params.input1_shift,
+                                            data->params.input1_multiplier,
+                                            input2_data_ptr,
+                                            data->params.input2_offset,
+                                            data->params.input2_shift,
+                                            data->params.input2_multiplier,
+                                            data->params.left_shift,
+                                            flat_size);
+        TF_LITE_ENSURE(context, err == 0);
+#else
+        reference_ops::GreaterWithScaling(
+            data->params, input1_shape,
+            tflite::micro::GetTensorData<int8_t>(input1), input2_shape,
+            tflite::micro::GetTensorData<int8_t>(input2), output_shape,
+            output_data);
+#endif // defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+      }
+      break;
+    case kTfLiteInt16:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowGreaterWithScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int16_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int16_t>(input2), output_shape,
+                output_data)
+          : reference_ops::GreaterWithScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int16_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int16_t>(input2), output_shape,
+                output_data);
+      break;
+    default:
+      MicroPrintf("Type %s (%d) not supported.",
+                  TfLiteTypeGetName(input1->type), input1->type);
+      return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+TfLiteStatus GreaterEqualEval(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const OpData* data = static_cast<const OpData*>(node->user_data);
+
+  const TfLiteEvalTensor* input1 =
+      tflite::micro::GetEvalInput(context, node, kInputTensor1);
+  const TfLiteEvalTensor* input2 =
+      tflite::micro::GetEvalInput(context, node, kInputTensor2);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+
+  RuntimeShape input1_shape = tflite::micro::GetTensorShape(input1);
+  RuntimeShape input2_shape = tflite::micro::GetTensorShape(input2);
+  RuntimeShape output_shape = tflite::micro::GetTensorShape(output);
+  bool* output_data = tflite::micro::GetTensorData<bool>(output);
+
+  bool requires_broadcast = !tflite::micro::HaveSameShapes(input1, input2);
+  switch (input1->type) {
+    case kTfLiteFloat32:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowGreaterEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<float>(input1), input2_shape,
+                tflite::micro::GetTensorData<float>(input2), output_shape,
+                output_data)
+          : reference_ops::GreaterEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<float>(input1), input2_shape,
+                tflite::micro::GetTensorData<float>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteInt32:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowGreaterEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int32_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int32_t>(input2), output_shape,
+                output_data)
+          : reference_ops::GreaterEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int32_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int32_t>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteInt64:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowGreaterEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int64_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int64_t>(input2), output_shape,
+                output_data)
+          : reference_ops::GreaterEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int64_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int64_t>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteInt8:
+      if(requires_broadcast)
+      {
+        reference_ops::Broadcast4DSlowGreaterEqualWithScaling(
+            data->params, input1_shape,
+            tflite::micro::GetTensorData<int8_t>(input1), input2_shape,
+            tflite::micro::GetTensorData<int8_t>(input2), output_shape,
+            output_data);
+      }
+      else
+      {
+#if defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+        int err;
+        const int8_t *input1_data_ptr, *input2_data_ptr;
+        int8_t *output_data_ptr;
+        const int flat_size = MatchingFlatSize(input1_shape, input2_shape, output_shape);
+
+        input1_data_ptr  = tflite::micro::GetTensorData<int8_t>(input1);
+        input2_data_ptr  = tflite::micro::GetTensorData<int8_t>(input2);
+        output_data_ptr  = tflite::micro::GetTensorData<int8_t>(output);
+
+        err = xa_nn_elm_greaterequal_asym8sxasym8s(output_data_ptr,
+                                            input1_data_ptr,
+                                            data->params.input1_offset,
+                                            data->params.input1_shift,
+                                            data->params.input1_multiplier,
+                                            input2_data_ptr,
+                                            data->params.input2_offset,
+                                            data->params.input2_shift,
+                                            data->params.input2_multiplier,
+                                            data->params.left_shift,
+                                            flat_size);
+        TF_LITE_ENSURE(context, err == 0);
+#else
+        reference_ops::GreaterEqualWithScaling(
+            data->params, input1_shape,
+            tflite::micro::GetTensorData<int8_t>(input1), input2_shape,
+            tflite::micro::GetTensorData<int8_t>(input2), output_shape,
+            output_data);
+#endif // defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+      }
+      break;
+    default:
+      MicroPrintf("Type %s (%d) not supported.",
+                  TfLiteTypeGetName(input1->type), input1->type);
+      return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+TfLiteStatus LessEval(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const OpData* data = static_cast<const OpData*>(node->user_data);
+
+  const TfLiteEvalTensor* input1 =
+      tflite::micro::GetEvalInput(context, node, kInputTensor1);
+  const TfLiteEvalTensor* input2 =
+      tflite::micro::GetEvalInput(context, node, kInputTensor2);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+
+  RuntimeShape input1_shape = tflite::micro::GetTensorShape(input1);
+  RuntimeShape input2_shape = tflite::micro::GetTensorShape(input2);
+  RuntimeShape output_shape = tflite::micro::GetTensorShape(output);
+  bool* output_data = tflite::micro::GetTensorData<bool>(output);
+
+  bool requires_broadcast = !tflite::micro::HaveSameShapes(input1, input2);
+  switch (input1->type) {
+    case kTfLiteFloat32:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowLessNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<float>(input1), input2_shape,
+                tflite::micro::GetTensorData<float>(input2), output_shape,
+                output_data)
+          : reference_ops::LessNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<float>(input1), input2_shape,
+                tflite::micro::GetTensorData<float>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteInt32:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowLessNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int32_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int32_t>(input2), output_shape,
+                output_data)
+          : reference_ops::LessNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int32_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int32_t>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteInt64:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowLessNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int64_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int64_t>(input2), output_shape,
+                output_data)
+          : reference_ops::LessNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int64_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int64_t>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteInt8:
+      if(requires_broadcast)
+      {
+        reference_ops::Broadcast4DSlowLessWithScaling(
+            data->params, input1_shape,
+            tflite::micro::GetTensorData<int8_t>(input1), input2_shape,
+            tflite::micro::GetTensorData<int8_t>(input2), output_shape,
+            output_data);
+      }
+      else
+      {
+#if defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+        int err;
+        const int8_t *input1_data_ptr, *input2_data_ptr;
+        int8_t *output_data_ptr;
+        const int flat_size = MatchingFlatSize(input1_shape, input2_shape, output_shape);
+
+        input1_data_ptr  = tflite::micro::GetTensorData<int8_t>(input1);
+        input2_data_ptr  = tflite::micro::GetTensorData<int8_t>(input2);
+        output_data_ptr  = tflite::micro::GetTensorData<int8_t>(output);
+
+        err = xa_nn_elm_less_asym8sxasym8s(output_data_ptr,
+                                            input1_data_ptr,
+                                            data->params.input1_offset,
+                                            data->params.input1_shift,
+                                            data->params.input1_multiplier,
+                                            input2_data_ptr,
+                                            data->params.input2_offset,
+                                            data->params.input2_shift,
+                                            data->params.input2_multiplier,
+                                            data->params.left_shift,
+                                            flat_size);
+        TF_LITE_ENSURE(context, err == 0);
+#else
+        reference_ops::LessWithScaling(
+            data->params, input1_shape,
+            tflite::micro::GetTensorData<int8_t>(input1), input2_shape,
+            tflite::micro::GetTensorData<int8_t>(input2), output_shape,
+            output_data);
+#endif // defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+      }
+      break;
+    default:
+      MicroPrintf("Type %s (%d) not supported.",
+                  TfLiteTypeGetName(input1->type), input1->type);
+      return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+TfLiteStatus LessEqualEval(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const OpData* data = static_cast<const OpData*>(node->user_data);
+
+  const TfLiteEvalTensor* input1 =
+      tflite::micro::GetEvalInput(context, node, kInputTensor1);
+  const TfLiteEvalTensor* input2 =
+      tflite::micro::GetEvalInput(context, node, kInputTensor2);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+
+  RuntimeShape input1_shape = tflite::micro::GetTensorShape(input1);
+  RuntimeShape input2_shape = tflite::micro::GetTensorShape(input2);
+  RuntimeShape output_shape = tflite::micro::GetTensorShape(output);
+  bool* output_data = tflite::micro::GetTensorData<bool>(output);
+
+  bool requires_broadcast = !tflite::micro::HaveSameShapes(input1, input2);
+  switch (input1->type) {
+    case kTfLiteFloat32:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowLessEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<float>(input1), input2_shape,
+                tflite::micro::GetTensorData<float>(input2), output_shape,
+                output_data)
+          : reference_ops::LessEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<float>(input1), input2_shape,
+                tflite::micro::GetTensorData<float>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteInt32:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowLessEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int32_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int32_t>(input2), output_shape,
+                output_data)
+          : reference_ops::LessEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int32_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int32_t>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteInt64:
+      requires_broadcast
+          ? reference_ops::Broadcast4DSlowLessEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int64_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int64_t>(input2), output_shape,
+                output_data)
+          : reference_ops::LessEqualNoScaling(
+                data->params, input1_shape,
+                tflite::micro::GetTensorData<int64_t>(input1), input2_shape,
+                tflite::micro::GetTensorData<int64_t>(input2), output_shape,
+                output_data);
+      break;
+    case kTfLiteInt8:
+      if(requires_broadcast)
+      {
+        reference_ops::Broadcast4DSlowLessEqualWithScaling(
+            data->params, input1_shape,
+            tflite::micro::GetTensorData<int8_t>(input1), input2_shape,
+            tflite::micro::GetTensorData<int8_t>(input2), output_shape,
+            output_data);
+      }
+      else
+      {
+#if defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+        int err;
+        const int8_t *input1_data_ptr, *input2_data_ptr;
+        int8_t *output_data_ptr;
+        const int flat_size = MatchingFlatSize(input1_shape, input2_shape, output_shape);
+
+        input1_data_ptr  = tflite::micro::GetTensorData<int8_t>(input1);
+        input2_data_ptr  = tflite::micro::GetTensorData<int8_t>(input2);
+        output_data_ptr  = tflite::micro::GetTensorData<int8_t>(output);
+
+        err = xa_nn_elm_lessequal_asym8sxasym8s(output_data_ptr,
+                                            input1_data_ptr,
+                                            data->params.input1_offset,
+                                            data->params.input1_shift,
+                                            data->params.input1_multiplier,
+                                            input2_data_ptr,
+                                            data->params.input2_offset,
+                                            data->params.input2_shift,
+                                            data->params.input2_multiplier,
+                                            data->params.left_shift,
+                                            flat_size);
+        TF_LITE_ENSURE(context, err == 0);
+#else
+        reference_ops::LessEqualWithScaling(
+            data->params, input1_shape,
+            tflite::micro::GetTensorData<int8_t>(input1), input2_shape,
+            tflite::micro::GetTensorData<int8_t>(input2), output_shape,
+            output_data);
+#endif // defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+      }
+      break;
+    default:
+      MicroPrintf("Type %s (%d) not supported.",
+                  TfLiteTypeGetName(input1->type), input1->type);
+      return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+void* Init(TfLiteContext* context, const char* buffer, size_t length) {
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+  return context->AllocatePersistentBuffer(context, sizeof(OpData));
+}
+
+TfLiteStatus ComparisonsPrepare(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  OpData* data = static_cast<OpData*>(node->user_data);
+
+  MicroContext* micro_context = GetMicroContext(context);
+
+  TfLiteTensor* input1 =
+      micro_context->AllocateTempInputTensor(node, kInputTensor1);
+  TF_LITE_ENSURE(context, input1 != nullptr);
+  TfLiteTensor* input2 =
+      micro_context->AllocateTempInputTensor(node, kInputTensor2);
+  TF_LITE_ENSURE(context, input2 != nullptr);
+
+  if (input1->type == kTfLiteInt8) {
+    auto input1_offset = -input1->params.zero_point;
+    auto input2_offset = -input2->params.zero_point;
+    const int kLeftShift = 8;
+
+    int32_t input1_multiplier;
+    int input1_shift;
+    QuantizeMultiplierSmallerThanOneExp(
+        static_cast<double>(input1->params.scale), &input1_multiplier,
+        &input1_shift);
+    int32_t input2_multiplier;
+    int input2_shift;
+    QuantizeMultiplierSmallerThanOneExp(
+        static_cast<double>(input2->params.scale), &input2_multiplier,
+        &input2_shift);
+
+    data->params.left_shift = kLeftShift;
+    data->params.input1_offset = input1_offset;
+    data->params.input1_multiplier = input1_multiplier;
+    data->params.input1_shift = input1_shift;
+    data->params.input2_offset = input2_offset;
+    data->params.input2_multiplier = input2_multiplier;
+    data->params.input2_shift = input2_shift;
+  }
+
+  micro_context->DeallocateTempTfLiteTensor(input1);
+  micro_context->DeallocateTempTfLiteTensor(input2);
+
+  return kTfLiteOk;
+}
+
+}  // namespace
+
+TFLMRegistration Register_EQUAL() {
+  return tflite::micro::RegisterOp(Init, ComparisonsPrepare, EqualEval);
+}
+
+TFLMRegistration Register_NOT_EQUAL() {
+  return tflite::micro::RegisterOp(Init, ComparisonsPrepare, NotEqualEval);
+}
+
+TFLMRegistration Register_GREATER() {
+  return tflite::micro::RegisterOp(Init, ComparisonsPrepare, GreaterEval);
+}
+
+TFLMRegistration Register_GREATER_EQUAL() {
+  return tflite::micro::RegisterOp(Init, ComparisonsPrepare, GreaterEqualEval);
+}
+
+TFLMRegistration Register_LESS() {
+  return tflite::micro::RegisterOp(Init, ComparisonsPrepare, LessEval);
+}
+
+TFLMRegistration Register_LESS_EQUAL() {
+  return tflite::micro::RegisterOp(Init, ComparisonsPrepare, LessEqualEval);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/elementwise.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/elementwise.cc
@@ -1,0 +1,580 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cmath>
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
+#include "tensorflow/lite/micro/micro_utils.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+
+namespace tflite {
+
+namespace hifi {
+
+#if defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+inline TfLiteStatus EvalLogicalNot(TfLiteContext* context, TfLiteNode* node) {
+    const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+    TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+    const size_t num_elements = ElementCount(*input->dims);
+
+    int err;
+    const int8_t *input_data_ptr;
+    int8_t *output_data_ptr;
+
+    input_data_ptr  = tflite::micro::GetTensorData<int8_t>(input);
+    output_data_ptr  = tflite::micro::GetTensorData<int8_t>(output);
+
+    err = xa_nn_elm_logicalnot_bool_bool(output_data_ptr,
+        input_data_ptr,
+        num_elements);
+    TF_LITE_ENSURE(context, err==0);
+    return kTfLiteOk;
+  }
+#endif // defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+
+} //namespae hifi
+
+namespace {
+
+constexpr int kAbsNameId = 0;
+constexpr int kRsrqtNameId = 1;
+
+const int kElementwiseInputTensor = 0;
+const int kElementwiseOutputTensor = 0;
+
+struct OpDataAbsRsqrt {
+  int32_t multiplier;
+  int shift;
+  int input_offset;
+  int output_offset;
+  bool needs_rescale;
+  TfLiteQuantizationType input_quantization_type;
+  TfLiteType input_type;
+};
+
+bool IsNumericSupportedType(const TfLiteType type) {
+  return type == kTfLiteFloat32;
+}
+
+bool IsLogicalSupportedType(const TfLiteType type) {
+  return type == kTfLiteBool;
+}
+
+bool IsAbsSupportedType(const TfLiteType type) {
+  return type == kTfLiteFloat32 || type == kTfLiteInt8 || type == kTfLiteInt16;
+}
+
+bool IsRsqrtSupportedType(const TfLiteType type) {
+  return type == kTfLiteFloat32 || type == kTfLiteInt8;
+}
+
+inline void SetAbsOutputMultiplier(const float input_scale,
+                                   const float output_scale,
+                                   int32_t* multiplier, int* shift) {
+  QuantizeMultiplier(static_cast<double>(input_scale / output_scale),
+                     multiplier, shift);
+}
+
+inline void SetRsqrtOutputMultiplier(const float input_scale,
+                                     const float output_scale,
+                                     int32_t* multiplier, int* shift) {
+  const double scale =
+      1. / static_cast<double>((std::sqrt(input_scale) * output_scale));
+  QuantizeMultiplier(scale, multiplier, shift);
+}
+
+typedef bool (*IsSupportedType)(TfLiteType);
+template <IsSupportedType>
+TfLiteStatus GenericPrepare(TfLiteContext* context, TfLiteNode* node) {
+  MicroContext* micro_context = GetMicroContext(context);
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 1);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+  TfLiteTensor* input =
+      micro_context->AllocateTempInputTensor(node, kElementwiseInputTensor);
+  TF_LITE_ENSURE(context, input != nullptr);
+  TfLiteTensor* output =
+      micro_context->AllocateTempOutputTensor(node, kElementwiseOutputTensor);
+  TF_LITE_ENSURE(context, output != nullptr);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
+  if (!IsSupportedType(input->type)) {
+    MicroPrintf("Input data type %s (%d) is not supported.",
+                TfLiteTypeGetName(input->type), input->type);
+    return kTfLiteError;
+  }
+
+  micro_context->DeallocateTempTfLiteTensor(input);
+  micro_context->DeallocateTempTfLiteTensor(output);
+  return kTfLiteOk;
+}
+
+typedef bool (*IsSupportedType)(TfLiteType);
+template <IsSupportedType, const int op_nameid>
+TfLiteStatus PrepareAbsRsqrt(TfLiteContext* context, TfLiteNode* node) {
+  MicroContext* micro_context = GetMicroContext(context);
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 1);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+  TfLiteTensor* input = micro_context->AllocateTempInputTensor(node, 0);
+  TF_LITE_ENSURE(context, input != nullptr);
+  TfLiteTensor* output = micro_context->AllocateTempOutputTensor(node, 0);
+  TF_LITE_ENSURE(context, output != nullptr);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
+  if (!IsSupportedType(input->type)) {
+    MicroPrintf("Input data type %s (%d) is not supported.",
+                TfLiteTypeGetName(input->type), input->type);
+    return kTfLiteError;
+  }
+
+  auto* op_data = static_cast<OpDataAbsRsqrt*>(node->user_data);
+  op_data->input_type = input->type;
+
+  // For int16 type input, we support both quantized and non-quantized
+  // evaluation.
+  if (op_nameid == kAbsNameId) {
+    op_data->input_quantization_type = input->quantization.type;
+  }
+
+  if (input->type == kTfLiteInt8 ||
+      (input->type == kTfLiteInt16 &&
+       input->quantization.type != kTfLiteNoQuantization)) {
+    TF_LITE_ENSURE_EQ(context, input->quantization.type,
+                      kTfLiteAffineQuantization);
+    TF_LITE_ENSURE_EQ(context, output->quantization.type,
+                      kTfLiteAffineQuantization);
+    const auto* input_params =
+        reinterpret_cast<TfLiteAffineQuantization*>(input->quantization.params);
+    const auto* output_params = reinterpret_cast<TfLiteAffineQuantization*>(
+        output->quantization.params);
+    TF_LITE_ENSURE(context, input_params != nullptr);
+    TF_LITE_ENSURE(context, input_params->scale != nullptr);
+    TF_LITE_ENSURE(context, input_params->scale->size > 0);
+    TF_LITE_ENSURE(context, input_params->zero_point->size > 0);
+    TF_LITE_ENSURE(context, output_params != nullptr);
+    TF_LITE_ENSURE(context, output_params->scale != nullptr);
+    TF_LITE_ENSURE(context, output_params->scale->size > 0);
+    TF_LITE_ENSURE(context, output_params->zero_point->size > 0);
+    op_data->input_offset = input_params->zero_point->data[0];
+    op_data->output_offset = output_params->zero_point->data[0];
+    if (input->type == kTfLiteInt16) {
+      TF_LITE_ENSURE_EQ(context, op_data->input_offset, 0);
+      TF_LITE_ENSURE_EQ(context, op_data->output_offset, 0);
+    }
+    const float input_scale = input_params->scale->data[0];
+    const float output_scale = output_params->scale->data[0];
+    op_data->needs_rescale = input_scale != output_scale;
+    if (op_nameid == kAbsNameId && op_data->needs_rescale) {
+      SetAbsOutputMultiplier(input_scale, output_scale, &op_data->multiplier,
+                             &op_data->shift);
+    } else if (op_nameid == kRsrqtNameId) {
+      SetRsqrtOutputMultiplier(input_scale, output_scale, &op_data->multiplier,
+                               &op_data->shift);
+    }
+  }
+  micro_context->DeallocateTempTfLiteTensor(input);
+  micro_context->DeallocateTempTfLiteTensor(output);
+  return kTfLiteOk;
+}
+
+template <typename T>
+inline TfLiteStatus EvalImplQuantized(
+    TfLiteContext* context, TfLiteNode* node,
+    T func(TfLiteContext*, TfLiteNode*, T),
+    TfLiteStatus validate_input_func(TfLiteContext*, TfLiteNode*, T),
+    TfLiteType expected_type) {
+  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, expected_type);
+  const size_t num_elements = ElementCount(*input->dims);
+  const T* in_data = tflite::micro::GetTensorData<T>(input);
+  T* out_data = tflite::micro::GetTensorData<T>(output);
+  for (size_t i = 0; i < num_elements; ++i) {
+    if (validate_input_func) {
+      TF_LITE_ENSURE_OK(context,
+                        validate_input_func(context, node, in_data[i]));
+    }
+    out_data[i] = func(context, node, in_data[i]);
+  }
+  return kTfLiteOk;
+}
+
+template <typename T>
+inline T AbsHelper(T i) {
+  return std::abs(i);
+}
+
+template <typename T>
+inline TfLiteStatus EvalImpl(TfLiteContext* context, TfLiteNode* node,
+                             T func(T), TfLiteStatus validate_input_func(T),
+                             TfLiteType expected_type) {
+  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, expected_type);
+  const size_t num_elements = ElementCount(*input->dims);
+  const T* in_data = tflite::micro::GetTensorData<T>(input);
+  T* out_data = tflite::micro::GetTensorData<T>(output);
+  for (size_t i = 0; i < num_elements; ++i) {
+    if (validate_input_func) {
+      TF_LITE_ENSURE_OK(context, validate_input_func(in_data[i]));
+    }
+    out_data[i] = func(in_data[i]);
+  }
+  return kTfLiteOk;
+}
+
+#if (!defined(INCLUDE_FLOAT_OPT) || defined(HIFI_IQ))
+inline TfLiteStatus EvalNumeric(TfLiteContext* context, TfLiteNode* node,
+                                float float_func(float)) {
+  return EvalImpl<float>(context, node, float_func,
+                         /*validate_input_func=*/nullptr, kTfLiteFloat32);
+}
+#endif // (!defined(INCLUDE_FLOAT_OPT))
+
+#if !(defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4))
+inline TfLiteStatus EvalLogical(TfLiteContext* context, TfLiteNode* node,
+
+                                bool bool_func(bool)) {
+  return EvalImpl<bool>(context, node, bool_func,
+                        /*validate_input_func=*/nullptr, kTfLiteBool);
+}
+#endif // !(defined(HIFI5) || defined(HIFI4))
+
+void* ElementWiseAbsRsqrtInit(TfLiteContext* context, const char* buffer,
+                              size_t length) {
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+  return context->AllocatePersistentBuffer(context, sizeof(OpDataAbsRsqrt));
+}
+
+template <typename T>
+inline T AbsEvalQuantized(TfLiteContext* context, TfLiteNode* node, T i) {
+  const auto* op_data = static_cast<const OpDataAbsRsqrt*>(node->user_data);
+  const int kMin = std::numeric_limits<T>::min();
+  const int kMax = std::numeric_limits<T>::max();
+
+  const int32_t value = std::abs(i - op_data->input_offset);
+  if (!op_data->needs_rescale) {
+    return static_cast<T>(
+        std::min(std::max(static_cast<long int>(value + op_data->output_offset),
+                          static_cast<long int>(kMin)),
+                 static_cast<long int>(kMax)));
+  }
+
+  const int32_t output = tflite::MultiplyByQuantizedMultiplier(
+                             value, op_data->multiplier, op_data->shift) +
+                         op_data->output_offset;
+  return static_cast<T>(std::min(
+      std::max(static_cast<long int>(output), static_cast<long int>(kMin)),
+      static_cast<long int>(kMax)));
+}
+
+template <typename T>
+inline T RsqrtEvalQuantized(TfLiteContext* context, TfLiteNode* node, T i) {
+  const auto* op_data = static_cast<const OpDataAbsRsqrt*>(node->user_data);
+  const int kMin = std::numeric_limits<T>::min();
+  const int kMax = std::numeric_limits<T>::max();
+
+  const int32_t value = (i - op_data->input_offset);
+  const int32_t kShift = 20;  // Shift to keep value integer.
+  if (value == 0) {
+    // Assume that any value close to 0 represents the max output value.
+    return static_cast<T>(kMax);
+  }
+  int32_t inv_sqrt_multiplier;
+  int inv_sqrt_shift;
+  GetInvSqrtQuantizedMultiplierExp(value, kReverseShift, &inv_sqrt_multiplier,
+                                   &inv_sqrt_shift);
+  const int32_t data = tflite::MultiplyByQuantizedMultiplier(
+      static_cast<int32_t>(1), inv_sqrt_multiplier, inv_sqrt_shift + kShift);
+  const int32_t output =
+      tflite::MultiplyByQuantizedMultiplier(data, op_data->multiplier,
+                                            op_data->shift - kShift) +
+      op_data->output_offset;
+  return static_cast<T>(std::min(
+      std::max(static_cast<long int>(output), static_cast<long int>(kMin)),
+      static_cast<long int>(kMax)));
+}
+
+template <typename T>
+TfLiteStatus validate_input_func(TfLiteContext* context, TfLiteNode* node,
+                                 T i) {
+  const auto* op_data = static_cast<const OpDataAbsRsqrt*>(node->user_data);
+
+  TF_LITE_ENSURE_MSG(context, i >= op_data->input_offset,
+                     "Rsqrt is only defined for positive values");
+  return static_cast<TfLiteStatus>(kTfLiteOk);
+}
+
+TfLiteStatus AbsEval(TfLiteContext* context, TfLiteNode* node) {
+  OpDataAbsRsqrt* op_data = reinterpret_cast<OpDataAbsRsqrt*>(node->user_data);
+  TfLiteType type = op_data->input_type;
+  TfLiteQuantizationType input_quantization_type =
+      op_data->input_quantization_type;
+  TfLiteStatus eval_result;
+
+  switch (type) {
+#if defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
+    case kTfLiteFloat32: {
+      const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+      TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+      TF_LITE_ENSURE_TYPES_EQ(context, input->type, kTfLiteFloat32);
+      const size_t num_elements = ElementCount(*input->dims);
+
+      const float* in_data = tflite::micro::GetTensorData<float>(input);
+      float* out_data = tflite::micro::GetTensorData<float>(output);
+
+      int err;
+      err = xa_nn_elm_abs_f32_f32(out_data,
+                                  in_data,
+                                  num_elements
+                                  );
+      TF_LITE_ENSURE(context, (err==0) );
+      return kTfLiteOk;
+    }
+#else
+    case kTfLiteFloat32:
+      eval_result = EvalNumeric(context, node, std::abs);
+      break;
+#endif // defined(INCLUDE_FLOAT_OPT)
+    case kTfLiteInt8:
+      eval_result =
+          EvalImplQuantized<int8_t>(context, node, AbsEvalQuantized,
+                                    /*validate_input_func=*/nullptr, type);
+      break;
+    case kTfLiteInt16:
+      eval_result =
+          input_quantization_type == kTfLiteNoQuantization
+              ? EvalImpl<int16_t>(context, node, AbsHelper,
+                                  /*validate_input_func=*/nullptr, type)
+              : EvalImplQuantized<int16_t>(context, node, AbsEvalQuantized,
+                                           /*validate_input_func=*/nullptr,
+                                           type);
+      break;
+    default:
+      MicroPrintf("Current data type %s is not supported.",
+                  TfLiteTypeGetName(type));
+      return kTfLiteError;
+      break;
+  }
+  return eval_result;
+}
+
+TfLiteStatus SinEval(TfLiteContext* context, TfLiteNode* node) {
+#if defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
+  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, kTfLiteFloat32);
+  const size_t num_elements = ElementCount(*input->dims);
+
+  const float* in_data = tflite::micro::GetTensorData<float>(input);
+  float* out_data = tflite::micro::GetTensorData<float>(output);
+
+  int err;
+  err = xa_nn_elm_sine_f32_f32(out_data,
+                               in_data,
+                               num_elements
+                              );
+  TF_LITE_ENSURE(context, (err==0) );
+  return kTfLiteOk;
+#else
+  return EvalNumeric(context, node, std::sin);
+#endif // defined(INCLUDE_FLOAT_OPT)
+}
+
+TfLiteStatus CosEval(TfLiteContext* context, TfLiteNode* node) {
+#if defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
+  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, kTfLiteFloat32);
+  const size_t num_elements = ElementCount(*input->dims);
+
+  const float* in_data = tflite::micro::GetTensorData<float>(input);
+  float* out_data = tflite::micro::GetTensorData<float>(output);
+
+  int err;
+  err = xa_nn_elm_cosine_f32_f32(out_data,
+                                 in_data,
+                                 num_elements
+                                );
+  TF_LITE_ENSURE(context, (err==0) );
+  return kTfLiteOk;
+#else
+  return EvalNumeric(context, node, std::cos);
+#endif // defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
+}
+
+TfLiteStatus LogEval(TfLiteContext* context, TfLiteNode* node) {
+#if defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
+  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, kTfLiteFloat32);
+  const size_t num_elements = ElementCount(*input->dims);
+
+  const float* in_data = tflite::micro::GetTensorData<float>(input);
+  float* out_data = tflite::micro::GetTensorData<float>(output);
+
+  int err;
+  err = xa_nn_elm_logn_f32_f32(out_data,
+                               in_data,
+                               num_elements
+                              );
+  TF_LITE_ENSURE(context, (err==0) );
+  return kTfLiteOk;
+#else
+  return EvalNumeric(context, node, std::log);
+#endif // defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
+}
+
+TfLiteStatus SqrtEval(TfLiteContext* context, TfLiteNode* node) {
+#if defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
+  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, kTfLiteFloat32);
+  const size_t num_elements = ElementCount(*input->dims);
+
+  const float* in_data = tflite::micro::GetTensorData<float>(input);
+  float* out_data = tflite::micro::GetTensorData<float>(output);
+
+  int err;
+  err = xa_nn_elm_sqrt_f32_f32(out_data,
+                               in_data,
+                               num_elements
+                              );
+  TF_LITE_ENSURE(context, (err==0) );
+  return kTfLiteOk;
+#else
+  return EvalNumeric(context, node, std::sqrt);
+#endif // defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
+}
+
+TfLiteStatus RsqrtEval(TfLiteContext* context, TfLiteNode* node) {
+  const auto* op_data = static_cast<const OpDataAbsRsqrt*>(node->user_data);
+  TfLiteType type = op_data->input_type;
+  switch (type) {
+#if defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
+    case kTfLiteFloat32: {
+      const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+      TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+      const size_t num_elements = ElementCount(*input->dims);
+
+      const float* in_data = tflite::micro::GetTensorData<float>(input);
+      float* out_data = tflite::micro::GetTensorData<float>(output);
+
+      int err;
+      err = xa_nn_elm_rsqrt_f32_f32(out_data,
+                                    in_data,
+                                    num_elements
+                                   );
+      TF_LITE_ENSURE(context, (err==0) );
+      return kTfLiteOk;
+    }
+#else
+    case kTfLiteFloat32:
+      return EvalImpl<float>(
+          context, node, [](float f) { return 1.f / std::sqrt(f); },
+          /*validate_input_func=*/nullptr, type);
+#endif // defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
+    case kTfLiteInt8:
+      return EvalImplQuantized<int8_t>(context, node, RsqrtEvalQuantized,
+                                       validate_input_func, type);
+    case kTfLiteInt16:
+      return EvalImplQuantized<int16_t>(context, node, RsqrtEvalQuantized,
+                                        validate_input_func, type);
+
+    default:
+      MicroPrintf("Current data type %s is not supported.",
+                  TfLiteTypeGetName(type));
+      return kTfLiteError;
+  }
+}
+
+TfLiteStatus SquareEval(TfLiteContext* context, TfLiteNode* node) {
+#if defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
+  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, kTfLiteFloat32);
+  const size_t num_elements = ElementCount(*input->dims);
+
+  const float* in_data = tflite::micro::GetTensorData<float>(input);
+  float* out_data = tflite::micro::GetTensorData<float>(output);
+
+  int err;
+  err = xa_nn_elm_square_f32_f32(out_data,
+                                 in_data,
+                                 num_elements
+                                );
+  TF_LITE_ENSURE(context, (err==0) );
+  return kTfLiteOk;
+#else
+  return EvalNumeric(context, node, [](float f) { return f * f; });
+#endif // defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
+}
+
+TfLiteStatus LogicalNotEval(TfLiteContext* context, TfLiteNode* node) {
+#if defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+  return hifi::EvalLogicalNot(context, node);
+#else
+  return EvalLogical(context, node, [](bool v) { return !v; });
+#endif // defined(HIFI5) || defined(HIFI4)
+}
+
+}  // namespace
+
+TFLMRegistration Register_ABS() {
+  return tflite::micro::RegisterOp(
+      ElementWiseAbsRsqrtInit, PrepareAbsRsqrt<IsAbsSupportedType, kAbsNameId>,
+      AbsEval);
+}
+
+TFLMRegistration Register_SIN() {
+  return tflite::micro::RegisterOp(
+      nullptr, GenericPrepare<IsNumericSupportedType>, SinEval);
+}
+
+TFLMRegistration Register_COS() {
+  return tflite::micro::RegisterOp(
+      nullptr, GenericPrepare<IsNumericSupportedType>, CosEval);
+}
+
+TFLMRegistration Register_LOG() {
+  return tflite::micro::RegisterOp(
+      nullptr, GenericPrepare<IsNumericSupportedType>, LogEval);
+}
+
+TFLMRegistration Register_SQRT() {
+  return tflite::micro::RegisterOp(
+      nullptr, GenericPrepare<IsNumericSupportedType>, SqrtEval);
+}
+
+TFLMRegistration Register_RSQRT() {
+  return tflite::micro::RegisterOp(
+      ElementWiseAbsRsqrtInit,
+      PrepareAbsRsqrt<IsRsqrtSupportedType, kRsrqtNameId>, RsqrtEval);
+}
+
+TFLMRegistration Register_SQUARE() {
+  return tflite::micro::RegisterOp(
+      nullptr, GenericPrepare<IsNumericSupportedType>, SquareEval);
+}
+
+TFLMRegistration Register_LOGICAL_NOT() {
+  return tflite::micro::RegisterOp(
+      nullptr, GenericPrepare<IsLogicalSupportedType>, LogicalNotEval);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/logical.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/logical.cc
@@ -1,0 +1,118 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/micro/kernels/logical.h"
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/reference/binary_function.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/op_macros.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+
+namespace tflite {
+namespace {
+
+// Input/output tensor index.
+#if defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+extern const int kLogicalInputTensor1 = 0;
+extern const int kLogicalInputTensor2 = 1;
+extern const int kLogicalOutputTensor = 0;
+
+TfLiteStatus HiFiLogicalImpl(TfLiteContext* context, TfLiteNode* node,
+                         bool (*func)(bool, bool)) {
+  const TfLiteEvalTensor* input1 =
+      tflite::micro::GetEvalInput(context, node, kLogicalInputTensor1);
+  const TfLiteEvalTensor* input2 =
+      tflite::micro::GetEvalInput(context, node, kLogicalInputTensor2);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kLogicalOutputTensor);
+
+  int err;
+  const int8_t *input1_data_ptr, *input2_data_ptr;
+  int8_t *output_data_ptr;
+  RuntimeShape input1_shape = tflite::micro::GetTensorShape(input1);
+  RuntimeShape input2_shape = tflite::micro::GetTensorShape(input2);
+  RuntimeShape output_shape = tflite::micro::GetTensorShape(output);
+  const int flat_size = MatchingFlatSize(input1_shape, input2_shape, output_shape);
+
+  input1_data_ptr  = tflite::micro::GetTensorData<int8_t>(input1);
+  input2_data_ptr  = tflite::micro::GetTensorData<int8_t>(input2);
+  output_data_ptr  = tflite::micro::GetTensorData<int8_t>(output);
+
+  if (func == LogicalAnd) {
+    err = xa_nn_elm_logicaland_boolxbool_bool(
+        output_data_ptr,
+        input1_data_ptr,
+        input2_data_ptr,
+        flat_size);
+    TF_LITE_ENSURE(context, err == 0);
+  } else if (func == LogicalOr) {
+    err = xa_nn_elm_logicalor_boolxbool_bool(
+        output_data_ptr,
+        input1_data_ptr,
+        input2_data_ptr,
+        flat_size);
+    TF_LITE_ENSURE(context, err == 0);
+  } else {
+    err = 1;
+    TF_LITE_ENSURE(context, err == 0);
+  }
+  return kTfLiteOk;
+}
+#endif
+
+TfLiteStatus LogicalOrEval(TfLiteContext* context, TfLiteNode* node) {
+#if defined(HIFI_IQ) || defined(HIFI5) || defined(HIFI4)
+  const TfLiteEvalTensor* input1 =
+      tflite::micro::GetEvalInput(context, node, kLogicalInputTensor1);
+  const TfLiteEvalTensor* input2 =
+      tflite::micro::GetEvalInput(context, node, kLogicalInputTensor2);
+  
+  if (tflite::micro::HaveSameShapes(input1, input2))
+    return HiFiLogicalImpl(context, node, LogicalOr);
+  else
+    return LogicalImpl(context, node, LogicalOr);
+#else
+  return LogicalImpl(context, node, LogicalOr);
+#endif
+}
+
+TfLiteStatus LogicalAndEval(TfLiteContext* context, TfLiteNode* node) {
+#if defined(HIFI5) || defined(HIFI4)
+  const TfLiteEvalTensor* input1 =
+      tflite::micro::GetEvalInput(context, node, kLogicalInputTensor1);
+  const TfLiteEvalTensor* input2 =
+      tflite::micro::GetEvalInput(context, node, kLogicalInputTensor2);
+  
+  if (tflite::micro::HaveSameShapes(input1, input2))
+    return HiFiLogicalImpl(context, node, LogicalAnd);
+  else
+    return LogicalImpl(context, node, LogicalAnd);
+#else
+  return LogicalImpl(context, node, LogicalAnd);
+#endif
+}
+
+}  // namespace
+
+TFLMRegistration Register_LOGICAL_OR() {
+  return tflite::micro::RegisterOp(nullptr, nullptr, LogicalOrEval);
+}
+
+TFLMRegistration Register_LOGICAL_AND() {
+  return tflite::micro::RegisterOp(nullptr, nullptr, LogicalAndEval);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/maximum_minimum.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/maximum_minimum.cc
@@ -1,0 +1,298 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/kernels/internal/reference/maximum_minimum.h"
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/op_macros.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/maximum_minimum.h"
+#include "tensorflow/lite/micro/micro_log.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+
+namespace tflite {
+
+namespace {
+
+#if (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+// This file has the HiFi implementation of TFMaximum/TFMinimum.
+enum KernelType {
+  kHiFi5,
+  kReference,
+};
+
+namespace hifi {
+
+enum class basic_op {
+  no_op,
+  min,
+  max
+};
+
+template <typename data_type>
+TfLiteStatus TFLiteOperation( TfLiteContext* context, TfLiteNode* node,
+                              const OpContext& op_context,
+                              basic_op operation);
+
+template <typename T, int NDims>
+int MaximumMinimumBroadcast( const RuntimeShape& unextended_input1_shape, const T* input1_data,
+                             const RuntimeShape& unextended_input2_shape, const T* input2_data,
+                             const RuntimeShape& unextended_output_shape,       T* output_data,
+                             hifi::basic_op op);
+
+template <typename data_type>
+int ExecElemKernel( hifi::basic_op op, data_type *out_data,
+                    const data_type *in1_data, const data_type *in2_data, size_t num_Elements);
+
+}  // namespace hifi
+
+/* Execute an element-wise kernel depending on the type specified by elem_op.
+ * For now, the only data_type supported is int8_t
+ * hifi::basic_op::min -> xa_nn_elm_min_8x8_8
+ * hifi::basic_op::max -> xa_nn_elm_max_8x8_8
+ */
+template <typename data_type>
+int hifi::ExecElemKernel( hifi::basic_op elem_op, data_type *out_data,
+                          const data_type *in1_data, const data_type *in2_data,
+                          size_t num_Elements) {
+  int err = 0;
+  
+  if(!std::is_same<data_type, int8_t>::value){
+      err = -1;
+  } else {
+    switch(elem_op){
+      case hifi::basic_op::min :
+        err = xa_nn_elm_min_8x8_8(out_data, in1_data, in2_data, num_Elements);
+        break;
+      case hifi::basic_op::max :
+        err = xa_nn_elm_max_8x8_8(out_data, in1_data, in2_data, num_Elements);
+        break;
+      default :
+        err = -1;
+    }
+  }
+
+  return err;
+}
+
+/*
+ * Invoke element-wise kernels if the shapes match, else,
+ * call hifi::MaximumMinimumBroadcast(...)
+ */
+template <typename data_type>
+TfLiteStatus hifi::TFLiteOperation(
+    TfLiteContext* context, TfLiteNode* node,
+    const OpContext& op_context, hifi::basic_op elem_op) {
+
+  int err = 0;
+
+  const RuntimeShape &unextended_input1_shape = tflite::micro::GetTensorShape(op_context.input1),
+                     &unextended_input2_shape = tflite::micro::GetTensorShape(op_context.input2),
+                     &unextended_output_shape = tflite::micro::GetTensorShape(op_context.output);
+
+  if (unextended_input1_shape == unextended_input2_shape) {
+    err = hifi::ExecElemKernel<data_type>( elem_op,
+                    tflite::micro::GetTensorData<data_type>(op_context.output),
+                    tflite::micro::GetTensorData<data_type>(op_context.input1),
+                    tflite::micro::GetTensorData<data_type>(op_context.input2),
+                    unextended_output_shape.FlatSize());
+  } else {
+    int maxDims = std::max( { unextended_input1_shape.DimensionsCount(),
+                              unextended_input2_shape.DimensionsCount(),
+                              unextended_output_shape.DimensionsCount()} );
+
+    /* Verify that number of dimensions is between 1 to 8 */
+    TFLITE_DCHECK_GE(maxDims, 1);
+    TFLITE_DCHECK_LE(maxDims, 8);
+
+    //decltype(&hifi::MaximumMinimumBroadcast<data_type, 4>) bCastMinMax = NULL;
+
+    if (maxDims <= 4) {
+      err = hifi::MaximumMinimumBroadcast<data_type, 4>(
+              tflite::micro::GetTensorShape(op_context.input1), tflite::micro::GetTensorData<data_type>(op_context.input1),
+              tflite::micro::GetTensorShape(op_context.input2), tflite::micro::GetTensorData<data_type>(op_context.input2),
+              tflite::micro::GetTensorShape(op_context.output), tflite::micro::GetTensorData<data_type>(op_context.output),
+              elem_op);
+    } else {
+      err = hifi::MaximumMinimumBroadcast<data_type, 8>(
+              tflite::micro::GetTensorShape(op_context.input1), tflite::micro::GetTensorData<data_type>(op_context.input1),
+              tflite::micro::GetTensorShape(op_context.input2), tflite::micro::GetTensorData<data_type>(op_context.input2),
+              tflite::micro::GetTensorShape(op_context.output), tflite::micro::GetTensorData<data_type>(op_context.output),
+              elem_op);
+    }
+  }
+
+  TF_LITE_ENSURE_EQ(context, err, 0);
+
+  return kTfLiteOk;
+}
+
+template <typename data_type, int NDims>
+int hifi::MaximumMinimumBroadcast( const RuntimeShape& unextended_input1_shape, const data_type *input1_data,
+                                   const RuntimeShape& unextended_input2_shape, const data_type *input2_data,
+                                   const RuntimeShape& unextended_output_shape,       data_type *output_data,
+                                   hifi::basic_op op) {
+  int err = 0;
+
+  TFLITE_DCHECK_GE(unextended_input1_shape.DimensionsCount(), 0);
+  TFLITE_DCHECK_GE(unextended_input2_shape.DimensionsCount(), 0);
+  TFLITE_DCHECK_GE(unextended_output_shape.DimensionsCount(), 0);
+
+  TFLITE_DCHECK_LE(unextended_input1_shape.DimensionsCount(), NDims);
+  TFLITE_DCHECK_LE(unextended_input2_shape.DimensionsCount(), NDims);
+  TFLITE_DCHECK_LE(unextended_output_shape.DimensionsCount(), NDims);
+
+  const RuntimeShape extended_input1_shape = RuntimeShape::ExtendedShape(NDims, unextended_input1_shape);
+  const RuntimeShape extended_input2_shape = RuntimeShape::ExtendedShape(NDims, unextended_input2_shape);
+  const RuntimeShape extended_output_shape = RuntimeShape::ExtendedShape(NDims, unextended_output_shape);
+
+  NdArrayDesc<NDims> input1_desc;
+  NdArrayDesc<NDims> input2_desc;
+  NdArrayDesc<NDims> output_desc;
+
+  NdArrayDescsForElementwiseBroadcast( unextended_input1_shape, unextended_input2_shape,
+                                                 &input1_desc,            &input2_desc );
+
+  CopyDimsToDesc(extended_output_shape, &output_desc);
+
+  if ( !(extended_input1_shape == extended_output_shape) &&              // input 1 needs broadcast
+       (extended_input2_shape == extended_output_shape)     ) {
+
+    err = xa_nn_broadcast_8_8(output_data, output_desc.extents,                       
+            input1_data, extended_input1_shape.DimsData(), NDims);      // broadcast input 1 into output_data buffer
+
+    err |= hifi::ExecElemKernel(op, output_data,                        // exec element-wise op after bcast
+                   output_data, input2_data,
+                   extended_output_shape.FlatSize());
+
+  } else if( (extended_input1_shape == extended_output_shape) &&
+             !(extended_input2_shape == extended_output_shape)     ) {   // input 2 needs broadcast
+
+    err = xa_nn_broadcast_8_8(output_data, output_desc.extents,                        
+            input2_data, extended_input2_shape.DimsData(), NDims);      // broadcast input 2 into output_data buffer
+
+    err |= hifi::ExecElemKernel(op, output_data,                        // exec element-wise op after bcast
+                   input1_data, output_data,
+                   extended_output_shape.FlatSize());
+  } 
+#if (defined(HIFI4) || defined(HIFI5))
+  else {
+
+    /* Both inputs need broadcast.
+     * Call any of the xa_nn_elm_[min,max]_[4D,8D]_Bcast_8x8_8(...) kernels.
+     * All these kernels have same the same function signature.
+     */
+
+    decltype(&xa_nn_elm_min_4D_Bcast_8x8_8) kernel = NULL;
+
+    if (NDims == 4) {
+      kernel = (op == hifi::basic_op::min) ? xa_nn_elm_min_4D_Bcast_8x8_8 :
+                 (op == hifi::basic_op::max) ? xa_nn_elm_max_4D_Bcast_8x8_8 : NULL;
+    } else if (NDims == 8) {
+      kernel = (op == hifi::basic_op::min) ? xa_nn_elm_min_8D_Bcast_8x8_8 :
+                 (op == hifi::basic_op::max) ? xa_nn_elm_max_8D_Bcast_8x8_8 : NULL;
+    }
+
+    if(kernel!=NULL){
+      err = kernel(output_data, output_desc.extents,
+                   input1_data, input1_desc.strides,
+                   input2_data, input2_desc.strides );
+    }
+  }
+#endif
+
+  return err;
+}
+
+#endif // defined(HIFI5) || defined(HIFI4)
+
+template <KernelType kernel_type, typename OpType>
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  OpContext op_context(context, node);
+
+#if (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+  if (kernel_type == kReference || kernel_type == kHiFi5) {
+
+    hifi::basic_op operation =
+        std::is_same<OpType, MinimumOp>::value ? hifi::basic_op::min :
+            std::is_same<OpType, MaximumOp>::value ? hifi::basic_op::max :
+                hifi::basic_op::no_op;
+#else
+  if (kernel_type == kReference) {
+#endif
+
+    switch (op_context.output->type) {
+      case kTfLiteFloat32:
+        TFLiteOperation<float, OpType>(context, node, op_context);
+        break;
+      case kTfLiteInt8:
+#if (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+        hifi::TFLiteOperation<int8_t>(context, node, op_context, operation);
+#else
+        TFLiteOperation<int8_t, OpType>(context, node, op_context);
+#endif
+        break;
+      case kTfLiteInt16:
+        TFLiteOperation<int16_t, OpType>(context, node, op_context);
+        break;
+      case kTfLiteInt32:
+        TFLiteOperation<int32_t, OpType>(context, node, op_context);
+        break;
+      case kTfLiteInt64:
+        TFLiteOperation<int64_t, OpType>(context, node, op_context);
+        break;
+      default:
+        MicroPrintf("Type %s (%d) is not supported by Maximum/Minimum.",
+                    TfLiteTypeGetName(op_context.output->type),
+                    op_context.output->type);
+        return kTfLiteError;
+    }
+  } else {
+    MicroPrintf("Kernel type not supported by Maximum/Minimum.");
+    return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+}  // namespace
+
+TFLMRegistration Register_MAXIMUM() {
+  return tflite::micro::RegisterOp(
+      nullptr, nullptr,
+#if (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+          Eval<kHiFi5, MaximumOp>
+#else
+          Eval<kReference, MaximumOp>
+#endif
+  );                                
+}
+
+TFLMRegistration Register_MINIMUM() {
+  return tflite::micro::RegisterOp(
+      nullptr, nullptr,
+#if (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+          Eval<kHiFi5, MinimumOp>
+#else
+          Eval<kReference, MinimumOp>
+#endif
+  );                                
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/maximum_minimum.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/maximum_minimum.cc
@@ -172,10 +172,21 @@ int hifi::MaximumMinimumBroadcast( const RuntimeShape& unextended_input1_shape, 
 
   CopyDimsToDesc(extended_output_shape, &output_desc);
 
+  // The NdArrayDesc extents/strides are int64_t, but the nnlib kernels expect
+  // int. Copy them into int buffers before passing to the nnlib calls.
+  int output_extents[NDims];
+  int input1_strides[NDims];
+  int input2_strides[NDims];
+  for (int i = 0; i < NDims; ++i) {
+    output_extents[i] = static_cast<int>(output_desc.extents[i]);
+    input1_strides[i] = static_cast<int>(input1_desc.strides[i]);
+    input2_strides[i] = static_cast<int>(input2_desc.strides[i]);
+  }
+
   if ( !(extended_input1_shape == extended_output_shape) &&              // input 1 needs broadcast
        (extended_input2_shape == extended_output_shape)     ) {
 
-    err = xa_nn_broadcast_8_8(output_data, output_desc.extents,                       
+    err = xa_nn_broadcast_8_8(output_data, output_extents,                       
             input1_data, extended_input1_shape.DimsData(), NDims);      // broadcast input 1 into output_data buffer
 
     err |= hifi::ExecElemKernel(op, output_data,                        // exec element-wise op after bcast
@@ -185,7 +196,7 @@ int hifi::MaximumMinimumBroadcast( const RuntimeShape& unextended_input1_shape, 
   } else if( (extended_input1_shape == extended_output_shape) &&
              !(extended_input2_shape == extended_output_shape)     ) {   // input 2 needs broadcast
 
-    err = xa_nn_broadcast_8_8(output_data, output_desc.extents,                        
+    err = xa_nn_broadcast_8_8(output_data, output_extents,                        
             input2_data, extended_input2_shape.DimsData(), NDims);      // broadcast input 2 into output_data buffer
 
     err |= hifi::ExecElemKernel(op, output_data,                        // exec element-wise op after bcast
@@ -211,9 +222,9 @@ int hifi::MaximumMinimumBroadcast( const RuntimeShape& unextended_input1_shape, 
     }
 
     if(kernel!=NULL){
-      err = kernel(output_data, output_desc.extents,
-                   input1_data, input1_desc.strides,
-                   input2_data, input2_desc.strides );
+      err = kernel(output_data, output_extents,
+                   input1_data, input1_strides,
+                   input2_data, input2_strides );
     }
   }
 #endif

--- a/tensorflow/lite/micro/kernels/xtensa/mul.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/mul.cc
@@ -1,0 +1,191 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/micro/kernels/mul.h"
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/integer_ops/mul.h"
+#include "tensorflow/lite/kernels/internal/reference/mul.h"
+#include "tensorflow/lite/kernels/internal/reference/process_broadcast_shapes.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/memory_helpers.h"
+#include "tensorflow/lite/micro/micro_log.h"
+
+namespace tflite {
+
+TfLiteStatus EvalMulQuantizedHiFi(TfLiteContext* context,
+                   TfLiteNode* node, const OpDataMul* data,
+                   const TfLiteEvalTensor* input1,
+                   const TfLiteEvalTensor* input2, TfLiteEvalTensor* output) {
+  tflite::ArithmeticParams op_params = {};
+  op_params.quantized_activation_min = data->output_activation_min;
+  op_params.quantized_activation_max = data->output_activation_max;
+  op_params.float_activation_max = data->output_activation_max_f32;
+  op_params.input1_offset = -data->input1_zero_point;
+  op_params.input2_offset = -data->input2_zero_point;
+  op_params.output_offset = data->output_zero_point;
+  op_params.output_multiplier = data->output_multiplier;
+  op_params.output_shift = data->output_shift;
+
+  if (output->type == kTfLiteInt8) {
+      int err;
+      const RuntimeShape extended_input1_shape =
+        RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(input1));
+      const RuntimeShape extended_input2_shape =
+        RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(input2));
+      const RuntimeShape extended_output_shape =
+        RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(output));
+
+      err = xa_nn_elm_mul_broadcast_4D_asym8sxasym8s_asym8s(
+          tflite::micro::GetTensorData<int8_t>(output),
+          extended_output_shape.DimsData(), op_params.output_offset,
+          op_params.output_shift, op_params.output_multiplier,
+          op_params.quantized_activation_min,
+          op_params.quantized_activation_max,
+          tflite::micro::GetTensorData<int8_t>(input1),
+          extended_input1_shape.DimsData(), op_params.input1_offset,
+          tflite::micro::GetTensorData<int8_t>(input2),
+          extended_input2_shape.DimsData(), op_params.input2_offset);
+
+      TF_LITE_ENSURE(context, err == 0);
+  }
+  if (output->type == kTfLiteInt16) {
+      int err;
+      const RuntimeShape extended_input1_shape =
+        RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(input1));
+      const RuntimeShape extended_input2_shape =
+        RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(input2));
+      const RuntimeShape extended_output_shape =
+        RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(output));
+
+      err = xa_nn_elm_mul_broadcast_4D_sym16sxsym16s_sym16s(
+          tflite::micro::GetTensorData<int16_t>(output),
+          extended_output_shape.DimsData(),
+          op_params.output_shift, op_params.output_multiplier,
+          op_params.quantized_activation_min,
+          op_params.quantized_activation_max,
+          tflite::micro::GetTensorData<int16_t>(input1),
+          extended_input1_shape.DimsData(),
+          tflite::micro::GetTensorData<int16_t>(input2),
+          extended_input2_shape.DimsData());
+
+      TF_LITE_ENSURE(context, err == 0);
+  }
+  return kTfLiteOk;
+}
+
+TfLiteStatus EvalMulFloatHiFi(TfLiteContext* context, TfLiteNode* node,
+    TfLiteMulParams* params, const OpDataMul* data,
+    const TfLiteEvalTensor* input1, const TfLiteEvalTensor* input2,
+    TfLiteEvalTensor* output) {
+  tflite::ArithmeticParams op_params = {};
+  op_params.float_activation_min = data->output_activation_min_f32;
+  op_params.float_activation_max = data->output_activation_max_f32;
+
+  int err;
+  const RuntimeShape& input1_shape = tflite::micro::GetTensorShape(input1);
+  const RuntimeShape& input2_shape = tflite::micro::GetTensorShape(input2);
+  const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+  const int flat_size =
+    MatchingElementsSize(input1_shape, input2_shape, output_shape);
+
+  err = xa_nn_elm_mul_f32xf32_f32(tflite::micro::GetTensorData<float>(output),
+      tflite::micro::GetTensorData<float>(input1),
+      tflite::micro::GetTensorData<float>(input2), flat_size);
+
+  TF_LITE_ENSURE(context, err == 0);
+
+  err = xa_nn_vec_activation_min_max_f32_f32(
+      tflite::micro::GetTensorData<float>(output), tflite::micro::GetTensorData<float>(output),
+      op_params.float_activation_min, op_params.float_activation_max, flat_size);
+
+  TF_LITE_ENSURE(context, err == 0);
+  return kTfLiteOk;
+}
+
+TfLiteStatus MulEval(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->builtin_data != nullptr);
+  auto* params = reinterpret_cast<TfLiteMulParams*>(node->builtin_data);
+
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const OpDataMul* data = static_cast<const OpDataMul*>(node->user_data);
+
+  const TfLiteEvalTensor* input1 =
+      tflite::micro::GetEvalInput(context, node, kMulInput1Tensor);
+  const TfLiteEvalTensor* input2 =
+      tflite::micro::GetEvalInput(context, node, kMulInput2Tensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kMulOutputTensor);
+
+#if defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
+  bool need_broadcast;
+  if(input1->type == kTfLiteFloat32)
+  {
+    tflite::ArithmeticParams op_params = {};
+    op_params.quantized_activation_min = data->output_activation_min;
+    op_params.quantized_activation_max = data->output_activation_max;
+    op_params.float_activation_max = data->output_activation_max_f32;
+    op_params.input1_offset = -data->input1_zero_point;
+    op_params.input2_offset = -data->input2_zero_point;
+    op_params.output_offset = data->output_zero_point;
+    op_params.output_multiplier = data->output_multiplier;
+    op_params.output_shift = data->output_shift;
+
+    need_broadcast = reference_ops::ProcessBroadcastShapes(
+        tflite::micro::GetTensorShape(input1),
+        tflite::micro::GetTensorShape(input2), &op_params);
+  }
+#endif
+
+  switch (input1->type) {
+    case kTfLiteInt8:
+    case kTfLiteInt16:
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+      EvalMulQuantizedHiFi(context, node, data, input1, input2, output);
+#else
+      EvalMulQuantizedReference(context, node, data, input1, input2, output);
+#endif
+      break;
+    case kTfLiteInt32:
+        EvalMulQuantizedReference(context, node, data, input1, input2, output);
+      break;
+    case kTfLiteFloat32:
+#if defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
+      if (!need_broadcast) 
+        EvalMulFloatHiFi(context, node, params, data, input1, input2, output);
+      else
+        EvalMulFloatReference(context, node, params, data, input1, input2, output);
+#else
+      EvalMulFloatReference(context, node, params, data, input1, input2, output);
+#endif
+      break;
+    default:
+      MicroPrintf("Type %s (%d) not supported.",
+                  TfLiteTypeGetName(input1->type), input1->type);
+      return kTfLiteError;
+  }
+
+  return kTfLiteOk;
+}
+
+TFLMRegistration Register_MUL() {
+  return tflite::micro::RegisterOp(MulInit, MulPrepare, MulEval);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/squared_difference.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/squared_difference.cc
@@ -1,0 +1,348 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/binary_function.h"
+#include "tensorflow/lite/kernels/internal/reference/integer_ops/add.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_context.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/micro_log.h"
+
+namespace tflite {
+namespace {
+constexpr int kInputTensor1 = 0;
+constexpr int kInputTensor2 = 1;
+constexpr int kOutputTensor = 0;
+
+struct OpData {
+  bool requires_broadcast;
+  ArithmeticParams arithmetic_params;
+};
+
+template <typename T>
+T SquaredDifference(T input1, T input2) {
+  const T difference = input1 - input2;
+  return difference * difference;
+}
+
+void* SquaredDifferenceInit(TfLiteContext* context, const char* buffer,
+                            size_t length) {
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+  return context->AllocatePersistentBuffer(context, sizeof(OpData));
+}
+
+void PrepareQuantized(
+    const TfLiteQuantizationParams& input1_quantization_params,
+    const TfLiteQuantizationParams& input2_quantization_params,
+    const TfLiteQuantizationParams& output_quantization_params,
+    const int left_shift, const int32_t quantized_activation_min,
+    const int32_t quantized_activation_max, OpData* data) {
+  data->arithmetic_params.input1_offset =
+      -input1_quantization_params.zero_point;
+  data->arithmetic_params.input2_offset =
+      -input2_quantization_params.zero_point;
+  data->arithmetic_params.output_offset = output_quantization_params.zero_point;
+  data->arithmetic_params.left_shift = left_shift;
+  const double twice_max_input_scale =
+      2.0 * static_cast<double>(std::max(input1_quantization_params.scale,
+                                         input2_quantization_params.scale));
+  const double real_input1_multiplier =
+      static_cast<double>(input1_quantization_params.scale) /
+      twice_max_input_scale;
+  double real_input2_multiplier =
+      static_cast<double>(input2_quantization_params.scale) /
+      twice_max_input_scale;
+  const double real_output_multiplier =
+      (twice_max_input_scale * twice_max_input_scale) /
+      static_cast<double>((1 << data->arithmetic_params.left_shift * 2) *
+                          output_quantization_params.scale);
+  QuantizeMultiplierSmallerThanOneExp(
+      real_input1_multiplier, &data->arithmetic_params.input1_multiplier,
+      &data->arithmetic_params.input1_shift);
+  QuantizeMultiplierSmallerThanOneExp(
+      real_input2_multiplier, &data->arithmetic_params.input2_multiplier,
+      &data->arithmetic_params.input2_shift);
+  QuantizeMultiplier(real_output_multiplier,
+                     &data->arithmetic_params.output_multiplier,
+                     &data->arithmetic_params.output_shift);
+  data->arithmetic_params.quantized_activation_min = quantized_activation_min;
+  data->arithmetic_params.quantized_activation_max = quantized_activation_max;
+}
+
+TfLiteStatus SquaredDifferencePrepare(TfLiteContext* context,
+                                      TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  OpData* data = reinterpret_cast<OpData*>(node->user_data);
+  data->requires_broadcast = false;
+
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 2);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+
+  MicroContext* micro_context = GetMicroContext(context);
+
+  TfLiteTensor* input1 =
+      micro_context->AllocateTempInputTensor(node, kInputTensor1);
+  TF_LITE_ENSURE(context, input1 != nullptr);
+  TfLiteTensor* input2 =
+      micro_context->AllocateTempInputTensor(node, kInputTensor2);
+  TF_LITE_ENSURE(context, input2 != nullptr);
+  TfLiteTensor* output =
+      micro_context->AllocateTempOutputTensor(node, kOutputTensor);
+  TF_LITE_ENSURE(context, output != nullptr);
+
+  TF_LITE_ENSURE_TYPES_EQ(context, input1->type, input2->type);
+  output->type = input2->type;
+
+  const TfLiteQuantizationParams& input1_quantization_params = input1->params;
+  const TfLiteQuantizationParams& input2_quantization_params = input2->params;
+  const TfLiteQuantizationParams& output_quantization_params = output->params;
+  if (input1->type == kTfLiteInt8) {
+    const int32_t integer_type_min = std::numeric_limits<int8_t>::min();
+    const int32_t integer_type_max = std::numeric_limits<int8_t>::max();
+    TF_LITE_ENSURE(context,
+                   input1_quantization_params.zero_point >= integer_type_min);
+    TF_LITE_ENSURE(context,
+                   input1_quantization_params.zero_point <= integer_type_max);
+    TF_LITE_ENSURE(context,
+                   input2_quantization_params.zero_point >= integer_type_min);
+    TF_LITE_ENSURE(context,
+                   input2_quantization_params.zero_point <= integer_type_max);
+    TF_LITE_ENSURE(context,
+                   output_quantization_params.zero_point >= integer_type_min);
+    TF_LITE_ENSURE(context,
+                   output_quantization_params.zero_point <= integer_type_max);
+    // leftshift = 7 is selected so that maximum shifted result 255^2 * (1 << (7
+    // * 2 )) does not overflow signed 32-bit integer
+    PrepareQuantized(input1_quantization_params, input2_quantization_params,
+                     output_quantization_params, /*left_shift=*/7,
+                     /*quantized_activation_min*/ integer_type_min,
+                     /*quantized_activation_max*/ integer_type_max, data);
+  } else if (input1->type == kTfLiteInt16) {
+    const int32_t integer_type_min = std::numeric_limits<int16_t>::min();
+    const int32_t integer_type_max = std::numeric_limits<int16_t>::max();
+    TF_LITE_ENSURE(context, input1_quantization_params.zero_point == 0);
+    TF_LITE_ENSURE(context, input2_quantization_params.zero_point == 0);
+    TF_LITE_ENSURE(context, output_quantization_params.zero_point == 0);
+
+    // leftshift = 0 as number is already 16-bit. so that maximum shifted result
+    // 32767^2 * (1 << (0 * 2 ))
+    PrepareQuantized(input1_quantization_params, input2_quantization_params,
+                     output_quantization_params, /*left_shift=*/0,
+                     /*quantized_activation_min*/ integer_type_min,
+                     /*quantized_activation_max*/ integer_type_max, data);
+  }
+
+  data->requires_broadcast = !HaveSameShapes(input1, input2);
+
+  micro_context->DeallocateTempTfLiteTensor(input1);
+  micro_context->DeallocateTempTfLiteTensor(input2);
+  micro_context->DeallocateTempTfLiteTensor(output);
+  return kTfLiteOk;
+}
+
+#if (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+void EvalQuantizedSquaredDifferenceInt8Hifi(TfLiteContext* context,
+                                            TfLiteNode* node,
+                                            const OpData* data,
+                                            const TfLiteEvalTensor* input1,
+                                            const TfLiteEvalTensor* input2,
+                                            TfLiteEvalTensor* output) {
+  const auto* op_data = static_cast<const OpData*>(node->user_data);
+  const ArithmeticParams& params = op_data->arithmetic_params;
+  int err;
+  const RuntimeShape extended_input1_shape =
+      RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(input1));
+  const RuntimeShape extended_input2_shape =
+      RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(input2));
+  const RuntimeShape extended_output_shape =
+      RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(output));
+
+  err = xa_nn_elm_squared_diff_broadcast_4D_asym8sxasym8s_asym8s(
+      tflite::micro::GetTensorData<int8_t>(output),
+      extended_output_shape.DimsData(), params.output_offset,
+      params.output_shift, params.output_multiplier,
+      params.quantized_activation_min,
+      params.quantized_activation_max,
+      tflite::micro::GetTensorData<int8_t>(input1),
+      extended_input1_shape.DimsData(), params.input1_offset,
+      params.input1_shift, params.input1_multiplier,
+      tflite::micro::GetTensorData<int8_t>(input2),
+      extended_input2_shape.DimsData(),
+      params.input2_offset, params.input2_shift,
+      params.input2_multiplier, params.left_shift);
+  (void)err;
+}
+
+void EvalQuantizedSquaredDifferenceInt16Hifi(TfLiteContext* context,
+                                            TfLiteNode* node,
+                                            const OpData* data,
+                                            const TfLiteEvalTensor* input1,
+                                            const TfLiteEvalTensor* input2,
+                                            TfLiteEvalTensor* output) {
+  const auto* op_data = static_cast<const OpData*>(node->user_data);
+  const ArithmeticParams& params = op_data->arithmetic_params;
+  int err;
+  const RuntimeShape extended_input1_shape =
+      RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(input1));
+  const RuntimeShape extended_input2_shape =
+      RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(input2));
+  const RuntimeShape extended_output_shape =
+      RuntimeShape::ExtendedShape(4, tflite::micro::GetTensorShape(output));
+
+  err = xa_nn_elm_squared_diff_broadcast_4D_sym16sxsym16s_sym16s(
+      tflite::micro::GetTensorData<int16_t>(output),
+      extended_output_shape.DimsData(),
+      params.output_shift, params.output_multiplier,
+      params.quantized_activation_min,
+      params.quantized_activation_max,
+      tflite::micro::GetTensorData<int16_t>(input1),
+      extended_input1_shape.DimsData(),
+      params.input1_shift, params.input1_multiplier,
+      tflite::micro::GetTensorData<int16_t>(input2),
+      extended_input2_shape.DimsData(),
+      params.input2_shift, params.input2_multiplier,
+      params.left_shift);
+  (void)err;    
+}
+#endif // #if !(defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+
+template <typename T>
+T SquaredDifference(T x, T y, const ArithmeticParams& params) {
+  const int32_t input1_val = params.input1_offset + x;
+  const int32_t input2_val = params.input2_offset + y;
+  const int32_t shifted_input1_val = input1_val * (1 << params.left_shift);
+  const int32_t shifted_input2_val = input2_val * (1 << params.left_shift);
+  const int32_t scaled_input1_val =
+      MultiplyByQuantizedMultiplierSmallerThanOneExp(
+          shifted_input1_val, params.input1_multiplier, params.input1_shift);
+  const int32_t scaled_input2_val =
+      MultiplyByQuantizedMultiplierSmallerThanOneExp(
+          shifted_input2_val, params.input2_multiplier, params.input2_shift);
+  const int32_t raw_diff = scaled_input1_val - scaled_input2_val;
+
+  // Max of this is 32767^2 * (1 << 0), so won't overflow 32 bits.
+  const int32_t squared_raw_diff = raw_diff * raw_diff;
+  const int32_t raw_output =
+      MultiplyByQuantizedMultiplier(squared_raw_diff, params.output_multiplier,
+                                    params.output_shift) +
+      params.output_offset;
+  const int32_t clamped_output =
+      std::min(params.quantized_activation_max,
+               std::max(params.quantized_activation_min, raw_output));
+  return static_cast<T>(clamped_output);
+}
+
+template <typename T>
+void EvalQuantizedSquaredDifference(TfLiteContext* context, TfLiteNode* node,
+                                    const OpData* data,
+                                    const TfLiteEvalTensor* input1,
+                                    const TfLiteEvalTensor* input2,
+                                    TfLiteEvalTensor* output) {
+  const auto* op_data = static_cast<const OpData*>(node->user_data);
+  if (data->requires_broadcast) {
+    reference_integer_ops::BroadcastBinaryFunction4DSlow(
+        op_data->arithmetic_params, tflite::micro::GetTensorShape(input1),
+        tflite::micro::GetTensorData<T>(input1),
+        tflite::micro::GetTensorShape(input2),
+        tflite::micro::GetTensorData<T>(input2),
+        tflite::micro::GetTensorShape(output),
+        tflite::micro::GetTensorData<T>(output),
+        reference_integer_ops::CheckArithmeticParams, SquaredDifference);
+  } else {
+    const int flat_size = tflite::micro::GetTensorShape(input1).FlatSize();
+    reference_integer_ops::ElementWise(
+        flat_size, op_data->arithmetic_params,
+        tflite::micro::GetTensorData<T>(input1),
+        tflite::micro::GetTensorData<T>(input2),
+        tflite::micro::GetTensorData<T>(output),
+        reference_integer_ops::CheckArithmeticParams, SquaredDifference);
+  }
+}
+
+template <typename T>
+void EvalSquaredDifference(TfLiteContext* context, TfLiteNode* node,
+                           const OpData* data, const TfLiteEvalTensor* input1,
+                           const TfLiteEvalTensor* input2,
+                           TfLiteEvalTensor* output) {
+  if (data->requires_broadcast) {
+    reference_ops::BroadcastBinaryFunction4DSlow<T, T, T>(
+        tflite::micro::GetTensorShape(input1),
+        tflite::micro::GetTensorData<T>(input1),
+        tflite::micro::GetTensorShape(input2),
+        tflite::micro::GetTensorData<T>(input2),
+        tflite::micro::GetTensorShape(output),
+        tflite::micro::GetTensorData<T>(output), SquaredDifference<T>);
+  } else {
+    reference_ops::BinaryFunction<T, T, T>(
+        tflite::micro::GetTensorShape(input1),
+        tflite::micro::GetTensorData<T>(input1),
+        tflite::micro::GetTensorShape(input2),
+        tflite::micro::GetTensorData<T>(input2),
+        tflite::micro::GetTensorShape(output),
+        tflite::micro::GetTensorData<T>(output), SquaredDifference<T>);
+  }
+}
+
+TfLiteStatus SquaredDifferenceEval(TfLiteContext* context, TfLiteNode* node) {
+  OpData* data = reinterpret_cast<OpData*>(node->user_data);
+
+  const TfLiteEvalTensor* input1 =
+      tflite::micro::GetEvalInput(context, node, kInputTensor1);
+  const TfLiteEvalTensor* input2 =
+      tflite::micro::GetEvalInput(context, node, kInputTensor2);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+
+  if (output->type == kTfLiteFloat32) {
+    EvalSquaredDifference<float>(context, node, data, input1, input2, output);
+  } else if (output->type == kTfLiteInt32) {
+    EvalSquaredDifference<int32_t>(context, node, data, input1, input2, output);
+  } else if (output->type == kTfLiteInt8) {
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+    EvalQuantizedSquaredDifferenceInt8Hifi(context, node, data, input1, input2,
+                                           output);
+#else
+    EvalQuantizedSquaredDifference<int8_t>(context, node, data, input1, input2,
+                                           output);
+#endif
+  } else if (output->type == kTfLiteInt16) {
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+    EvalQuantizedSquaredDifferenceInt16Hifi(context, node, data, input1, input2,
+                                           output);
+#else
+    EvalQuantizedSquaredDifference<int16_t>(context, node, data, input1, input2,
+                                            output);
+#endif
+  } else {
+    MicroPrintf(
+        "SquaredDifference only supports FLOAT32, INT32 , INT16 and INT8 now, "
+        "got %d.",
+        output->type);
+    return kTfLiteError;
+  }
+
+  return kTfLiteOk;
+}
+
+}  // namespace
+
+TFLMRegistration Register_SQUARED_DIFFERENCE() {
+  return tflite::micro::RegisterOp(
+      SquaredDifferenceInit, SquaredDifferencePrepare, SquaredDifferenceEval);
+}
+
+}  // namespace tflite


### PR DESCRIPTION
Adds xtensa-specific elementwise.cc, logical.cc, mul.cc, and squared_difference.cc kernels with HiFi-optimized implementations (xa_nn_elm_* NN library calls) for the elementwise unary ops (abs, sin, cos, log, sqrt, rsqrt, square), logical_not, and the binary MUL and SQUARED_DIFFERENCE operators.

@cad-audio @joshih-cad