### PR TITLE
refactor(compression): compressors inherit from Compressor protocol

### DIFF
--- a/tensorflow/lite/micro/compression/huffman.py
+++ b/tensorflow/lite/micro/compression/huffman.py
@@ -25,7 +25,7 @@ from tflite_micro.tensorflow.lite.micro.compression import model_editor
 from tflite_micro.tensorflow.lite.micro.compression import spec
 
 
-class HuffmanCompressor:
+class HuffmanCompressor(compressor.Compressor):
   """Huffman compression plugin (stub).
 
   This stub exists to validate the plugin architecture. The actual Huffman

--- a/tensorflow/lite/micro/compression/lut.py
+++ b/tensorflow/lite/micro/compression/lut.py
@@ -241,7 +241,7 @@ def pack_lookup_tables(tables: list[np.ndarray], table_len: int) -> bytes:
   return bytes(buffer)
 
 
-class LutCompressor:
+class LutCompressor(compressor.Compressor):
   """LUT compression plugin implementing the Compressor protocol."""
 
   @property

--- a/tensorflow/lite/micro/compression/pruning.py
+++ b/tensorflow/lite/micro/compression/pruning.py
@@ -25,7 +25,7 @@ from tflite_micro.tensorflow.lite.micro.compression import model_editor
 from tflite_micro.tensorflow.lite.micro.compression import spec
 
 
-class PruningCompressor:
+class PruningCompressor(compressor.Compressor):
   """Pruning compression plugin (stub).
 
   This stub exists to validate the plugin architecture. The actual pruning


### PR DESCRIPTION
Explicit inheritance from Protocol enables static type checking at
definition time and makes the interface self-documenting.

BUG=part of #3256

