### PR TITLE
Validate RESIZE_NEAREST_NEIGHBOR size tensor against output shape

### DIFF
--- a/tensorflow/lite/micro/kernels/resize_nearest_neighbor.cc
+++ b/tensorflow/lite/micro/kernels/resize_nearest_neighbor.cc
@@ -57,6 +57,14 @@ TfLiteStatus ResizeNearestNeighborPrepare(TfLiteContext* context,
   TF_LITE_ENSURE_MSG(context, IsConstantTensor(size),
                      "Non-constant >size< tensor is not supported");
 
+  // Eval() writes size[0] * size[1] * depth bytes into the output buffer,
+  // which the allocator sized from the declared output dimensions. Reject
+  // models whose size tensor disagrees with the declared output shape to
+  // prevent a linear out-of-bounds write.
+  TF_LITE_ENSURE_EQ(context, NumDimensions(output), 4);
+  TF_LITE_ENSURE_EQ(context, size->data.i32[0], output->dims->data[1]);
+  TF_LITE_ENSURE_EQ(context, size->data.i32[1], output->dims->data[2]);
+
   micro_context->DeallocateTempTfLiteTensor(input);
   micro_context->DeallocateTempTfLiteTensor(size);
   micro_context->DeallocateTempTfLiteTensor(output);

--- a/tensorflow/lite/micro/kernels/resize_nearest_neighbor_test.cc
+++ b/tensorflow/lite/micro/kernels/resize_nearest_neighbor_test.cc
@@ -353,4 +353,41 @@ TEST(ResizeNearestNeighborTest, ThreeDimensionalResizeInt16) {
       output_dims, output_data);
 }
 
+TEST(ResizeNearestNeighborTest, RejectsSizeMismatchWithDeclaredOutputShape) {
+  // The size tensor requests a 1024x1024 output, but the model declares a
+  // 1x1 output. Prepare must reject this instead of letting Eval() write
+  // 1024*1024*depth bytes into a 1-element buffer.
+  int input_dims[] = {4, 1, 1, 2, 1};
+  const int8_t input_data[] = {1, 2};
+  int size_dims[] = {1, 2};
+  const int32_t size_data[] = {1024, 1024};
+  int output_dims[] = {4, 1, 1, 1, 1};
+  int8_t output_data[1];
+
+  TfLiteIntArray* input_dims_arr = IntArrayFromInts(input_dims);
+  TfLiteIntArray* size_dims_arr = IntArrayFromInts(size_dims);
+  TfLiteIntArray* output_dims_arr = IntArrayFromInts(output_dims);
+
+  constexpr int tensors_size = 3;
+  TfLiteTensor tensors[tensors_size] = {
+      CreateTensor(input_data, input_dims_arr),
+      CreateTensor(size_data, size_dims_arr),
+      CreateTensor(output_data, output_dims_arr),
+  };
+  tensors[1].allocation_type = kTfLiteMmapRo;
+
+  TfLiteResizeNearestNeighborParams builtin_data = {false, false};
+
+  int inputs_array_data[] = {2, 0, 1};
+  TfLiteIntArray* inputs_array = IntArrayFromInts(inputs_array_data);
+  int outputs_array_data[] = {1, 2};
+  TfLiteIntArray* outputs_array = IntArrayFromInts(outputs_array_data);
+
+  const TFLMRegistration registration = Register_RESIZE_NEAREST_NEIGHBOR();
+  micro::KernelRunner runner(registration, tensors, tensors_size, inputs_array,
+                             outputs_array, &builtin_data);
+
+  EXPECT_NE(kTfLiteOk, runner.InitAndPrepare());
+}
+
 TF_LITE_MICRO_TESTS_MAIN


### PR DESCRIPTION
BUG=n/a

ResizeNearestNeighborPrepare() validates the size tensor's rank, type and constness but never compares its values against the declared output dimensions. Eval() then writes size[0]*size[1]*depth bytes sequentially into the output buffer, which the allocator sized from the declared shape, so a mismatch produces a linear out-of-bounds write (attacker-controlled length and content).

Reject such models at Prepare time and add a regression test that asserts a size/output mismatch fails allocation.

Verified locally: with this change, a model declaring output [1,1,1,1] with a size tensor {1024,1024} is rejected at AllocateTensors instead of overflowing the arena.