### PR TITLE
DECODE fix channel count for non-quantized tensors

### DIFF
--- a/tensorflow/lite/micro/kernels/cast_test.cc
+++ b/tensorflow/lite/micro/kernels/cast_test.cc
@@ -59,6 +59,7 @@ void TestCast(const InputT (&input)[N], const OutputT (&golden)[N]) {
 
 template <typename IntT>
 void TestFloatToInt(float pos_overflow, float neg_overflow) {
+  [[maybe_unused]]
   constexpr bool is_signed = std::numeric_limits<IntT>::is_signed;
   const float input[] = {100.f,
                          1.0f,

--- a/tensorflow/lite/micro/kernels/decode.cc
+++ b/tensorflow/lite/micro/kernels/decode.cc
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <utility>
+
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/compatibility.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
@@ -47,6 +49,27 @@ TfLiteStatus SetOutputTensorData(TfLiteContext* context, const TfLiteNode* node,
   }
 
   return kTfLiteOk;
+}
+
+DecodeState* GetDecodeStateFromCustomRegistration(const TfLiteContext* context,
+                                                  uint8_t type) {
+  const MicroContext* mc = GetMicroContext(context);
+  const MicroContext::CustomDecodeRegistration* registrations;
+  size_t registrations_count;
+  std::tie(registrations, registrations_count) =
+      mc->GetCustomDecodeRegistrations();
+  if (registrations == nullptr) {
+    return nullptr;
+  }
+
+  for (size_t i = 0; i < registrations_count; i++) {
+    auto& reg = registrations[i];
+    if (reg.type == type && reg.create_state != nullptr) {
+      return reg.create_state(reg, *context, mc->GetAlternateProfiler());
+    }
+  }
+
+  return nullptr;
 }
 
 TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
@@ -113,21 +136,22 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
         dsp = DecodeState::CreateDecodeStateHuffman(
             context, micro_context->GetAlternateProfiler());
         break;
-      case DecodeState::kDcmTypeCustom:
-        MicroPrintf("Custom decode type not yet supported");
-        break;
       default:
-        MicroPrintf("unsupported decode type %u",
-                    DecodeState::Type(*ancillary));
+        uint32_t type = DecodeState::Type(*ancillary);
+        if (type >= DecodeState::kDcmTypeCustomFirst &&
+            type <= DecodeState::kDcmTypeCustomLast) {
+          dsp = GetDecodeStateFromCustomRegistration(context, type);
+        } else {
+          MicroPrintf("unsupported decode type %u", type);
+        }
         break;
-    }
-
-    status = SetOutputTensorData(context, node, i / 2, output);
-    if (status != kTfLiteOk) {
-      break;
     }
 
     if (dsp != nullptr) {
+      status = SetOutputTensorData(context, node, i / 2, output);
+      if (status != kTfLiteOk) {
+        break;
+      }
       status = dsp->Setup(*input, *ancillary, *output);
       if (status != kTfLiteOk) {
         break;

--- a/tensorflow/lite/micro/kernels/decode_state.h
+++ b/tensorflow/lite/micro/kernels/decode_state.h
@@ -72,7 +72,8 @@ class DecodeState {
   static constexpr uint8_t kDcmTypeLUT = 0;
   static constexpr uint8_t kDcmTypeHuffman = 1;
   static constexpr uint8_t kDcmTypePrune = 2;
-  static constexpr uint8_t kDcmTypeCustom = 127;
+  static constexpr uint8_t kDcmTypeCustomFirst = 128;
+  static constexpr uint8_t kDcmTypeCustomLast = 255;
 
   static constexpr size_t kDcmSizeInBytes = 16;
 

--- a/tensorflow/lite/micro/kernels/decode_state_huffman_test.cc
+++ b/tensorflow/lite/micro/kernels/decode_state_huffman_test.cc
@@ -269,7 +269,7 @@ TEST(DecodeStateHuffmanTest, DecodeHuffmanTable16BitsInt16Fail) {
   tflite::testing::TestDecode<encodes.size() + ancillaries.size(),
                               outputs.size()>(
       encodes, ancillaries, outputs, expected, tflite::Register_DECODE(),
-      nullptr, kTfLiteError);
+      nullptr, nullptr, kTfLiteError);
 }
 
 TEST(DecodeStateHuffmanTest, DecodeHuffmanTable32BitsInt8) {

--- a/tensorflow/lite/micro/kernels/decode_state_lut.cc
+++ b/tensorflow/lite/micro/kernels/decode_state_lut.cc
@@ -30,25 +30,40 @@ TfLiteStatus DecodeStateLut::Setup(const TfLiteTensor& input,
                                    const TfLiteTensor& ancillary,
                                    const TfLiteTensor& output) {
   const uint8_t* const ancillary_data = GetTensorData<uint8_t>(&ancillary);
-  if (ancillary_data[kDcmVersionOffset] != 1) {
-    MicroPrintf("unsupported version %u", ancillary_data[kDcmVersionOffset]);
-    return kTfLiteError;
+  TF_LITE_ENSURE_MSG(const_cast<TfLiteContext*>(context_),
+                     ancillary_data[kDcmVersionOffset] == 1,
+                     "unsupported version %u",
+                     ancillary_data[kDcmVersionOffset]);
+
+  // Resolve num_channels_, use_alternate_axis_.
+  // Axis parameter of the DCM is used to extract the channel count dimension
+  // from the output tensor shape.
+  // Constructor defaults num_channels_ to 1 (one).
+  // If the axis has all masked bits set, the output tensor has a single
+  // channel.
+  const uint8_t axis_mask =
+      ancillary_data[kDcmParamsOffset] & kDcmParamsAxisMask;
+  if (axis_mask != kDcmParamsAxisMask) {
+    const uint8_t axis = axis_mask >> kDcmParamsAxisMaskShift;
+    TFLITE_DCHECK(axis < NumDimensions(&output));
+    num_channels_ = SizeOfDimension(&output, axis);
+
+    if ((axis == NumDimensions(&output) - 1)) {
+      if (num_channels_ > 1) {
+        use_alternate_axis_ = true;
+      }
+    } else {
+      TF_LITE_ENSURE_MSG(const_cast<TfLiteContext*>(context_), axis == 0,
+                         "unsupported channel axis %u", axis);
+    }
   }
 
-  // resolve num_channels_ and use_alternate_axis_
   if (output.quantization.type == kTfLiteAffineQuantization &&
       output.quantization.params != nullptr) {
     const TfLiteAffineQuantization* quantization =
         reinterpret_cast<TfLiteAffineQuantization*>(output.quantization.params);
-    num_channels_ = quantization->scale->size;
-    if ((quantization->quantized_dimension == output.dims->size - 1) &&
-        num_channels_ > 1) {
-      use_alternate_axis_ = true;
-    } else if (quantization->quantized_dimension != 0) {
-      MicroPrintf("unsupported quantization axis %u",
-                  quantization->quantized_dimension);
-      return kTfLiteError;
-    }
+    TFLITE_DCHECK(num_channels_ ==
+                  static_cast<size_t>(quantization->scale->size));
   }
 
   compressed_indices_ = GetTensorData<uint8_t>(&input);

--- a/tensorflow/lite/micro/kernels/decode_state_lut.h
+++ b/tensorflow/lite/micro/kernels/decode_state_lut.h
@@ -42,11 +42,13 @@ class DecodeStateLut : public DecodeState {
   static constexpr size_t kMaxBitWidth = 7;
   static constexpr size_t kMaxValueTableChannelStride = 128;
 
- private:
+ public:
   // LUT Decode Common Metadata constants
   static constexpr size_t kDcmVersionOffset = 4;
   static constexpr size_t kDcmParamsOffset = 5;
   static constexpr uint8_t kDcmParamsBitWidthMask = 0x07;
+  static constexpr uint8_t kDcmParamsAxisMask = 0xF0;
+  static constexpr uint8_t kDcmParamsAxisMaskShift = 4;
   static constexpr size_t kDcmValueTableStrideOffset = 6;
 
  protected:

--- a/tensorflow/lite/micro/kernels/decode_state_lut_test.cc
+++ b/tensorflow/lite/micro/kernels/decode_state_lut_test.cc
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "tensorflow/lite/micro/kernels/decode_state_lut.h"
+
 #include <algorithm>
 #include <array>
 #include <cstdint>
@@ -265,19 +267,60 @@ void TestDataSetup(TestingInfo<T>* info, TestingData<T>* data) {
   info->decode_common_metadata = &data->decode_common_metadata;
 }
 
+uint8_t ComputeAxis(bool use_alt_axis, bool quantized,
+                    const TfLiteIntArray& dims) {
+  const uint8_t axis = use_alt_axis ? dims.size - 1 : 0;
+  const int channel_count = dims.data[axis];
+  if (quantized || channel_count > 1) {
+    return axis << tflite::DecodeStateLut::kDcmParamsAxisMaskShift;
+  }
+
+  return tflite::DecodeStateLut::kDcmParamsAxisMask;
+}
+
 template <typename T>
 void TestDecompression(TestingInfo<T>* info) {
   GenerateData(*info);
 
+  const int first_dim = info->use_alt_axis
+                            ? info->total_elements / info->channel_count
+                            : info->channel_count;
+  const int last_dim = info->use_alt_axis
+                           ? info->channel_count
+                           : info->total_elements / info->channel_count;
+  const int output_dims_array[] = {2, first_dim, last_dim};
+  const TfLiteIntArray* const output_dims =
+      tflite::testing::IntArrayFromInts(output_dims_array);
+  // The actual zero-point and scale data are never used,
+  // so only supply the sizes.
+  const TfLiteIntArray kOutputZeroPoints = {
+      std::is_same<T, bool>::value || std::is_same<T, float>::value
+          ? 0
+          : static_cast<int>(info->channel_count)};
+  const TfLiteFloatArray kOutputScales = {kOutputZeroPoints.size};
+  const TensorOutDatum tod = {
+      info->output,
+      *output_dims,
+      typeToTfLiteType<T>(),
+      kOutputScales,
+      kOutputZeroPoints,
+      info->use_alt_axis ? output_dims->size - 1 : 0,
+      {},
+  };
+  const std::initializer_list<const TensorOutDatum*> outputs = {&tod};
+
   const size_t stride = info->total_value_table_elements / info->channel_count;
+  const uint8_t axis_param = ComputeAxis(
+      info->use_alt_axis, kOutputZeroPoints.size != 0, *output_dims);
+  const uint8_t lut_params = axis_param | static_cast<uint8_t>(info->bit_width);
   *info->decode_common_metadata = {
-      tflite::DecodeState::kDcmTypeLUT,       // type: LUT
-      1,                                      // DCM version: 1
-      0,                                      // reserved
-      0,                                      // reserved
-      1,                                      // LUT version: 1
-      static_cast<uint8_t>(info->bit_width),  // Parameters: bit-width
-      static_cast<uint8_t>(stride),           // value table channel stride
+      tflite::DecodeState::kDcmTypeLUT,  // type: LUT
+      1,                                 // DCM version: 1
+      0,                                 // reserved
+      0,                                 // reserved
+      1,                                 // LUT version: 1
+      lut_params,                        // Parameters: axis, bit-width
+      static_cast<uint8_t>(stride),      // value table channel stride
   };
 
   const int encoded_dims_array[] = {
@@ -303,31 +346,6 @@ void TestDecompression(TestingInfo<T>* info) {
   };
   const std::initializer_list<const TensorInDatum*> ancillaries = {
       &tid_ancillary};
-
-  const int first_dim = info->use_alt_axis
-                            ? info->total_elements / info->channel_count
-                            : info->channel_count;
-  const int last_dim = info->use_alt_axis
-                           ? info->channel_count
-                           : info->total_elements / info->channel_count;
-  const int output_dims_array[] = {2, first_dim, last_dim};
-  const TfLiteIntArray* const output_dims =
-      tflite::testing::IntArrayFromInts(output_dims_array);
-  // The actual zero-point and scale data are never used,
-  // so only supply the sizes.
-  const TfLiteIntArray kOutputZeroPoints = {
-      static_cast<int>(info->channel_count)};
-  const TfLiteFloatArray kOutputScales = {kOutputZeroPoints.size};
-  const TensorOutDatum tod = {
-      info->output,
-      *output_dims,
-      typeToTfLiteType<T>(),
-      kOutputScales,
-      kOutputZeroPoints,
-      info->use_alt_axis ? kOutputScales.size - 1 : 0,
-      {},
-  };
-  const std::initializer_list<const TensorOutDatum*> outputs = {&tod};
 
   const std::initializer_list<const void*> expected = {info->goldens};
 

--- a/tensorflow/lite/micro/kernels/decode_state_prune.cc
+++ b/tensorflow/lite/micro/kernels/decode_state_prune.cc
@@ -31,26 +31,38 @@ TfLiteStatus DecodeStatePrune::Setup(const TfLiteTensor& input,
                                      const TfLiteTensor& ancillary,
                                      const TfLiteTensor& output) {
   const uint8_t* const ancillary_data = GetTensorData<uint8_t>(&ancillary);
-  if (ancillary_data[kDcmVersionOffset] != 1) {
-    MicroPrintf("unsupported version %u", ancillary_data[kDcmVersionOffset]);
-    return kTfLiteError;
+  TF_LITE_ENSURE_MSG(const_cast<TfLiteContext*>(context_),
+                     ancillary_data[kDcmVersionOffset] == 1,
+                     "unsupported version %u",
+                     ancillary_data[kDcmVersionOffset]);
+
+  // Resolve num_channels_, use_alternate_axis_, and zero points.
+  // Axis parameter of the DCM is used to extract the channel count dimension
+  // from the output tensor shape.
+  // Constructor defaults num_channels_ to 1 (one).
+  // If the axis has all masked bits set, the output tensor has a single
+  // channel.
+  const uint8_t axis_mask =
+      ancillary_data[kDcmParamsOffset] & kDcmParamsAxisMask;
+  if (axis_mask != kDcmParamsAxisMask) {
+    const uint8_t axis = axis_mask >> kDcmParamsAxisMaskShift;
+    TFLITE_DCHECK(axis < NumDimensions(&output));
+    num_channels_ = SizeOfDimension(&output, axis);
+
+    if ((axis == NumDimensions(&output) - 1)) {
+      if (num_channels_ > 1) {
+        use_alternate_axis_ = true;
+      }
+    } else {
+      TF_LITE_ENSURE_MSG(const_cast<TfLiteContext*>(context_), axis == 0,
+                         "unsupported channel axis %u", axis);
+    }
   }
 
-  // resolve num_channels_, use_alternate_axis_, and zero points
   if (output.quantization.type == kTfLiteAffineQuantization &&
       output.quantization.params != nullptr) {
     const TfLiteAffineQuantization* quantization =
         reinterpret_cast<TfLiteAffineQuantization*>(output.quantization.params);
-    num_channels_ = quantization->scale->size;
-    if ((quantization->quantized_dimension == output.dims->size - 1) &&
-        num_channels_ > 1) {
-      use_alternate_axis_ = true;
-    } else if (quantization->quantized_dimension != 0) {
-      MicroPrintf("unsupported quantization axis %u",
-                  quantization->quantized_dimension);
-      return kTfLiteError;
-    }
-
     TFLITE_DCHECK(num_channels_ ==
                   static_cast<size_t>(quantization->zero_point->size));
     bool has_non_zero_zp =
@@ -71,10 +83,8 @@ TfLiteStatus DecodeStatePrune::Setup(const TfLiteTensor& input,
       const size_t bufsize = num_channels_ * sizeof(*zero_points_);
       zero_points_ = static_cast<decltype(zero_points_)>(
           micro_context->AllocatePersistentBuffer(bufsize));
-      if (zero_points_ == nullptr) {
-        MicroPrintf("unable to allocate zero_points_");
-        return kTfLiteError;
-      }
+      TF_LITE_ENSURE(const_cast<TfLiteContext*>(context_),
+                     zero_points_ != nullptr);
       std::copy_n(quantization->zero_point->data, num_channels_, zero_points_);
     } else {
       single_zero_point_ = quantization->zero_point->data[0];

--- a/tensorflow/lite/micro/kernels/decode_state_prune.h
+++ b/tensorflow/lite/micro/kernels/decode_state_prune.h
@@ -38,9 +38,12 @@ class DecodeStatePrune : public DecodeState {
                               const TfLiteEvalTensor& ancillary,
                               const TfLiteEvalTensor& output) override;
 
- private:
+ public:
   // Prune Decode Common Metadata constants
   static constexpr size_t kDcmVersionOffset = 4;
+  static constexpr size_t kDcmParamsOffset = 5;
+  static constexpr uint8_t kDcmParamsAxisMask = 0xF0;
+  static constexpr uint8_t kDcmParamsAxisMaskShift = 4;
 
  protected:
   virtual ~DecodeStatePrune() = default;

--- a/tensorflow/lite/micro/kernels/decode_state_prune_test.cc
+++ b/tensorflow/lite/micro/kernels/decode_state_prune_test.cc
@@ -573,7 +573,7 @@ TEST(DecodeStatePruneTest, DecodePruneQuantizedInvalidZeroPointInt16) {
   tflite::testing::TestDecode<kEncodes.size() + kAncillaries.size(),
                               kOutputs.size()>(
       kEncodes, kAncillaries, kOutputs, kExpected, tflite::Register_DECODE(),
-      nullptr, kTfLiteError);
+      nullptr, nullptr, kTfLiteError);
 }
 
 TF_LITE_MICRO_TESTS_MAIN

--- a/tensorflow/lite/micro/kernels/decode_state_prune_test.cc
+++ b/tensorflow/lite/micro/kernels/decode_state_prune_test.cc
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "tensorflow/lite/micro/kernels/decode_state_prune.h"
+
 #include <array>
 #include <cstdint>
 #include <initializer_list>
@@ -86,12 +88,44 @@ constexpr int8_t kAncillaryDataPrune5[] = {
     26, 23, 24, 25, 26   // chan 0
 };
 
-constexpr uint8_t kDcmPrune[tflite::DecodeState::kDcmSizeInBytes] = {
-    tflite::DecodeState::kDcmTypePrune,  // type: Prune
-    1,                                   // DCM version: 1
-    0,                                   // reserved
-    0,                                   // reserved
-    1,                                   // Prune version: 1
+constexpr uint8_t kDcmPruneAxis0[tflite::DecodeState::kDcmSizeInBytes] = {
+    tflite::DecodeState::kDcmTypePrune,                      // type: Prune
+    1,                                                       // DCM version: 1
+    0,                                                       // reserved
+    0,                                                       // reserved
+    1,                                                       // Prune version: 1
+    0 << tflite::DecodeStatePrune::kDcmParamsAxisMaskShift,  // prune params:
+                                                             // axis
+};
+
+constexpr uint8_t kDcmPruneAxis3[tflite::DecodeState::kDcmSizeInBytes] = {
+    tflite::DecodeState::kDcmTypePrune,                      // type: Prune
+    1,                                                       // DCM version: 1
+    0,                                                       // reserved
+    0,                                                       // reserved
+    1,                                                       // Prune version: 1
+    3 << tflite::DecodeStatePrune::kDcmParamsAxisMaskShift,  // prune params:
+                                                             // axis
+};
+
+constexpr uint8_t kDcmPruneNoAxis[tflite::DecodeState::kDcmSizeInBytes] = {
+    tflite::DecodeState::kDcmTypePrune,            // type: Prune
+    1,                                             // DCM version: 1
+    0,                                             // reserved
+    0,                                             // reserved
+    1,                                             // Prune version: 1
+    tflite::DecodeStatePrune::kDcmParamsAxisMask,  // prune params: axis
+};
+
+constexpr uint8_t
+    kDcmPruneUnsupportedAxis[tflite::DecodeState::kDcmSizeInBytes] = {
+        tflite::DecodeState::kDcmTypePrune,  // type: Prune
+        1,                                   // DCM version: 1
+        0,                                   // reserved
+        0,                                   // reserved
+        1,                                   // Prune version: 1
+        1 << tflite::DecodeStatePrune::kDcmParamsAxisMaskShift,  // prune
+                                                                 // params: axis
 };
 
 // Align the tensor data the same as a Buffer in the TfLite schema.
@@ -193,11 +227,11 @@ using tflite::testing::AncillaryData;
 using tflite::testing::TensorInDatum;
 using tflite::testing::TensorOutDatum;
 
-TEST(DecodeStatePruneTest, DecodePruneFloat) {
+TEST(DecodeStatePruneTest, DecodePruneFloatAxis0) {
   // Align the tensor data the same as a Buffer in the TfLite schema
   alignas(16) float output_data[std::size(kExpectPrune2)] = {};
   alignas(16) const AncillaryData<float, std::size(kAncillaryDataPrune2)>
-      kAncillaryData = {{kDcmPrune}, {kAncillaryDataPrune2}};
+      kAncillaryData = {{kDcmPruneAxis0}, {kAncillaryDataPrune2}};
 
   const TfLiteIntArray* const kEncodedDims =
       tflite::testing::IntArrayFromInts(kEncodedShapePrune);
@@ -244,11 +278,114 @@ TEST(DecodeStatePruneTest, DecodePruneFloat) {
       kEncodes, kAncillaries, kOutputs, kExpected, tflite::Register_DECODE());
 }
 
+TEST(DecodeStatePruneTest, DecodePruneFloatNoAxis) {
+  // Align the tensor data the same as a Buffer in the TfLite schema
+  alignas(16) float output_data[std::size(kExpectPrune2)] = {};
+  alignas(16) const AncillaryData<float, std::size(kAncillaryDataPrune2)>
+      kAncillaryData = {{kDcmPruneNoAxis}, {kAncillaryDataPrune2}};
+
+  const TfLiteIntArray* const kEncodedDims =
+      tflite::testing::IntArrayFromInts(kEncodedShapePrune);
+  static const TensorInDatum kEncodeTID = {
+      kEncodedPrune,
+      *kEncodedDims,
+  };
+  static constexpr std::initializer_list<const TensorInDatum*> kEncodes = {
+      &kEncodeTID,
+  };
+
+  constexpr int kAncillaryShape[] = {1, sizeof(kAncillaryData)};
+  const TfLiteIntArray* const kAncillaryDims =
+      tflite::testing::IntArrayFromInts(kAncillaryShape);
+  static const TensorInDatum kAncillaryTID = {
+      &kAncillaryData,
+      *kAncillaryDims,
+  };
+  static constexpr std::initializer_list<const TensorInDatum*> kAncillaries = {
+      &kAncillaryTID};
+
+  const TfLiteIntArray* const kOutputDims =
+      tflite::testing::IntArrayFromInts(kOutputShapePrune);
+  constexpr int kOutputZeroPointsData[] = {0};
+  const TfLiteIntArray* const kOutputZeroPoints =
+      tflite::testing::IntArrayFromInts(kOutputZeroPointsData);
+  const TfLiteFloatArray kOutputScales = {kOutputZeroPoints->size};
+  static const TensorOutDatum kTOD = {
+      output_data,
+      *kOutputDims,
+      kTfLiteFloat32,
+      kOutputScales,
+      *kOutputZeroPoints,
+      0,
+      {},
+  };
+  static constexpr std::initializer_list<const TensorOutDatum*> kOutputs = {
+      &kTOD};
+
+  const std::initializer_list<const void*> kExpected = {kExpectPrune2};
+
+  tflite::testing::TestDecode<kEncodes.size() + kAncillaries.size(),
+                              kOutputs.size()>(
+      kEncodes, kAncillaries, kOutputs, kExpected, tflite::Register_DECODE());
+}
+
+TEST(DecodeStatePruneTest, DecodePruneFloatUnsupportedAxis) {
+  // Align the tensor data the same as a Buffer in the TfLite schema
+  alignas(16) float output_data[std::size(kExpectPrune2)] = {};
+  alignas(16) const AncillaryData<float, std::size(kAncillaryDataPrune2)>
+      kAncillaryData = {{kDcmPruneUnsupportedAxis}, {kAncillaryDataPrune2}};
+
+  const TfLiteIntArray* const kEncodedDims =
+      tflite::testing::IntArrayFromInts(kEncodedShapePrune);
+  static const TensorInDatum kEncodeTID = {
+      kEncodedPrune,
+      *kEncodedDims,
+  };
+  static constexpr std::initializer_list<const TensorInDatum*> kEncodes = {
+      &kEncodeTID,
+  };
+
+  constexpr int kAncillaryShape[] = {1, sizeof(kAncillaryData)};
+  const TfLiteIntArray* const kAncillaryDims =
+      tflite::testing::IntArrayFromInts(kAncillaryShape);
+  static const TensorInDatum kAncillaryTID = {
+      &kAncillaryData,
+      *kAncillaryDims,
+  };
+  static constexpr std::initializer_list<const TensorInDatum*> kAncillaries = {
+      &kAncillaryTID};
+
+  const TfLiteIntArray* const kOutputDims =
+      tflite::testing::IntArrayFromInts(kOutputShapePrune);
+  constexpr int kOutputZeroPointsData[] = {0};
+  const TfLiteIntArray* const kOutputZeroPoints =
+      tflite::testing::IntArrayFromInts(kOutputZeroPointsData);
+  const TfLiteFloatArray kOutputScales = {kOutputZeroPoints->size};
+  static const TensorOutDatum kTOD = {
+      output_data,
+      *kOutputDims,
+      kTfLiteFloat32,
+      kOutputScales,
+      *kOutputZeroPoints,
+      0,
+      {},
+  };
+  static constexpr std::initializer_list<const TensorOutDatum*> kOutputs = {
+      &kTOD};
+
+  const std::initializer_list<const void*> kExpected = {kExpectPrune2};
+
+  tflite::testing::TestDecode<kEncodes.size() + kAncillaries.size(),
+                              kOutputs.size()>(
+      kEncodes, kAncillaries, kOutputs, kExpected, tflite::Register_DECODE(),
+      nullptr, nullptr, kTfLiteError);
+}
+
 TEST(DecodeStatePruneTest, DecodePruneInt8) {
   // Align the tensor data the same as a Buffer in the TfLite schema
   alignas(16) int8_t output_data[std::size(kExpectPrune3)] = {};
   alignas(16) const AncillaryData<int8_t, std::size(kAncillaryDataPrune3)>
-      kAncillaryData = {{kDcmPrune}, {kAncillaryDataPrune3}};
+      kAncillaryData = {{kDcmPruneAxis0}, {kAncillaryDataPrune3}};
 
   const TfLiteIntArray* const kEncodedDims =
       tflite::testing::IntArrayFromInts(kEncodedShapePrune);
@@ -294,7 +431,7 @@ TEST(DecodeStatePruneTest, DecodePruneQuantizedInt8) {
   // Align the tensor data the same as a Buffer in the TfLite schema
   alignas(16) int8_t output_data[std::size(kExpectPrune3)] = {};
   alignas(16) const AncillaryData<int8_t, std::size(kAncillaryDataPrune3)>
-      kAncillaryData = {{kDcmPrune}, {kAncillaryDataPrune3}};
+      kAncillaryData = {{kDcmPruneAxis0}, {kAncillaryDataPrune3}};
 
   const TfLiteIntArray* const kEncodedDims =
       tflite::testing::IntArrayFromInts(kEncodedShapePrune);
@@ -339,7 +476,7 @@ TEST(DecodeStatePruneTest, DecodePruneQuantizedMixedZeroPointInt8) {
   // Align the tensor data the same as a Buffer in the TfLite schema
   alignas(16) int8_t output_data[std::size(kExpectPrune0)] = {};
   alignas(16) const AncillaryData<int8_t, std::size(kAncillaryDataPrune0)>
-      kAncillaryData = {{kDcmPrune}, {kAncillaryDataPrune0}};
+      kAncillaryData = {{kDcmPruneAxis0}, {kAncillaryDataPrune0}};
 
   const TfLiteIntArray* const kEncodedDims =
       tflite::testing::IntArrayFromInts(kEncodedShapePrune);
@@ -384,7 +521,7 @@ TEST(DecodeStatePruneTest, DecodePruneQuantizedSingleChannelInt8) {
   // Align the tensor data the same as a Buffer in the TfLite schema
   alignas(16) int8_t output_data[std::size(kExpectPrune5)] = {};
   alignas(16) const AncillaryData<int8_t, std::size(kAncillaryDataPrune5)>
-      kAncillaryData = {{kDcmPrune}, {kAncillaryDataPrune5}};
+      kAncillaryData = {{kDcmPruneAxis0}, {kAncillaryDataPrune5}};
 
   const TfLiteIntArray* const kEncodedDims =
       tflite::testing::IntArrayFromInts(kEncodedShapePrune);
@@ -429,7 +566,7 @@ TEST(DecodeStatePruneTest, DecodePruneQuantizedAltAxisInt8) {
   // Align the tensor data the same as a Buffer in the TfLite schema
   alignas(16) int8_t output_data[std::size(kExpectPrune4)] = {};
   alignas(16) const AncillaryData<int8_t, std::size(kAncillaryDataPrune4)>
-      kAncillaryData = {{kDcmPrune}, {kAncillaryDataPrune4}};
+      kAncillaryData = {{kDcmPruneAxis3}, {kAncillaryDataPrune4}};
 
   const TfLiteIntArray* const kEncodedDims =
       tflite::testing::IntArrayFromInts(kEncodedShapePrune);
@@ -479,7 +616,7 @@ TEST(DecodeStatePruneTest, DecodePruneQuantizedInt16) {
   // Align the tensor data the same as a Buffer in the TfLite schema
   alignas(16) int16_t output_data[std::size(kExpectPrune1)] = {};
   alignas(16) const AncillaryData<int16_t, std::size(kAncillaryDataPrune1)>
-      kAncillaryData = {{kDcmPrune}, {kAncillaryDataPrune1}};
+      kAncillaryData = {{kDcmPruneAxis0}, {kAncillaryDataPrune1}};
 
   const TfLiteIntArray* const kEncodedDims =
       tflite::testing::IntArrayFromInts(kEncodedShapePrune);
@@ -529,7 +666,7 @@ TEST(DecodeStatePruneTest, DecodePruneQuantizedInvalidZeroPointInt16) {
   // Align the tensor data the same as a Buffer in the TfLite schema
   alignas(16) int16_t output_data[std::size(kExpectPrune1)] = {};
   alignas(16) const AncillaryData<int16_t, std::size(kAncillaryDataPrune1)>
-      kAncillaryData = {{kDcmPrune}, {kAncillaryDataPrune1}};
+      kAncillaryData = {{kDcmPruneAxis0}, {kAncillaryDataPrune1}};
 
   const TfLiteIntArray* const kEncodedDims =
       tflite::testing::IntArrayFromInts(kEncodedShapePrune);

--- a/tensorflow/lite/micro/kernels/decode_test.cc
+++ b/tensorflow/lite/micro/kernels/decode_test.cc
@@ -66,6 +66,77 @@ constexpr int kEncodedShapeLUT[] = {1, sizeof(kEncodedLUT)};
 constexpr int8_t kExpectLUT0[] = {1, 2, 3, 4, 4, 3, 2, 1};
 constexpr int16_t kExpectLUT1[] = {5, 6, 7, 8, 8, 7, 6, 5};
 
+//
+// Custom DECODE test data
+//
+constexpr int kDecodeTypeCustom = 200;
+
+constexpr int8_t kAncillaryDataCustom[] = {0x42};
+
+constexpr uint8_t kDcmCustom[tflite::DecodeState::kDcmSizeInBytes] = {
+    kDecodeTypeCustom,  // type: custom
+    1,                  // DCM version: 1
+};
+
+// Align the tensor data the same as a Buffer in the TfLite schema
+alignas(16) const uint8_t kEncodedCustom[] = {0x42, 0x43, 0x40, 0x46,
+                                              0x4A, 0x52, 0x62, 0x02};
+
+// Tensor shapes as TfLiteIntArray
+constexpr int kOutputShapeCustom[] = {1, 8};
+constexpr int kEncodedShapeCustom[] = {1, sizeof(kEncodedCustom)};
+
+constexpr int8_t kExpectCustom[] = {0x00, 0x01, 0x02, 0x04,
+                                    0x08, 0x10, 0x20, 0x40};
+
+class DecodeStateCustom : public tflite::DecodeState {
+ public:
+  DecodeStateCustom() = delete;
+
+  DecodeStateCustom(const TfLiteContext* context,
+                    tflite::MicroProfilerInterface* profiler)
+      : DecodeState(context, profiler) {}
+
+  virtual TfLiteStatus Setup(const TfLiteTensor& input,
+                             const TfLiteTensor& ancillary,
+                             const TfLiteTensor& output) override {
+    return kTfLiteOk;
+  }
+
+  virtual TfLiteStatus Decode(const TfLiteEvalTensor& input,
+                              const TfLiteEvalTensor& ancillary,
+                              const TfLiteEvalTensor& output) override {
+    const uint8_t* inp = tflite::micro::GetTensorData<uint8_t>(&input);
+    TF_LITE_ENSURE(const_cast<TfLiteContext*>(context_), inp != nullptr);
+    uint8_t* outp = tflite::micro::GetTensorData<uint8_t>(
+        const_cast<TfLiteEvalTensor*>(&output));
+    TF_LITE_ENSURE(const_cast<TfLiteContext*>(context_), outp != nullptr);
+    const uint8_t* vp = tflite::micro::GetTensorData<uint8_t>(&ancillary);
+    TF_LITE_ENSURE(const_cast<TfLiteContext*>(context_), vp != nullptr);
+    vp += kDcmSizeInBytes;
+
+    // simple XOR de-obfuscation
+    std::transform(inp, inp + input.dims->data[0], outp,
+                   [vp](uint8_t i) { return i ^ *vp; });
+
+    return kTfLiteOk;
+  }
+
+  static DecodeState* CreateDecodeStateCustom(
+      const tflite::MicroContext::CustomDecodeRegistration& registration,
+      const TfLiteContext& context, tflite::MicroProfilerInterface* profiler) {
+    alignas(DecodeStateCustom) static uint8_t buffer[sizeof(DecodeStateCustom)];
+    DecodeState* instance = new (buffer) DecodeStateCustom(&context, profiler);
+    return instance;
+  }
+
+ protected:
+  virtual ~DecodeStateCustom() = default;
+
+ private:
+  TF_LITE_REMOVE_VIRTUAL_DELETE
+};
+
 }  // namespace
 
 using tflite::testing::AncillaryData;
@@ -242,6 +313,118 @@ TEST(DecodeTest, DecodeWithAltDecompressionMemory) {
   tflite::testing::TestDecode<encodes.size() + ancillaries.size(),
                               outputs.size()>(
       encodes, ancillaries, outputs, expected, tflite::Register_DECODE(), &amr);
+}
+
+TEST(DecodeTest, DecodeWithCustomRegistration) {
+  // Align the tensor data the same as a Buffer in the TfLite schema
+  alignas(16) int8_t output_data[std::size(kExpectCustom)] = {};
+  alignas(16) const AncillaryData<int8_t, std::size(kAncillaryDataCustom)>
+      kAncillaryData = {{kDcmCustom}, {kAncillaryDataCustom}};
+
+  constexpr int kAncillaryShapeCustom[] = {1, sizeof(kAncillaryData)};
+
+  const TfLiteIntArray* const encoded_dims =
+      tflite::testing::IntArrayFromInts(kEncodedShapeCustom);
+  static const TensorInDatum tid_encode = {
+      kEncodedCustom,
+      *encoded_dims,
+  };
+  static constexpr std::initializer_list<const TensorInDatum*> encodes = {
+      &tid_encode,
+  };
+
+  const TfLiteIntArray* const ancillary_dims =
+      tflite::testing::IntArrayFromInts(kAncillaryShapeCustom);
+  static const TensorInDatum tid_ancillary = {
+      &kAncillaryData,
+      *ancillary_dims,
+  };
+  static constexpr std::initializer_list<const TensorInDatum*> ancillaries = {
+      &tid_ancillary};
+
+  const TfLiteIntArray* const output_dims =
+      tflite::testing::IntArrayFromInts(kOutputShapeCustom);
+  constexpr int kOutputZeroPointsData[] = {0};
+  const TfLiteIntArray* const kOutputZeroPoints =
+      tflite::testing::IntArrayFromInts(kOutputZeroPointsData);
+  const TfLiteFloatArray kOutputScales = {kOutputZeroPoints->size};
+  static const TensorOutDatum tod = {
+      output_data, *output_dims, kTfLiteInt8, kOutputScales, *kOutputZeroPoints,
+      0,           {},
+  };
+  static constexpr std::initializer_list<const TensorOutDatum*> outputs = {
+      &tod};
+
+  const std::initializer_list<const void*> expected = {kExpectCustom};
+
+  const std::initializer_list<tflite::MicroContext::CustomDecodeRegistration>
+      cdr = {
+          {
+              DecodeStateCustom::CreateDecodeStateCustom,
+              kDecodeTypeCustom,
+          },
+      };
+
+  tflite::testing::TestDecode<encodes.size() + ancillaries.size(),
+                              outputs.size()>(
+      encodes, ancillaries, outputs, expected, tflite::Register_DECODE(),
+      nullptr, &cdr);
+}
+
+TEST(DecodeTest, DecodeWithCustomMismatchedRegistration) {
+  // Align the tensor data the same as a Buffer in the TfLite schema
+  alignas(16) int8_t output_data[std::size(kExpectCustom)] = {};
+  alignas(16) const AncillaryData<int8_t, std::size(kAncillaryDataCustom)>
+      kAncillaryData = {{kDcmCustom}, {kAncillaryDataCustom}};
+
+  constexpr int kAncillaryShapeCustom[] = {1, sizeof(kAncillaryData)};
+
+  const TfLiteIntArray* const encoded_dims =
+      tflite::testing::IntArrayFromInts(kEncodedShapeCustom);
+  static const TensorInDatum tid_encode = {
+      kEncodedCustom,
+      *encoded_dims,
+  };
+  static constexpr std::initializer_list<const TensorInDatum*> encodes = {
+      &tid_encode,
+  };
+
+  const TfLiteIntArray* const ancillary_dims =
+      tflite::testing::IntArrayFromInts(kAncillaryShapeCustom);
+  static const TensorInDatum tid_ancillary = {
+      &kAncillaryData,
+      *ancillary_dims,
+  };
+  static constexpr std::initializer_list<const TensorInDatum*> ancillaries = {
+      &tid_ancillary};
+
+  const TfLiteIntArray* const output_dims =
+      tflite::testing::IntArrayFromInts(kOutputShapeCustom);
+  constexpr int kOutputZeroPointsData[] = {0};
+  const TfLiteIntArray* const kOutputZeroPoints =
+      tflite::testing::IntArrayFromInts(kOutputZeroPointsData);
+  const TfLiteFloatArray kOutputScales = {kOutputZeroPoints->size};
+  static const TensorOutDatum tod = {
+      output_data, *output_dims, kTfLiteInt8, kOutputScales, *kOutputZeroPoints,
+      0,           {},
+  };
+  static constexpr std::initializer_list<const TensorOutDatum*> outputs = {
+      &tod};
+
+  const std::initializer_list<const void*> expected = {kExpectCustom};
+
+  const std::initializer_list<tflite::MicroContext::CustomDecodeRegistration>
+      cdr = {
+          {
+              DecodeStateCustom::CreateDecodeStateCustom,
+              kDecodeTypeCustom + 1,
+          },
+      };
+
+  tflite::testing::TestDecode<encodes.size() + ancillaries.size(),
+                              outputs.size()>(
+      encodes, ancillaries, outputs, expected, tflite::Register_DECODE(),
+      nullptr, &cdr, kTfLiteError);
 }
 
 TF_LITE_MICRO_TESTS_MAIN

--- a/tensorflow/lite/micro/kernels/decode_test.cc
+++ b/tensorflow/lite/micro/kernels/decode_test.cc
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include "tensorflow/lite/core/c/common.h"
 #include "tensorflow/lite/micro/kernels/decode_state.h"
+#include "tensorflow/lite/micro/kernels/decode_state_lut.h"
 #include "tensorflow/lite/micro/kernels/decode_test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test_v2.h"
 
@@ -38,7 +39,7 @@ constexpr uint8_t kDcmLUT0[tflite::DecodeState::kDcmSizeInBytes] = {
     0,                                 // reserved
     0,                                 // reserved
     1,                                 // LUT version: 1
-    kBitWidthLUT,                      // Parameters: bit-width 2
+    kBitWidthLUT,                      // Parameters: axis 0, bit-width 2
     std::size(kAncillaryDataLUT0),     // channel stride
 };
 
@@ -48,7 +49,7 @@ constexpr uint8_t kDcmLUT1[tflite::DecodeState::kDcmSizeInBytes] = {
     0,                                 // reserved
     0,                                 // reserved
     1,                                 // LUT version: 1
-    kBitWidthLUT,                      // Parameters: bit-width 2
+    kBitWidthLUT,                      // Parameters: axis 0, bit-width 2
     std::size(kAncillaryDataLUT1),     // channel stride
 };
 
@@ -425,6 +426,65 @@ TEST(DecodeTest, DecodeWithCustomMismatchedRegistration) {
                               outputs.size()>(
       encodes, ancillaries, outputs, expected, tflite::Register_DECODE(),
       nullptr, &cdr, kTfLiteError);
+}
+
+TEST(DecodeTest, DecodeAxisNotSupportedLUT) {
+  constexpr uint8_t
+      kDcmUnsupportedAxisLUT[tflite::DecodeState::kDcmSizeInBytes] = {
+          tflite::DecodeState::kDcmTypeLUT,  // type: LUT
+          1,                                 // DCM version: 1
+          0,                                 // reserved
+          0,                                 // reserved
+          1,                                 // LUT version: 1
+          (1 << tflite::DecodeStateLut::kDcmParamsAxisMaskShift) |
+              kBitWidthLUT,               // Parameters: axis 1, bit-width 2
+          std::size(kAncillaryDataLUT0),  // channel stride
+      };
+  // Align the tensor data the same as a Buffer in the TfLite schema
+  alignas(16) int8_t output_data[std::size(kExpectLUT0)] = {};
+  alignas(16) const AncillaryData<int8_t, std::size(kAncillaryDataLUT0)>
+      kAncillaryData = {{kDcmUnsupportedAxisLUT}, {kAncillaryDataLUT0}};
+
+  constexpr int kAncillaryShapeLUT[] = {1, sizeof(kAncillaryData)};
+
+  const TfLiteIntArray* const encoded_dims =
+      tflite::testing::IntArrayFromInts(kEncodedShapeLUT);
+  static const TensorInDatum tid_encode = {
+      kEncodedLUT,
+      *encoded_dims,
+  };
+  static constexpr std::initializer_list<const TensorInDatum*> encodes = {
+      &tid_encode,
+  };
+
+  const TfLiteIntArray* const ancillary_dims =
+      tflite::testing::IntArrayFromInts(kAncillaryShapeLUT);
+  static const TensorInDatum tid_ancillary = {
+      &kAncillaryData,
+      *ancillary_dims,
+  };
+  static constexpr std::initializer_list<const TensorInDatum*> ancillaries = {
+      &tid_ancillary};
+
+  const TfLiteIntArray* const output_dims =
+      tflite::testing::IntArrayFromInts(kOutputShapeLUT);
+  constexpr int kOutputZeroPointsData[] = {0};
+  const TfLiteIntArray* const kOutputZeroPoints =
+      tflite::testing::IntArrayFromInts(kOutputZeroPointsData);
+  const TfLiteFloatArray kOutputScales = {kOutputZeroPoints->size};
+  static const TensorOutDatum tod = {
+      output_data, *output_dims, kTfLiteInt8, kOutputScales, *kOutputZeroPoints,
+      1,           {},
+  };
+  static constexpr std::initializer_list<const TensorOutDatum*> outputs = {
+      &tod};
+
+  const std::initializer_list<const void*> expected = {kExpectLUT0};
+
+  tflite::testing::TestDecode<encodes.size() + ancillaries.size(),
+                              outputs.size()>(
+      encodes, ancillaries, outputs, expected, tflite::Register_DECODE(),
+      nullptr, nullptr, kTfLiteError);
 }
 
 TF_LITE_MICRO_TESTS_MAIN

--- a/tensorflow/lite/micro/kernels/decode_test_helpers.h
+++ b/tensorflow/lite/micro/kernels/decode_test_helpers.h
@@ -81,6 +81,8 @@ void ExecuteDecodeTest(
     const std::initializer_list<const void*>& expected,
     TfLiteStatus expected_status,
     const std::initializer_list<MicroContext::AlternateMemoryRegion>* amr =
+        nullptr,
+    const std::initializer_list<MicroContext::CustomDecodeRegistration>* cdr =
         nullptr) {
   int kInputArrayData[kNumInputs + 1] = {kNumInputs};
   for (size_t i = 0; i < kNumInputs; i++) {
@@ -100,6 +102,11 @@ void ExecuteDecodeTest(
   if (amr != nullptr) {
     runner.GetFakeMicroContext()->SetDecompressionMemory(amr->begin(),
                                                          amr->size());
+  }
+
+  if (cdr != nullptr) {
+    runner.GetFakeMicroContext()->SetCustomDecodeRegistrations(cdr->begin(),
+                                                               cdr->size());
   }
 
   TfLiteStatus status = runner.InitAndPrepare();
@@ -152,6 +159,8 @@ void TestDecode(
     const TFLMRegistration& registration,
     const std::initializer_list<MicroContext::AlternateMemoryRegion>* amr =
         nullptr,
+    const std::initializer_list<MicroContext::CustomDecodeRegistration>* cdr =
+        nullptr,
     const TfLiteStatus expected_status = kTfLiteOk) {
   TfLiteTensor tensors[kNumInputs + kNumOutputs] = {};
 
@@ -185,7 +194,7 @@ void TestDecode(
   }
 
   ExecuteDecodeTest<kNumInputs, kNumOutputs>(tensors, registration, expected,
-                                             expected_status, amr);
+                                             expected_status, amr, cdr);
 }
 
 }  // namespace testing

--- a/tensorflow/lite/micro/kernels/decompress_common.cc
+++ b/tensorflow/lite/micro/kernels/decompress_common.cc
@@ -326,7 +326,7 @@ void DecompressionState::DecompressToBufferWidthAny(T* buffer) {
       const T* value_table =
           static_cast<const T*>(comp_data_.data.lut_data->value_table);
       for (size_t channel = 0; channel < num_channels_; channel++) {
-        size_t index;
+        size_t index = 0;
         switch (compressed_bit_width_) {
           case 1:
             index = GetNextTableIndexWidth1(current_offset);
@@ -367,7 +367,7 @@ void DecompressionState::DecompressToBufferWidthAny(T* buffer) {
       size_t count = max_count;
 
       while (count-- > 0) {
-        size_t index;
+        size_t index = 0;
         switch (compressed_bit_width_) {
           case 1:
             index = GetNextTableIndexWidth1(current_offset);

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
@@ -98,9 +98,11 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 
   MicroContext* micro_context = GetMicroContext(context);
 
+  [[maybe_unused]]
   const CompressionTensorData* filter_comp_td =
       micro_context->GetTensorCompressionData(node,
                                               kDepthwiseConvWeightsTensor);
+  [[maybe_unused]]
   const CompressionTensorData* bias_comp_td =
       micro_context->GetTensorCompressionData(node, kDepthwiseConvBiasTensor);
 

--- a/tensorflow/lite/micro/micro_context.cc
+++ b/tensorflow/lite/micro/micro_context.cc
@@ -174,4 +174,14 @@ void MicroContext::ResetDecompressionMemoryAllocations() {
   std::fill_n(decompress_regions_allocations_, decompress_regions_size_, 0);
 }
 
+TfLiteStatus MicroContext::SetCustomDecodeRegistrations(
+    const CustomDecodeRegistration* registrations, size_t count) {
+  if (custom_decode_registrations_ != nullptr) {
+    return kTfLiteError;
+  }
+  custom_decode_registrations_ = registrations;
+  custom_decode_registrations_size_ = count;
+  return kTfLiteOk;
+}
+
 }  // namespace tflite

--- a/tensorflow/lite/micro/micro_context.h
+++ b/tensorflow/lite/micro/micro_context.h
@@ -17,7 +17,7 @@ limitations under the License.
 #define TENSORFLOW_LITE_MICRO_MICRO_CONTEXT_H_
 
 #include <cstddef>
-#include <initializer_list>
+#include <utility>
 
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/micro_graph.h"
@@ -32,6 +32,8 @@ limitations under the License.
 namespace tflite {
 // TODO(b/149795762): kTfLiteAbort cannot be part of the tflite TfLiteStatus.
 const TfLiteStatus kTfLiteAbort = static_cast<TfLiteStatus>(15);
+
+class DecodeState;  // can't use decode_state.h due to circular include
 
 // MicroContext is eventually going to become the API between TFLM and the
 // kernels, replacing all the functions in TfLiteContext. The end state is code
@@ -136,7 +138,7 @@ class MicroContext {
   };
 
   // Set the alternate decompression memory regions.
-  // Can only be called during the MicroInterpreter kInit state.
+  // Can only be called during the kInit state.
   virtual TfLiteStatus SetDecompressionMemory(
       const AlternateMemoryRegion* regions, size_t count);
 
@@ -169,11 +171,33 @@ class MicroContext {
     return nullptr;
   }
 
+  struct CustomDecodeRegistration {
+    tflite::DecodeState* (*create_state)(const CustomDecodeRegistration&,
+                                         const TfLiteContext&,
+                                         MicroProfilerInterface*);
+    uint8_t type;  // custom decode type
+  };
+
+  // Set the DECODE operator custom registrations.
+  // Can only be called during the kInit state.
+  virtual TfLiteStatus SetCustomDecodeRegistrations(
+      const CustomDecodeRegistration* registrations, size_t count);
+
+  // Get the custom decompression registrations.
+  virtual const std::pair<const CustomDecodeRegistration*, size_t /*count*/>
+  GetCustomDecodeRegistrations() const {
+    return std::make_pair(custom_decode_registrations_,
+                          custom_decode_registrations_size_);
+  }
+
  private:
   const AlternateMemoryRegion* decompress_regions_ = nullptr;
   size_t decompress_regions_size_ = 0;
   // array of size_t elements with length equal to decompress_regions_size_
   size_t* decompress_regions_allocations_ = nullptr;
+
+  const CustomDecodeRegistration* custom_decode_registrations_ = nullptr;
+  size_t custom_decode_registrations_size_ = 0;
 
   TF_LITE_REMOVE_VIRTUAL_DELETE
 };

--- a/tensorflow/lite/micro/micro_interpreter.cc
+++ b/tensorflow/lite/micro/micro_interpreter.cc
@@ -349,4 +349,9 @@ TfLiteStatus MicroInterpreter::SetDecompressionMemory(
   return micro_context_.SetDecompressionMemory(regions, count);
 }
 
+TfLiteStatus MicroInterpreter::SetCustomDecodeRegistrations(
+    const MicroContext::CustomDecodeRegistration* registrations, size_t count) {
+  return micro_context_.SetCustomDecodeRegistrations(registrations, count);
+}
+
 }  // namespace tflite

--- a/tensorflow/lite/micro/micro_interpreter.h
+++ b/tensorflow/lite/micro/micro_interpreter.h
@@ -174,6 +174,18 @@ class MicroInterpreter {
   TfLiteStatus SetDecompressionMemory(
       const MicroContext::AlternateMemoryRegion* regions, size_t count);
 
+  // Set the DECODE operator custom registrations.
+  // Can only be called during the MicroInterpreter kInit state (i.e. must
+  // be called before MicroInterpreter::AllocateTensors).
+  // The regions pointer argument is the start of a
+  // MicroContext::CustomDecodeRegistration array where the length of the array
+  // is given by the count argument. The lifetime of the
+  // MicroContext::CustomDecodeRegistration array must be at least that of the
+  // MicroInterpreter.
+  TfLiteStatus SetCustomDecodeRegistrations(
+      const MicroContext::CustomDecodeRegistration* registrations,
+      size_t count);
+
  protected:
   const MicroAllocator& allocator() const { return allocator_; }
   const TfLiteContext& context() const { return context_; }

--- a/tensorflow/lite/micro/micro_interpreter_context.cc
+++ b/tensorflow/lite/micro/micro_interpreter_context.cc
@@ -247,4 +247,12 @@ MicroProfilerInterface* MicroInterpreterContext::GetAlternateProfiler() const {
   return alt_profiler_;
 }
 
+TfLiteStatus MicroInterpreterContext::SetCustomDecodeRegistrations(
+    const CustomDecodeRegistration* registrations, size_t count) {
+  if (state_ != InterpreterState::kInit) {
+    return kTfLiteError;
+  }
+  return MicroContext::SetCustomDecodeRegistrations(registrations, count);
+}
+
 }  // namespace tflite

--- a/tensorflow/lite/micro/micro_interpreter_context.h
+++ b/tensorflow/lite/micro/micro_interpreter_context.h
@@ -159,6 +159,11 @@ class MicroInterpreterContext : public MicroContext {
   // decompression subsystem.
   MicroProfilerInterface* GetAlternateProfiler() const override;
 
+  // Set the DECODE operator custom registrations.
+  // Can only be called during the kInit state.
+  virtual TfLiteStatus SetCustomDecodeRegistrations(
+      const CustomDecodeRegistration* registrations, size_t count) override;
+
  private:
   MicroAllocator& allocator_;
   MicroInterpreterGraph& graph_;

--- a/tensorflow/lite/micro/micro_interpreter_context_test.cc
+++ b/tensorflow/lite/micro/micro_interpreter_context_test.cc
@@ -15,7 +15,9 @@ limitations under the License.
 #include "tensorflow/lite/micro/micro_interpreter_context.h"
 
 #include <cstdint>
+#include <utility>
 
+#include "tensorflow/lite/micro/kernels/decode_state.h"
 #include "tensorflow/lite/micro/micro_allocator.h"
 #include "tensorflow/lite/micro/micro_arena_constants.h"
 #include "tensorflow/lite/micro/micro_interpreter_graph.h"
@@ -308,6 +310,56 @@ TEST(MicroInterpreterContextTest, TestResetDecompressionMemory) {
   p = static_cast<uint8_t*>(micro_context.AllocateDecompressionMemory(
       kAllocateSize, tflite::MicroArenaBufferAlignment()));
   EXPECT_EQ(p, &g_alt_memory[0]);
+}
+
+TEST(MicroInterpreterContextTest, TestSetCustomDecode) {
+  tflite::MicroInterpreterContext micro_context =
+      tflite::CreateMicroInterpreterContext();
+
+  const std::initializer_list<tflite::MicroContext::CustomDecodeRegistration>
+      cdr = {
+          {
+              nullptr,  // the test won't instantiate tflite::DecodeState
+              tflite::DecodeState::kDcmTypeCustomFirst,
+          },
+      };
+  TfLiteStatus status;
+
+  // Test that all of the MicroInterpreterContext fences are correct, by
+  // forcing the MicroInterpreterContext state. The SetCustomDecodeRegistrations
+  // method should only be allowed during the kInit state, and can only be
+  // set once.
+
+  // fail during Prepare state
+  micro_context.SetInterpreterState(
+      tflite::MicroInterpreterContext::InterpreterState::kPrepare);
+  status = micro_context.SetCustomDecodeRegistrations(cdr.begin(), cdr.size());
+  EXPECT_EQ(status, kTfLiteError);
+
+  // fail during Invoke state
+  micro_context.SetInterpreterState(
+      tflite::MicroInterpreterContext::InterpreterState::kInvoke);
+  status = micro_context.SetCustomDecodeRegistrations(cdr.begin(), cdr.size());
+  EXPECT_EQ(status, kTfLiteError);
+
+  // succeed during Init state
+  micro_context.SetInterpreterState(
+      tflite::MicroInterpreterContext::InterpreterState::kInit);
+  status = micro_context.SetCustomDecodeRegistrations(cdr.begin(), cdr.size());
+  EXPECT_EQ(status, kTfLiteOk);
+
+  // fail on second Init state attempt
+  micro_context.SetInterpreterState(
+      tflite::MicroInterpreterContext::InterpreterState::kInit);
+  status = micro_context.SetCustomDecodeRegistrations(cdr.begin(), cdr.size());
+  EXPECT_EQ(status, kTfLiteError);
+
+  // check registered info. matches
+  const tflite::MicroContext::CustomDecodeRegistration* registration;
+  size_t count;
+  std::tie(registration, count) = micro_context.GetCustomDecodeRegistrations();
+  EXPECT_EQ(registration, cdr.begin());
+  EXPECT_EQ(count, 1U);
 }
 
 TF_LITE_MICRO_TESTS_MAIN

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -161,6 +161,7 @@ endif
 
 
 CC_WARNINGS := \
+  -Werror \
   -Wsign-compare \
   -Wdouble-promotion \
   -Wunused-variable \


### PR DESCRIPTION
@tensorflow/micro

Bring DECODE operator LUT and pruning channel count discovery in-line with design documentation. This fixes the channel count always being 1 (one) for non-quantized tensors.

Parse additional field in DCM.

Update unit tests.

bug=fixes #3685