### PR TITLE
feat(kernels): add basic_classifier custom operator

### DIFF
--- a/python/tflite_micro/python_ops_resolver.cc
+++ b/python/tflite_micro/python_ops_resolver.cc
@@ -28,6 +28,7 @@ PythonOpsResolver::PythonOpsResolver() {
   AddArgMin();
   AddAssignVariable();
   AddAveragePool2D();
+  AddBasicClassifier();
   AddBatchMatMul();
   AddBatchToSpaceNd();
   AddBroadcastArgs();

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -236,6 +236,7 @@ tflm_kernel_cc_library(
         "add_n.cc",
         "arg_min_max.cc",
         "assign_variable.cc",
+        "basic_classifier.cc",
         "batch_matmul.cc",
         "batch_matmul_common.cc",
         "batch_to_space_nd.cc",
@@ -496,6 +497,21 @@ tflm_cc_test(
         ":kernel_runner",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/micro:op_resolvers",
+        "//tensorflow/lite/micro:test_helpers",
+        "//tensorflow/lite/micro/testing:micro_test",
+    ],
+)
+
+tflm_cc_test(
+    name = "basic_classifier_test",
+    srcs = [
+        "basic_classifier_test.cc",
+    ],
+    deps = [
+        ":kernel_runner",
+        ":micro_ops",
+        "//tensorflow/lite/c:c_api_types",
+        "//tensorflow/lite/c:common",
         "//tensorflow/lite/micro:test_helpers",
         "//tensorflow/lite/micro/testing:micro_test",
     ],

--- a/tensorflow/lite/micro/kernels/Makefile.inc
+++ b/tensorflow/lite/micro/kernels/Makefile.inc
@@ -114,6 +114,7 @@ $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/activations_test.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/add_test.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/add_n_test.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/arg_min_max_test.cc \
+$(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/basic_classifier_test.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/batch_matmul_test.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/batch_to_space_nd_test.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/broadcast_args_test.cc \

--- a/tensorflow/lite/micro/kernels/basic_classifier.cc
+++ b/tensorflow/lite/micro/kernels/basic_classifier.cc
@@ -1,0 +1,114 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+
+#include "tensorflow/lite/c/c_api_types.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/micro_ops.h"
+#include "tensorflow/lite/micro/micro_common.h"
+#include "tensorflow/lite/micro/micro_context.h"
+
+namespace tflite {
+namespace {
+
+constexpr int kInputTensor = 0;
+constexpr int kTargetIndicesTensor = 1;
+constexpr int kThresholdsTensor = 2;
+constexpr int kDetectedTensor = 0;
+constexpr int kTargetPosteriorsTensor = 1;
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 3);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 2);
+
+  MicroContext* micro_context = GetMicroContext(context);
+  TfLiteTensor* input =
+      micro_context->AllocateTempInputTensor(node, kInputTensor);
+  TF_LITE_ENSURE(context, input != nullptr);
+  TfLiteTensor* target_indices =
+      micro_context->AllocateTempInputTensor(node, kTargetIndicesTensor);
+  TF_LITE_ENSURE(context, target_indices != nullptr);
+  TfLiteTensor* thresholds =
+      micro_context->AllocateTempInputTensor(node, kThresholdsTensor);
+  TF_LITE_ENSURE(context, thresholds != nullptr);
+  TfLiteTensor* detected =
+      micro_context->AllocateTempOutputTensor(node, kDetectedTensor);
+  TF_LITE_ENSURE(context, detected != nullptr);
+  TfLiteTensor* target_posteriors =
+      micro_context->AllocateTempOutputTensor(node, kTargetPosteriorsTensor);
+  TF_LITE_ENSURE(context, target_posteriors != nullptr);
+
+  TF_LITE_ENSURE_EQ(context, NumDimensions(target_indices), 1);
+  TF_LITE_ENSURE_EQ(context, NumDimensions(thresholds), 1);
+  TF_LITE_ENSURE_EQ(context, NumDimensions(detected), 1);
+  TF_LITE_ENSURE_EQ(context, NumDimensions(target_posteriors), 1);
+
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, kTfLiteInt32);
+  TF_LITE_ENSURE_TYPES_EQ(context, target_indices->type, kTfLiteInt32);
+  TF_LITE_ENSURE_TYPES_EQ(context, thresholds->type, kTfLiteInt32);
+  TF_LITE_ENSURE_TYPES_EQ(context, detected->type, kTfLiteBool);
+  TF_LITE_ENSURE_TYPES_EQ(context, target_posteriors->type, kTfLiteInt32);
+
+  micro_context->DeallocateTempTfLiteTensor(input);
+  micro_context->DeallocateTempTfLiteTensor(target_indices);
+  micro_context->DeallocateTempTfLiteTensor(thresholds);
+  micro_context->DeallocateTempTfLiteTensor(detected);
+  micro_context->DeallocateTempTfLiteTensor(target_posteriors);
+  return kTfLiteOk;
+}
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kInputTensor);
+  TF_LITE_ENSURE(context, input != nullptr);
+  const TfLiteEvalTensor* target_indices =
+      tflite::micro::GetEvalInput(context, node, kTargetIndicesTensor);
+  TF_LITE_ENSURE(context, target_indices != nullptr);
+  const TfLiteEvalTensor* thresholds =
+      tflite::micro::GetEvalInput(context, node, kThresholdsTensor);
+  TF_LITE_ENSURE(context, thresholds != nullptr);
+  TfLiteEvalTensor* detected =
+      tflite::micro::GetEvalOutput(context, node, kDetectedTensor);
+  TF_LITE_ENSURE(context, detected != nullptr);
+  TfLiteEvalTensor* target_posteriors =
+      tflite::micro::GetEvalOutput(context, node, kTargetPosteriorsTensor);
+  TF_LITE_ENSURE(context, target_posteriors != nullptr);
+
+  const int32_t* input_data = tflite::micro::GetTensorData<int32_t>(input);
+  const int32_t* target_indices_data =
+      tflite::micro::GetTensorData<int32_t>(target_indices);
+  const int32_t* thresholds_data =
+      tflite::micro::GetTensorData<int32_t>(thresholds);
+  bool* detected_data = tflite::micro::GetTensorData<bool>(detected);
+  int32_t* target_posteriors_data =
+      tflite::micro::GetTensorData<int32_t>(target_posteriors);
+
+  for (int i = 0; i < detected->dims->data[0]; i++) {
+    detected_data[i] = input_data[target_indices_data[i]] >= thresholds_data[i];
+    target_posteriors_data[i] = input_data[target_indices_data[i]];
+  }
+  return kTfLiteOk;
+}
+
+}  // namespace
+
+TFLMRegistration Register_BASIC_CLASSIFIER() {
+  return tflite::micro::RegisterOp(nullptr, Prepare, Eval);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/basic_classifier.cc
+++ b/tensorflow/lite/micro/kernels/basic_classifier.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "tensorflow/lite/c/c_api_types.h"
 #include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/compatibility.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/micro_ops.h"
@@ -53,10 +54,16 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
       micro_context->AllocateTempOutputTensor(node, kTargetPosteriorsTensor);
   TF_LITE_ENSURE(context, target_posteriors != nullptr);
 
+  TF_LITE_ENSURE_EQ(context, NumDimensions(input), 1);
   TF_LITE_ENSURE_EQ(context, NumDimensions(target_indices), 1);
   TF_LITE_ENSURE_EQ(context, NumDimensions(thresholds), 1);
   TF_LITE_ENSURE_EQ(context, NumDimensions(detected), 1);
   TF_LITE_ENSURE_EQ(context, NumDimensions(target_posteriors), 1);
+
+  const int num_targets = target_indices->dims->data[0];
+  TF_LITE_ENSURE_EQ(context, thresholds->dims->data[0], num_targets);
+  TF_LITE_ENSURE_EQ(context, detected->dims->data[0], num_targets);
+  TF_LITE_ENSURE_EQ(context, target_posteriors->dims->data[0], num_targets);
 
   TF_LITE_ENSURE_TYPES_EQ(context, input->type, kTfLiteInt32);
   TF_LITE_ENSURE_TYPES_EQ(context, target_indices->type, kTfLiteInt32);
@@ -75,19 +82,19 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   const TfLiteEvalTensor* input =
       tflite::micro::GetEvalInput(context, node, kInputTensor);
-  TF_LITE_ENSURE(context, input != nullptr);
+  TFLITE_DCHECK(input != nullptr);
   const TfLiteEvalTensor* target_indices =
       tflite::micro::GetEvalInput(context, node, kTargetIndicesTensor);
-  TF_LITE_ENSURE(context, target_indices != nullptr);
+  TFLITE_DCHECK(target_indices != nullptr);
   const TfLiteEvalTensor* thresholds =
       tflite::micro::GetEvalInput(context, node, kThresholdsTensor);
-  TF_LITE_ENSURE(context, thresholds != nullptr);
+  TFLITE_DCHECK(thresholds != nullptr);
   TfLiteEvalTensor* detected =
       tflite::micro::GetEvalOutput(context, node, kDetectedTensor);
-  TF_LITE_ENSURE(context, detected != nullptr);
+  TFLITE_DCHECK(detected != nullptr);
   TfLiteEvalTensor* target_posteriors =
       tflite::micro::GetEvalOutput(context, node, kTargetPosteriorsTensor);
-  TF_LITE_ENSURE(context, target_posteriors != nullptr);
+  TFLITE_DCHECK(target_posteriors != nullptr);
 
   const int32_t* input_data = tflite::micro::GetTensorData<int32_t>(input);
   const int32_t* target_indices_data =
@@ -98,9 +105,15 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   int32_t* target_posteriors_data =
       tflite::micro::GetTensorData<int32_t>(target_posteriors);
 
-  for (int i = 0; i < detected->dims->data[0]; i++) {
-    detected_data[i] = input_data[target_indices_data[i]] >= thresholds_data[i];
-    target_posteriors_data[i] = input_data[target_indices_data[i]];
+  const int32_t input_size = input->dims->data[0];
+  const int num_targets = detected->dims->data[0];
+  for (int i = 0; i < num_targets; ++i) {
+    const int32_t target_idx = target_indices_data[i];
+    if (target_idx < 0 || target_idx >= input_size) {
+      return kTfLiteError;
+    }
+    detected_data[i] = input_data[target_idx] >= thresholds_data[i];
+    target_posteriors_data[i] = input_data[target_idx];
   }
   return kTfLiteOk;
 }

--- a/tensorflow/lite/micro/kernels/basic_classifier_test.cc
+++ b/tensorflow/lite/micro/kernels/basic_classifier_test.cc
@@ -73,6 +73,79 @@ void TestBasicClassifier(
   }
 }
 
+void TestBasicClassifierInvalidTargetIndex(
+    int* input_dims_data, const int32_t* input_data,
+    int* target_indices_dims_data, const int32_t* target_indices_data,
+    int* thresholds_dims_data, const int32_t* thresholds_data,
+    int* detected_dims_data, bool* detected_data,
+    int* target_posteriors_dims_data, int32_t* target_posteriors_data) {
+  TfLiteIntArray* input_dims = IntArrayFromInts(input_dims_data);
+  TfLiteIntArray* target_indices_dims =
+      IntArrayFromInts(target_indices_dims_data);
+  TfLiteIntArray* thresholds_dims = IntArrayFromInts(thresholds_dims_data);
+  TfLiteIntArray* detected_dims = IntArrayFromInts(detected_dims_data);
+  TfLiteIntArray* target_posteriors_dims =
+      IntArrayFromInts(target_posteriors_dims_data);
+  constexpr int kInputsSize = 3;
+  constexpr int kOutputsSize = 2;
+  constexpr int kTensorsSize = kInputsSize + kOutputsSize;
+  TfLiteTensor tensors[kTensorsSize] = {
+      CreateTensor(input_data, input_dims),
+      CreateTensor(target_indices_data, target_indices_dims),
+      CreateTensor(thresholds_data, thresholds_dims),
+      CreateTensor(detected_data, detected_dims),
+      CreateTensor(target_posteriors_data, target_posteriors_dims),
+  };
+  int inputs_array_data[] = {3, 0, 1, 2};
+  TfLiteIntArray* inputs_array = IntArrayFromInts(inputs_array_data);
+  int outputs_array_data[] = {2, 3, 4};
+  TfLiteIntArray* outputs_array = IntArrayFromInts(outputs_array_data);
+
+  const TFLMRegistration registration = Register_BASIC_CLASSIFIER();
+  micro::KernelRunner runner(registration, tensors, kTensorsSize, inputs_array,
+                             outputs_array,
+                             /*builtin_data=*/nullptr);
+
+  EXPECT_EQ(kTfLiteOk, runner.InitAndPrepare());
+  EXPECT_NE(kTfLiteOk, runner.Invoke());
+}
+
+void TestBasicClassifierMismatchedDims(
+    int* input_dims_data, const int32_t* input_data,
+    int* target_indices_dims_data, const int32_t* target_indices_data,
+    int* thresholds_dims_data, const int32_t* thresholds_data,
+    int* detected_dims_data, bool* detected_data,
+    int* target_posteriors_dims_data, int32_t* target_posteriors_data) {
+  TfLiteIntArray* input_dims = IntArrayFromInts(input_dims_data);
+  TfLiteIntArray* target_indices_dims =
+      IntArrayFromInts(target_indices_dims_data);
+  TfLiteIntArray* thresholds_dims = IntArrayFromInts(thresholds_dims_data);
+  TfLiteIntArray* detected_dims = IntArrayFromInts(detected_dims_data);
+  TfLiteIntArray* target_posteriors_dims =
+      IntArrayFromInts(target_posteriors_dims_data);
+  constexpr int kInputsSize = 3;
+  constexpr int kOutputsSize = 2;
+  constexpr int kTensorsSize = kInputsSize + kOutputsSize;
+  TfLiteTensor tensors[kTensorsSize] = {
+      CreateTensor(input_data, input_dims),
+      CreateTensor(target_indices_data, target_indices_dims),
+      CreateTensor(thresholds_data, thresholds_dims),
+      CreateTensor(detected_data, detected_dims),
+      CreateTensor(target_posteriors_data, target_posteriors_dims),
+  };
+  int inputs_array_data[] = {3, 0, 1, 2};
+  TfLiteIntArray* inputs_array = IntArrayFromInts(inputs_array_data);
+  int outputs_array_data[] = {2, 3, 4};
+  TfLiteIntArray* outputs_array = IntArrayFromInts(outputs_array_data);
+
+  const TFLMRegistration registration = Register_BASIC_CLASSIFIER();
+  micro::KernelRunner runner(registration, tensors, kTensorsSize, inputs_array,
+                             outputs_array,
+                             /*builtin_data=*/nullptr);
+
+  EXPECT_NE(kTfLiteOk, runner.InitAndPrepare());
+}
+
 }  // namespace
 }  // namespace testing
 }  // namespace tflite
@@ -141,6 +214,42 @@ TEST(BasicClassifierTest, MulticlassCase) {
       thresholds_shape, thresholds, detected_shape, detected,
       target_posteriors_shape, target_posteriors, golden_detected,
       golden_target_posteriors);
+}
+
+TEST(BasicClassifierTest, InvalidTargetIndex) {
+  int input_shape[] = {1, 3};
+  int target_indices_shape[] = {1, 1};
+  int thresholds_shape[] = {1, 1};
+  int detected_shape[] = {1, 1};
+  int target_posteriors_shape[] = {1, 1};
+  const int32_t input[] = {10, 20, 30};
+  const int32_t target_indices[] = {5};
+  const int32_t thresholds[] = {15};
+  bool detected[1];
+  int32_t target_posteriors[1];
+
+  tflite::testing::TestBasicClassifierInvalidTargetIndex(
+      input_shape, input, target_indices_shape, target_indices,
+      thresholds_shape, thresholds, detected_shape, detected,
+      target_posteriors_shape, target_posteriors);
+}
+
+TEST(BasicClassifierTest, MismatchedDims) {
+  int input_shape[] = {1, 5};
+  int target_indices_shape[] = {1, 2};
+  int thresholds_shape[] = {1, 3};
+  int detected_shape[] = {1, 2};
+  int target_posteriors_shape[] = {1, 2};
+  const int32_t input[] = {10, 20, 30, 40, 50};
+  const int32_t target_indices[] = {1, 2};
+  const int32_t thresholds[] = {15, 25, 35};
+  bool detected[2];
+  int32_t target_posteriors[2];
+
+  tflite::testing::TestBasicClassifierMismatchedDims(
+      input_shape, input, target_indices_shape, target_indices,
+      thresholds_shape, thresholds, detected_shape, detected,
+      target_posteriors_shape, target_posteriors);
 }
 
 TF_LITE_MICRO_TESTS_MAIN

--- a/tensorflow/lite/micro/kernels/basic_classifier_test.cc
+++ b/tensorflow/lite/micro/kernels/basic_classifier_test.cc
@@ -1,0 +1,146 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+#include <cstring>
+
+#include "tensorflow/lite/c/c_api_types.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/micro/kernels/kernel_runner.h"
+#include "tensorflow/lite/micro/kernels/micro_ops.h"
+#include "tensorflow/lite/micro/micro_common.h"
+#include "tensorflow/lite/micro/micro_utils.h"
+#include "tensorflow/lite/micro/test_helpers.h"
+#include "tensorflow/lite/micro/testing/micro_test_v2.h"
+
+namespace tflite {
+namespace testing {
+namespace {
+
+void TestBasicClassifier(
+    int* input_dims_data, const int32_t* input_data,
+    int* target_indices_dims_data, const int32_t* target_indices_data,
+    int* thresholds_dims_data, const int32_t* thresholds_data,
+    int* detected_dims_data, bool* detected_data,
+    int* target_posteriors_dims_data, int32_t* target_posteriors_data,
+    const bool* golden_detected, const int32_t* golden_target_posteriors) {
+  TfLiteIntArray* input_dims = IntArrayFromInts(input_dims_data);
+  TfLiteIntArray* target_indices_dims =
+      IntArrayFromInts(target_indices_dims_data);
+  TfLiteIntArray* thresholds_dims = IntArrayFromInts(thresholds_dims_data);
+  TfLiteIntArray* detected_dims = IntArrayFromInts(detected_dims_data);
+  TfLiteIntArray* target_posteriors_dims =
+      IntArrayFromInts(target_posteriors_dims_data);
+  const int output_len = ElementCount(*detected_dims);
+  constexpr int kInputsSize = 3;
+  constexpr int kOutputsSize = 2;
+  constexpr int kTensorsSize = kInputsSize + kOutputsSize;
+  TfLiteTensor tensors[kTensorsSize] = {
+      CreateTensor(input_data, input_dims),
+      CreateTensor(target_indices_data, target_indices_dims),
+      CreateTensor(thresholds_data, thresholds_dims),
+      CreateTensor(detected_data, detected_dims),
+      CreateTensor(target_posteriors_data, target_posteriors_dims),
+  };
+  int inputs_array_data[] = {3, 0, 1, 2};
+  TfLiteIntArray* inputs_array = IntArrayFromInts(inputs_array_data);
+  int outputs_array_data[] = {2, 3, 4};
+  TfLiteIntArray* outputs_array = IntArrayFromInts(outputs_array_data);
+
+  const TFLMRegistration registration = Register_BASIC_CLASSIFIER();
+  micro::KernelRunner runner(registration, tensors, kTensorsSize, inputs_array,
+                             outputs_array,
+                             /*builtin_data=*/nullptr);
+
+  EXPECT_EQ(kTfLiteOk, runner.InitAndPrepare());
+  EXPECT_EQ(kTfLiteOk, runner.Invoke());
+
+  for (int i = 0; i < output_len; ++i) {
+    EXPECT_EQ(golden_detected[i], detected_data[i]);
+    EXPECT_EQ(golden_target_posteriors[i], target_posteriors_data[i]);
+  }
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace tflite
+
+TEST(BasicClassifierTest, TrueCase) {
+  int input_shape[] = {1, 5};
+  int target_indices_shape[] = {1, 1};
+  int thresholds_shape[] = {1, 1};
+  int detected_shape[] = {1, 1};
+  int target_posteriors_shape[] = {1, 1};
+  const int32_t input[] = {15, 15, 15, 18, 15};
+  const int32_t target_indices[] = {3};
+  const int32_t thresholds[] = {17};
+  bool detected[1];
+  int32_t target_posteriors[1];
+  const bool golden_detected[] = {true};
+  const int32_t golden_target_posteriors[] = {18};
+  memset(detected, 0, sizeof(detected));
+  memset(target_posteriors, 0, sizeof(target_posteriors));
+  tflite::testing::TestBasicClassifier(
+      input_shape, input, target_indices_shape, target_indices,
+      thresholds_shape, thresholds, detected_shape, detected,
+      target_posteriors_shape, target_posteriors, golden_detected,
+      golden_target_posteriors);
+}
+
+TEST(BasicClassifierTest, FalseCase) {
+  int input_shape[] = {1, 2};
+  int target_indices_shape[] = {1, 1};
+  int thresholds_shape[] = {1, 1};
+  int detected_shape[] = {1, 1};
+  int target_posteriors_shape[] = {1, 1};
+  const int32_t input[] = {0, 12345};
+  const int32_t target_indices[] = {0};
+  const int32_t thresholds[] = {12345};
+  bool detected[1];
+  int32_t target_posteriors[1];
+  const bool golden_detected[] = {false};
+  const int32_t golden_target_posteriors[] = {0};
+  memset(detected, 0, sizeof(detected));
+  memset(target_posteriors, 0, sizeof(target_posteriors));
+  tflite::testing::TestBasicClassifier(
+      input_shape, input, target_indices_shape, target_indices,
+      thresholds_shape, thresholds, detected_shape, detected,
+      target_posteriors_shape, target_posteriors, golden_detected,
+      golden_target_posteriors);
+}
+
+TEST(BasicClassifierTest, MulticlassCase) {
+  int input_shape[] = {1, 5};
+  int target_indices_shape[] = {1, 2};
+  int thresholds_shape[] = {1, 2};
+  int detected_shape[] = {1, 2};
+  int target_posteriors_shape[] = {1, 2};
+  const int32_t input[] = {14, 654, 321, 865, 653};
+  const int32_t target_indices[] = {2, 4};
+  const int32_t thresholds[] = {322, 653};
+  bool detected[2];
+  int32_t target_posteriors[2];
+  const bool golden_detected[] = {false, true};
+  const int32_t golden_target_posteriors[] = {321, 653};
+  memset(detected, 0, sizeof(detected));
+  memset(target_posteriors, 0, sizeof(target_posteriors));
+  tflite::testing::TestBasicClassifier(
+      input_shape, input, target_indices_shape, target_indices,
+      thresholds_shape, thresholds, detected_shape, detected,
+      target_posteriors_shape, target_posteriors, golden_detected,
+      golden_target_posteriors);
+}
+
+TF_LITE_MICRO_TESTS_MAIN

--- a/tensorflow/lite/micro/kernels/micro_ops.h
+++ b/tensorflow/lite/micro/kernels/micro_ops.h
@@ -40,6 +40,7 @@ TFLMRegistration Register_ARG_MAX();
 TFLMRegistration Register_ARG_MIN();
 TFLMRegistration Register_ASSIGN_VARIABLE();
 TFLMRegistration Register_AVERAGE_POOL_2D();
+TFLMRegistration Register_BASIC_CLASSIFIER();
 TFLMRegistration Register_BATCH_MATMUL();
 TFLMRegistration Register_BATCH_TO_SPACE_ND();
 TFLMRegistration Register_BROADCAST_ARGS();

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -154,6 +154,11 @@ class MicroMutableOpResolver : public MicroOpResolver {
     return AddBuiltin(BuiltinOperator_AVERAGE_POOL_2D, registration, ParsePool);
   }
 
+  TfLiteStatus AddBasicClassifier(
+      const TFLMRegistration& registration = Register_BASIC_CLASSIFIER()) {
+    return AddCustom("BasicClassifier", &registration);
+  }
+
   TfLiteStatus AddBatchMatMul(
       const TFLMRegistration& registration = Register_BATCH_MATMUL()) {
     return AddBuiltin(BuiltinOperator_BATCH_MATMUL, registration,

--- a/tensorflow/lite/micro/tools/benchmarking/op_resolver.h
+++ b/tensorflow/lite/micro/tools/benchmarking/op_resolver.h
@@ -23,7 +23,7 @@ limitations under the License.
 
 namespace tflite {
 
-using TflmOpResolver = MicroMutableOpResolver<117>;
+using TflmOpResolver = MicroMutableOpResolver<118>;
 
 inline TfLiteStatus CreateOpResolver(TflmOpResolver& op_resolver) {
   TF_LITE_ENSURE_STATUS(op_resolver.AddAbs());
@@ -33,6 +33,7 @@ inline TfLiteStatus CreateOpResolver(TflmOpResolver& op_resolver) {
   TF_LITE_ENSURE_STATUS(op_resolver.AddArgMin());
   TF_LITE_ENSURE_STATUS(op_resolver.AddAssignVariable());
   TF_LITE_ENSURE_STATUS(op_resolver.AddAveragePool2D());
+  TF_LITE_ENSURE_STATUS(op_resolver.AddBasicClassifier());
   TF_LITE_ENSURE_STATUS(op_resolver.AddBatchMatMul());
   TF_LITE_ENSURE_STATUS(op_resolver.AddBatchToSpaceNd());
   TF_LITE_ENSURE_STATUS(op_resolver.AddBroadcastArgs());

--- a/tensorflow/lite/micro/tools/make/sources.inc
+++ b/tensorflow/lite/micro/tools/make/sources.inc
@@ -153,6 +153,7 @@ $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/add_common.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/add_n.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/arg_min_max.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/assign_variable.cc \
+$(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/basic_classifier.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/batch_matmul.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/batch_matmul_common.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/batch_to_space_nd.cc \


### PR DESCRIPTION
### Description
Add the `basic_classifier` custom operator kernel and corresponding unit tests to the TFLM kernel set.

- Implements `Prepare` and `Eval` for `BasicClassifier`.
- Registers `AddBasicClassifier` in `MicroMutableOpResolver` and `PythonOpsResolver`.
- Adds unit tests covering single and multi-class classification cases.
- Updates Bazel and Make build configurations.

### Testing
- `make -f tensorflow/lite/micro/tools/make/Makefile test_kernel_basic_classifier_test` passed (3/3 tests).

BUG=477580655