### PR TITLE
test(compression): run integration tests without compression flag

### DIFF
--- a/tensorflow/lite/micro/compression/BUILD
+++ b/tensorflow/lite/micro/compression/BUILD
@@ -206,11 +206,7 @@ tflm_py_test(
         "nomsan",
         "noubsan",
     ],
-    # Only run when compression IS enabled
-    target_compatible_with = select({
-        "//:with_compression_enabled": [],
-        "//conditions:default": ["@platforms//:incompatible"],
-    }),
+    target_compatible_with = INCOMPATIBLE_WITH_WINDOWS,
     deps = [
         ":compress_lib",
         ":decode_insert",
@@ -233,10 +229,7 @@ tflm_py_test(
         "nomsan",
         "noubsan",
     ],
-    target_compatible_with = select({
-        "//:with_compression_enabled": [],
-        "//conditions:default": ["@platforms//:incompatible"],
-    }),
+    target_compatible_with = INCOMPATIBLE_WITH_WINDOWS,
     deps = [
         ":compress_lib",
         ":spec",


### PR DESCRIPTION
Remove the with_compression_enabled gating from the compression and
proprietary-model integration tests. The tests exercise DECODE-based
models, and the DECODE kernel and its dependencies are compiled and
registered unconditionally, so the tests need no special build flags.

BUG=part of #3256

