### PR TITLE
test(compression): add proprietary model integration test

### DIFF
--- a/tensorflow/lite/micro/compression/BUILD
+++ b/tensorflow/lite/micro/compression/BUILD
@@ -169,6 +169,34 @@ py_test(
     ],
 )
 
+tflm_py_library(
+    name = "verify",
+    srcs = ["verify.py"],
+    deps = [
+        ":model_editor",
+        ":tensor_type",
+        "//python/tflite_micro:runtime",
+        requirement("numpy"),
+    ],
+)
+
+tflm_py_test(
+    name = "verify_test",
+    size = "small",
+    srcs = ["verify_test.py"],
+    tags = [
+        "noasan",
+        "nomsan",
+        "noubsan",
+    ],
+    deps = [
+        ":model_editor",
+        ":verify",
+        "//tensorflow/lite/python:schema_py",
+        requirement("numpy"),
+    ],
+)
+
 tflm_py_test(
     name = "compression_integration_test",
     size = "small",
@@ -188,9 +216,62 @@ tflm_py_test(
         ":decode_insert",
         ":model_editor",
         ":spec",
+        ":verify",
         "//python/tflite_micro:runtime",
         "//tensorflow/lite/python:schema_py",
         requirement("numpy"),
+    ],
+)
+
+tflm_py_test(
+    name = "proprietary_integration_test",
+    size = "small",
+    srcs = ["proprietary_integration_test.py"],
+    tags = [
+        "manual",
+        "noasan",
+        "nomsan",
+        "noubsan",
+    ],
+    target_compatible_with = select({
+        "//:with_compression_enabled": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        ":compress_lib",
+        ":spec",
+        ":verify",
+        requirement("pyyaml"),
+    ],
+)
+
+tflm_py_test(
+    name = "proprietary_integration_smoke_test",
+    size = "small",
+    srcs = [
+        "compression_integration_test.py",
+        "proprietary_integration_smoke_test.py",
+        "proprietary_integration_test.py",
+    ],
+    tags = [
+        "noasan",
+        "nomsan",
+        "noubsan",
+    ],
+    target_compatible_with = select({
+        "//:with_compression_enabled": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        ":compress_lib",
+        ":decode_insert",
+        ":model_editor",
+        ":spec",
+        ":verify",
+        "//python/tflite_micro:runtime",
+        "//tensorflow/lite/python:schema_py",
+        requirement("numpy"),
+        requirement("pyyaml"),
     ],
 )
 

--- a/tensorflow/lite/micro/compression/compression_integration_test.py
+++ b/tensorflow/lite/micro/compression/compression_integration_test.py
@@ -29,6 +29,7 @@ from tflite_micro.tensorflow.lite.micro.compression import compress
 from tflite_micro.tensorflow.lite.micro.compression import decode_insert
 from tflite_micro.tensorflow.lite.micro.compression import model_editor
 from tflite_micro.tensorflow.lite.micro.compression import spec
+from tflite_micro.tensorflow.lite.micro.compression import verify
 from tflite_micro.tensorflow.lite.python import schema_py_generated as tflite
 
 
@@ -121,27 +122,9 @@ class LutCompressionTest(unittest.TestCase):
         )
     ]
 
-    # Compress
     compressed_fb = compress.compress(flatbuffer, specs)
 
-    # Run inference on both (convert bytearray to bytes for interpreter)
-    uncompressed_interp = runtime.Interpreter.from_bytes(bytes(flatbuffer))
-    compressed_interp = runtime.Interpreter.from_bytes(bytes(compressed_fb))
-
-    # Test with multiple random inputs
-    np.random.seed(42)
-    for _ in range(10):
-      test_input = np.random.randint(-128, 127, (1, 4), dtype=np.int8)
-
-      uncompressed_interp.set_input(test_input, 0)
-      uncompressed_interp.invoke()
-      expected = uncompressed_interp.get_output(0)
-
-      compressed_interp.set_input(test_input, 0)
-      compressed_interp.invoke()
-      actual = compressed_interp.get_output(0)
-
-      np.testing.assert_array_equal(expected, actual)
+    verify.assert_outputs_match(flatbuffer, compressed_fb)
 
   def test_lut_decode_operators_present(self):
     """DECODE operators are inserted for LUT-compressed tensors."""
@@ -208,20 +191,7 @@ class LutCompressionTest(unittest.TestCase):
 
     compressed_fb = compress.compress(flatbuffer, specs)
 
-    uncompressed_interp = runtime.Interpreter.from_bytes(bytes(flatbuffer))
-    compressed_interp = runtime.Interpreter.from_bytes(bytes(compressed_fb))
-
-    test_input = np.array([[1, 2, 3, 4]], dtype=np.int8)
-
-    uncompressed_interp.set_input(test_input, 0)
-    uncompressed_interp.invoke()
-    expected = uncompressed_interp.get_output(0)
-
-    compressed_interp.set_input(test_input, 0)
-    compressed_interp.invoke()
-    actual = compressed_interp.get_output(0)
-
-    np.testing.assert_array_equal(expected, actual)
+    verify.assert_outputs_match(flatbuffer, compressed_fb)
 
   def test_lut_per_channel_quantization(self):
     """Per-channel quantized weights compress and decompress correctly."""
@@ -237,20 +207,7 @@ class LutCompressionTest(unittest.TestCase):
 
     compressed_fb = compress.compress(flatbuffer, specs)
 
-    uncompressed_interp = runtime.Interpreter.from_bytes(bytes(flatbuffer))
-    compressed_interp = runtime.Interpreter.from_bytes(bytes(compressed_fb))
-
-    test_input = np.array([[1, 2, 3, 4]], dtype=np.int8)
-
-    uncompressed_interp.set_input(test_input, 0)
-    uncompressed_interp.invoke()
-    expected = uncompressed_interp.get_output(0)
-
-    compressed_interp.set_input(test_input, 0)
-    compressed_interp.invoke()
-    actual = compressed_interp.get_output(0)
-
-    np.testing.assert_array_equal(expected, actual)
+    verify.assert_outputs_match(flatbuffer, compressed_fb)
 
   def test_lut_unquantized_weights(self):
     """Unquantized weights compress and decompress correctly."""
@@ -266,20 +223,7 @@ class LutCompressionTest(unittest.TestCase):
 
     compressed_fb = compress.compress(flatbuffer, specs)
 
-    uncompressed_interp = runtime.Interpreter.from_bytes(bytes(flatbuffer))
-    compressed_interp = runtime.Interpreter.from_bytes(bytes(compressed_fb))
-
-    test_input = np.array([[1, 2, 3, 4]], dtype=np.int8)
-
-    uncompressed_interp.set_input(test_input, 0)
-    uncompressed_interp.invoke()
-    expected = uncompressed_interp.get_output(0)
-
-    compressed_interp.set_input(test_input, 0)
-    compressed_interp.invoke()
-    actual = compressed_interp.get_output(0)
-
-    np.testing.assert_array_equal(expected, actual)
+    verify.assert_outputs_match(flatbuffer, compressed_fb)
 
 
 def _build_shared_weights_model():

--- a/tensorflow/lite/micro/compression/proprietary_integration_smoke_test.py
+++ b/tensorflow/lite/micro/compression/proprietary_integration_smoke_test.py
@@ -1,0 +1,65 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Smoke test for the proprietary-model integration test harness.
+
+Run the harness in proprietary_integration_test.py over a temporary
+models directory holding synthetic models, so the harness's model
+discovery, sidecar parsing, input generation, and output comparison
+run in normal CI, where no proprietary model is available.
+"""
+
+import pathlib
+import tempfile
+import unittest
+
+from tflite_micro.tensorflow.lite.micro.compression import compression_integration_test
+from tflite_micro.tensorflow.lite.micro.compression import proprietary_integration_test
+
+_SPEC_YAML = """\
+tensors:
+  - subgraph: 0
+    tensor: 0
+    compression:
+      - lut:
+          index_bitwidth: 2
+"""
+
+
+class HarnessSmokeTest(proprietary_integration_test.ProprietaryModelTest):
+  """The harness's own tests, run over a generated models directory.
+
+  One model pairs with only a spec file and takes the exact-match
+  path; the other adds a config file and takes the tolerance path.
+  """
+
+  @classmethod
+  def setUpClass(cls):
+    cls._tmpdir = tempfile.TemporaryDirectory()
+    d = pathlib.Path(cls._tmpdir.name)
+    flatbuffer = compression_integration_test._build_compressible_model()
+    (d / "exact.tflite").write_bytes(flatbuffer)
+    (d / "exact.spec.yaml").write_text(_SPEC_YAML)
+    (d / "tolerant.tflite").write_bytes(flatbuffer)
+    (d / "tolerant.spec.yaml").write_text(_SPEC_YAML)
+    (d / "tolerant.config.yaml").write_text("rtol: 1.0e-6\natol: 1.0e-6\n")
+    cls.models_dir = str(d)
+    super().setUpClass()
+
+  @classmethod
+  def tearDownClass(cls):
+    cls._tmpdir.cleanup()
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tensorflow/lite/micro/compression/proprietary_integration_test.py
+++ b/tensorflow/lite/micro/compression/proprietary_integration_test.py
@@ -1,0 +1,134 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration tests for compression using proprietary models.
+
+These tests verify that compressed models produce correct inference results
+when run through the TFLM Python interpreter. Tests compress models and
+compare outputs against uncompressed originals using random inputs.
+
+This test is tagged `manual` and requires a path to a directory containing
+.tflite model files.
+
+Usage:
+    bazel test //tensorflow/lite/micro/compression:proprietary_integration_test \
+        --//:with_compression \
+        --test_arg=--models-dir=/path/to/models
+
+Required files:
+    Each model requires a compression spec file:
+        model.spec.yaml  (replacing .tflite extension)
+
+    See spec.py for the YAML format.
+
+Optional files:
+    model.config.yaml  (replacing .tflite extension)
+        Comparison tolerances. Example:
+            rtol: 1.0e-6
+            atol: 1.0e-6
+        An output element passes when:
+            abs(actual - expected) <= atol + rtol * abs(expected)
+        rtol scales with the expected value's magnitude; atol is an
+        absolute floor for values near zero. Without this file,
+        outputs must match exactly.
+"""
+
+import argparse
+import glob
+import os
+import sys
+import unittest
+
+import yaml
+
+from tflite_micro.tensorflow.lite.micro.compression import compress
+from tflite_micro.tensorflow.lite.micro.compression import spec
+from tflite_micro.tensorflow.lite.micro.compression import verify
+
+
+class ProprietaryModelTest(unittest.TestCase):
+  """Integration tests using proprietary models."""
+
+  # Injection seam: filled by the --models-dir option in main(), or by a
+  # subclass
+  models_dir = None
+
+  @classmethod
+  def setUpClass(cls):
+    if not cls.models_dir:
+      raise unittest.SkipTest(
+          "No models directory provided. "
+          "Usage: bazel test ... --test_arg=--models-dir=/path/to/models")
+
+    cls.model_paths = sorted(
+        glob.glob(os.path.join(cls.models_dir, '*.tflite')))
+    if not cls.model_paths:
+      raise unittest.SkipTest(f"No .tflite files found in {cls.models_dir}")
+
+  def test_all_models(self):
+    """Run compression test on each discovered model."""
+    for model_path in self.model_paths:
+      with self.subTest(model=os.path.basename(model_path)):
+        self._test_model_compression(model_path)
+
+  def _test_model_compression(self, model_path):
+    """Test that a compressed model produces same outputs as original."""
+    with open(model_path, 'rb') as f:
+      flatbuffer = f.read()
+
+    specs = self._load_compression_spec(model_path)
+    tolerance = self._load_tolerance(model_path)
+    compressed = compress.compress(flatbuffer, specs)
+    verify.assert_outputs_match(flatbuffer, compressed, tolerance=tolerance)
+
+  def _load_compression_spec(self, model_path):
+    """Load compression spec from sidecar YAML file.
+
+    Raises:
+      FileNotFoundError: If no spec file is found.
+    """
+    spec_path = model_path.removesuffix('.tflite') + '.spec.yaml'
+    if os.path.exists(spec_path):
+      with open(spec_path) as f:
+        return spec.parse_yaml(f.read())
+
+    raise FileNotFoundError(
+        f"No compression spec file found for {model_path}. "
+        f"Expected: {spec_path}")
+
+  def _load_tolerance(self, model_path):
+    """Load tolerance from sidecar config if present.
+
+    Returns None, meaning exact match, if no config file exists.
+    """
+    config_path = model_path.removesuffix('.tflite') + '.config.yaml'
+    if not os.path.exists(config_path):
+      return None
+    with open(config_path) as f:
+      config = yaml.safe_load(f)
+    # float() rescues exponents like 1e-6, which YAML reads as strings
+    return verify.Tolerance(rtol=float(config.get('rtol', 0)),
+                            atol=float(config.get('atol', 0)))
+
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      "--models-dir",
+      help="directory of .tflite models with sidecar compression specs")
+  args, rest = parser.parse_known_args()
+  if args.models_dir:
+    if not os.path.isdir(args.models_dir):
+      parser.error(f"not a directory: {args.models_dir}")
+    ProprietaryModelTest.models_dir = args.models_dir
+  unittest.main(argv=[sys.argv[0]] + rest)

--- a/tensorflow/lite/micro/compression/verify.py
+++ b/tensorflow/lite/micro/compression/verify.py
@@ -1,0 +1,88 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Verify that two models produce matching outputs.
+
+Feed identical random inputs to two models through the TFLM Python
+interpreter and compare their outputs. The primary use is checking that
+a compressed model behaves the same as the original it was compressed
+from.
+"""
+
+import typing
+
+import numpy as np
+
+from tflite_micro.python.tflite_micro import runtime
+from tflite_micro.tensorflow.lite.micro.compression import model_editor
+from tflite_micro.tensorflow.lite.micro.compression import tensor_type
+
+_TRIALS = 5
+_SEED = 42
+
+
+def assert_outputs_match(original, candidate, *, tolerance=None):
+  """Assert that two models produce matching outputs on random inputs.
+
+  Run both models on identical random inputs for several trials.
+  Outputs must match exactly, unless a Tolerance is given, in which
+  case an output element passes when:
+      abs(candidate - original) <= atol + rtol * abs(original)
+
+  Raises:
+    AssertionError: if any output mismatches.
+  """
+  original_interp = runtime.Interpreter.from_bytes(bytes(original))
+  candidate_interp = runtime.Interpreter.from_bytes(bytes(candidate))
+
+  rng = np.random.default_rng(_SEED)
+  sg = model_editor.read(original).subgraphs[0]
+
+  for trial in range(_TRIALS):
+    for i, tensor in enumerate(sg.inputs):
+      value = _random_input(rng, tensor)
+      original_interp.set_input(value, i)
+      candidate_interp.set_input(value, i)
+
+    original_interp.invoke()
+    candidate_interp.invoke()
+
+    for i in range(len(sg.outputs)):
+      expected = original_interp.get_output(i)
+      actual = candidate_interp.get_output(i)
+      msg = f"Output mismatch (trial {trial}, output {i})"
+      if tolerance is None:
+        np.testing.assert_array_equal(expected, actual, err_msg=msg)
+      else:
+        np.testing.assert_allclose(expected,
+                                   actual,
+                                   rtol=tolerance.rtol,
+                                   atol=tolerance.atol,
+                                   err_msg=msg)
+
+
+class Tolerance(typing.NamedTuple):
+  """Output comparison tolerances for assert_outputs_match."""
+  rtol: float
+  atol: float
+
+
+def _random_input(rng, tensor):
+  """Generate a random array matching the tensor's shape and dtype."""
+  shape = tensor.shape
+  dtype = tensor_type.to_numpy(tensor.dtype)
+
+  if np.issubdtype(dtype, np.floating):
+    return rng.uniform(-1.0, 1.0, shape).astype(dtype)
+  info = np.iinfo(dtype)
+  return rng.integers(info.min, info.max, shape, dtype=dtype, endpoint=True)

--- a/tensorflow/lite/micro/compression/verify_test.py
+++ b/tensorflow/lite/micro/compression/verify_test.py
@@ -1,0 +1,137 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for verify.py.
+
+The library's callers only ever exercise the passing direction, so
+these tests focus on the failing direction: assert_outputs_match must
+raise when two models disagree. The fixture model has two inputs and
+two outputs, each input feeding its own operator, so the input and
+output loops genuinely iterate and a positional mix-up between the
+branches shows up as a mismatch.
+"""
+
+import unittest
+
+import numpy as np
+
+from tflite_micro.tensorflow.lite.micro.compression import model_editor
+from tflite_micro.tensorflow.lite.micro.compression import verify
+from tflite_micro.tensorflow.lite.python import schema_py_generated as tflite
+
+
+class VerifyTest(unittest.TestCase):
+
+  def test_identical_models_pass(self):
+    verify.assert_outputs_match(_build_model(), _build_model())
+
+  def test_mismatch_in_either_branch_raises(self):
+    for branch in (1, 2):
+      with self.subTest(branch=branch):
+        with self.assertRaises(AssertionError):
+          verify.assert_outputs_match(_build_model(),
+                                      _build_model(nudge_branch=branch))
+
+  def test_tolerance_allows_small_differences(self):
+    original = _build_model()
+    nudged = _build_model(nudge_branch=2)
+
+    with self.assertRaises(AssertionError):
+      verify.assert_outputs_match(original, nudged)
+
+    # int8 outputs differ by at most 255, so this tolerance admits the
+    # nudge while still proving the tolerance parameter changes the
+    # outcome of the exact comparison above.
+    verify.assert_outputs_match(original,
+                                nudged,
+                                tolerance=verify.Tolerance(rtol=0, atol=255))
+
+
+def _build_model(nudge_branch=None):
+  """Build a model holding two disconnected one-layer branches.
+
+  The graph has two dataflow paths that share nothing:
+
+      input1 -> FULLY_CONNECTED(weights1) -> output1
+      input2 -> FULLY_CONNECTED(weights2) -> output2
+
+  One invocation runs both branches. This gives the model two inputs
+  and two outputs, with each output depending on exactly one input
+  and one weight tensor, so a comparison that mixes up input or
+  output positions compares genuinely different numbers. The two
+  weight tensors differ from each other for the same reason.
+
+  nudge_branch=1 or 2 adds one to a single weight in that branch,
+  making only that branch's output differ from the unnudged model's.
+  """
+  # 4 unique small values per tensor avoid saturation; different rows
+  # produce varied outputs.
+  weights_data = [
+      np.array([
+          [-1, 0, 0, 1],
+          [-1, 0, 1, 1],
+          [-1, 1, 1, 1],
+          [0, 1, 1, 1],
+      ],
+               dtype=np.int8),
+      np.array([
+          [1, 1, 1, 1],
+          [1, 1, 2, 2],
+          [1, 2, 2, 3],
+          [2, 2, 3, 3],
+      ],
+               dtype=np.int8),
+  ]
+  if nudge_branch is not None:
+    nudged = weights_data[nudge_branch - 1].copy()
+    nudged[0, 0] += 1
+    weights_data[nudge_branch - 1] = nudged
+
+  def tensor(name, shape, data=None):
+    return model_editor.Tensor(shape=shape,
+                               dtype=tflite.TensorType.INT8,
+                               data=data,
+                               name=name,
+                               quantization=model_editor.Quantization(
+                                   scales=1.0, zero_points=0))
+
+  return model_editor.Model(subgraphs=[
+      model_editor.Subgraph(
+          tensors=[
+              w1 := tensor("weights1", (4, 4), weights_data[0]),
+              w2 := tensor("weights2", (4, 4), weights_data[1]),
+          ],
+          inputs=[
+              i1 := tensor("input1", (1, 4)),
+              i2 := tensor("input2", (1, 4)),
+          ],
+          outputs=[
+              o1 := tensor("output1", (1, 4)),
+              o2 := tensor("output2", (1, 4)),
+          ],
+          operators=[
+              model_editor.Operator(
+                  opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+                  inputs=[i1, w1],
+                  outputs=[o1]),
+              model_editor.Operator(
+                  opcode=tflite.BuiltinOperator.FULLY_CONNECTED,
+                  inputs=[i2, w2],
+                  outputs=[o2]),
+          ],
+      )
+  ]).build()
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Add a manual test that verifies compression on proprietary models
that can't be checked into the repository. The test discovers models
in a directory given on the command line, compresses each per a
sidecar spec file, and requires the compressed model to produce the
same outputs as the original. See the module docstring for usage.

Extract the output-equivalence check into a shared library used by
both this test and the in-tree integration tests, which previously
repeated it inline. Outputs must match exactly by default; a sidecar
config file can relax the comparison to a tolerance for future lossy
compression schemes. Give the library its own test, built around a
two-input, two-output model, to prove it detects mismatches; its
callers only ever exercise the passing direction.

Add a smoke test that runs the manual test's harness on synthetic
models in a temporary directory, so the harness's model discovery and
sidecar parsing stay covered by normal CI runs, which have no
proprietary model to use.

BUG=part of #3256

