### PR TITLE
ci(pypi): file an issue on wheel build failure

### DIFF
--- a/.github/workflows/pypi_build.yml
+++ b/.github/workflows/pypi_build.yml
@@ -61,3 +61,18 @@ jobs:
         run: |
           python/tflite_micro/pypi_upload.sh \
           bazel-pypi-out/tflite_micro-*.whl
+
+  issue-on-error:
+    needs: [pypi-build]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    permissions:
+      issues: write
+    uses: ./.github/workflows/issue_on_error.yml
+    with:
+      repo: ${{ github.repository }}
+      workflow: ${{ github.workflow }}
+      run_id: ${{ github.run_id }}
+      run_number: ${{ github.run_number }}
+      flag_label: bot:issue
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pypi_build.yml
+++ b/.github/workflows/pypi_build.yml
@@ -32,7 +32,7 @@ jobs:
   pypi-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ secrets.TFLM_BOT_REPO_TOKEN }}
       - name: Build Wheel 3.10


### PR DESCRIPTION
File an issue when the nightly PyPI build fails, using the reusable
reporting workflow the platform test workflows already call. The
nightly build broke in February and failed daily for six months
before anyone noticed, because nothing reported the failures.

Also pin the checkout action to a commit hash. CI runs the zizmor
scanner on any workflow file a PR changes, and zizmor requires
actions pinned to hashes.

BUG=fixes #3655
