### PR TITLE
Re-enable -Werror in Makefile

### DIFF
--- a/tensorflow/lite/micro/kernels/cast_test.cc
+++ b/tensorflow/lite/micro/kernels/cast_test.cc
@@ -59,6 +59,7 @@ void TestCast(const InputT (&input)[N], const OutputT (&golden)[N]) {
 
 template <typename IntT>
 void TestFloatToInt(float pos_overflow, float neg_overflow) {
+  [[maybe_unused]]
   constexpr bool is_signed = std::numeric_limits<IntT>::is_signed;
   const float input[] = {100.f,
                          1.0f,

--- a/tensorflow/lite/micro/kernels/decompress_common.cc
+++ b/tensorflow/lite/micro/kernels/decompress_common.cc
@@ -326,7 +326,7 @@ void DecompressionState::DecompressToBufferWidthAny(T* buffer) {
       const T* value_table =
           static_cast<const T*>(comp_data_.data.lut_data->value_table);
       for (size_t channel = 0; channel < num_channels_; channel++) {
-        size_t index;
+        size_t index = 0;
         switch (compressed_bit_width_) {
           case 1:
             index = GetNextTableIndexWidth1(current_offset);
@@ -367,7 +367,7 @@ void DecompressionState::DecompressToBufferWidthAny(T* buffer) {
       size_t count = max_count;
 
       while (count-- > 0) {
-        size_t index;
+        size_t index = 0;
         switch (compressed_bit_width_) {
           case 1:
             index = GetNextTableIndexWidth1(current_offset);

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
@@ -98,9 +98,11 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 
   MicroContext* micro_context = GetMicroContext(context);
 
+  [[maybe_unused]]
   const CompressionTensorData* filter_comp_td =
       micro_context->GetTensorCompressionData(node,
                                               kDepthwiseConvWeightsTensor);
+  [[maybe_unused]]
   const CompressionTensorData* bias_comp_td =
       micro_context->GetTensorCompressionData(node, kDepthwiseConvBiasTensor);
 

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -161,6 +161,7 @@ endif
 
 
 CC_WARNINGS := \
+  -Werror \
   -Wsign-compare \
   -Wdouble-promotion \
   -Wunused-variable \


### PR DESCRIPTION
@tensorflow/micro

Put the -Werror flag back into the primary makefile, to prevent creaping warning accumulation.

Fix various warning generators in codebase.

bug=fixes #3689