### PR TITLE
[CI] Added check maintainer edits

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+### Description
+
+<!-- Provide a concise description of what this PR changes and why. -->
+
+BUG=
+
+<!--
+### Checklist
+
+- [ ] "Allow edits from maintainers" is enabled
+-->

--- a/.github/workflows/check_maintainer_edits.yml
+++ b/.github/workflows/check_maintainer_edits.yml
@@ -1,0 +1,60 @@
+name: Check Maintainer Edits
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-maintainer-edits:
+    runs-on: ubuntu-latest
+    name: Check Maintainer Edits Permission
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check Permission and Remind
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+
+            // Skip known automated bots
+            const exemptBots = ['dependabot[bot]', 'TFLM-bot', 'github-actions[bot]'];
+            if (exemptBots.includes(author)) {
+              return;
+            }
+
+            // Only check PRs created from forks
+            const isFork = pr.head.repo && pr.head.repo.full_name !== context.payload.repository.full_name;
+            if (!isFork) {
+              return;
+            }
+
+            // If maintainer_can_modify is disabled, check if reminder was already posted
+            if (pr.maintainer_can_modify === false) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+              });
+
+              const alreadyCommented = comments.some(comment =>
+                comment.user.login === 'github-actions[bot]' &&
+                comment.body.includes('Allow edits from maintainers')
+              );
+
+              if (!alreadyCommented) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: `Hi @${author},\n\nPlease enable "Allow edits from maintainers" in the right sidebar of this pull request so maintainers can assist with rebasing, resolving CI issues, and merging.\n\nFor instructions, see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork`
+                });
+              }
+            }

--- a/.github/workflows/check_maintainer_edits.yml
+++ b/.github/workflows/check_maintainer_edits.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check Permission and Remind
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/check_maintainer_edits.yml
+++ b/.github/workflows/check_maintainer_edits.yml
@@ -1,10 +1,13 @@
 name: Check Maintainer Edits
 
+# zizmor: ignore[dangerous-triggers]
 on:
   pull_request_target:
     types:
       - opened
       - reopened
+
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Add a workflow and pull request template to verify and remind contributors to enable "Allow edits from maintainers" on  PRs. This allows to help rebase branches, resolve CI failures, and streamline merges.

BUG=n/a