### PR TITLE
[CI] Hardened warning tests

### DIFF
--- a/.github/workflows/test_makefile.yml
+++ b/.github/workflows/test_makefile.yml
@@ -31,7 +31,7 @@ jobs:
             script: test_x86_no_tflite_static_memory.sh
     name: ${{ matrix.name }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.trigger-sha || github.ref }}
           allow-unsafe-pr-checkout: true

--- a/.github/workflows/test_makefile.yml
+++ b/.github/workflows/test_makefile.yml
@@ -13,6 +13,8 @@ jobs:
     timeout-minutes: 60
     container:
       image: ghcr.io/tflm-bot/tflm-ci:0.6.7
+    env:
+      WERROR: 1
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_misc.yml
+++ b/.github/workflows/test_misc.yml
@@ -16,7 +16,7 @@ jobs:
     container:
       image: ghcr.io/tflm-bot/tflm-ci:0.6.7
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.trigger-sha }}
           allow-unsafe-pr-checkout: true
@@ -30,11 +30,11 @@ jobs:
       image: ghcr.io/tflm-bot/tflm-ci:0.6.7
     name: C++ Build Warnings
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.trigger-sha || github.ref }}
           allow-unsafe-pr-checkout: true
-      - uses: bazel-contrib/setup-bazel@0.18.0
+      - uses: bazel-contrib/setup-bazel@083175551ceeceebc757ebee2127fde78840ca77 # 0.18.0
         with:
           bazelisk-cache: true
           disk-cache: true
@@ -53,11 +53,11 @@ jobs:
     container:
       image: ghcr.io/tflm-bot/tflm-ci:0.6.7
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.trigger-sha }}
           allow-unsafe-pr-checkout: true
-      - uses: bazel-contrib/setup-bazel@0.18.0
+      - uses: bazel-contrib/setup-bazel@083175551ceeceebc757ebee2127fde78840ca77 # 0.18.0
         with:
           bazelisk-cache: true
           disk-cache: true

--- a/.github/workflows/test_misc.yml
+++ b/.github/workflows/test_misc.yml
@@ -41,9 +41,7 @@ jobs:
           cache-save: ${{ github.event_name == 'push' }}
           repository-cache: true
       - name: Build with Warnings as Errors
-        run: |
-          bazel build --compilation_mode=opt --copt="-Werror" --copt="-Wall" --copt="-Wextra" --copt="-Wno-unused-parameter" //...
-          bazel build --compilation_mode=opt --copt="-Werror" --copt="-Wall" --copt="-Wextra" --copt="-Wno-unused-parameter" --//:with_compression //...
+        run: bazel build --compilation_mode=opt --copt="-Werror" --copt="-Wall" --copt="-Wextra" --copt="-Wno-unused-parameter" //...
 
   project_generation:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_misc.yml
+++ b/.github/workflows/test_misc.yml
@@ -41,7 +41,9 @@ jobs:
           cache-save: ${{ github.event_name == 'push' }}
           repository-cache: true
       - name: Build with Warnings as Errors
-        run: bazel build --copt="-Werror" //...
+        run: |
+          bazel build --compilation_mode=opt --copt="-Werror" --copt="-Wall" --copt="-Wextra" --copt="-Wno-unused-parameter" //...
+          bazel build --compilation_mode=opt --copt="-Werror" --copt="-Wall" --copt="-Wextra" --copt="-Wno-unused-parameter" --//:with_compression //...
 
   project_generation:
     runs-on: ubuntu-latest

--- a/tensorflow/lite/micro/kernels/cast_test.cc
+++ b/tensorflow/lite/micro/kernels/cast_test.cc
@@ -59,7 +59,8 @@ void TestCast(const InputT (&input)[N], const OutputT (&golden)[N]) {
 
 template <typename IntT>
 void TestFloatToInt(float pos_overflow, float neg_overflow) {
-  constexpr bool is_signed = std::numeric_limits<IntT>::is_signed;
+  [[maybe_unused]] constexpr bool is_signed =
+      std::numeric_limits<IntT>::is_signed;
   const float input[] = {100.f,
                          1.0f,
                          0.f,

--- a/tensorflow/lite/micro/kernels/decompress_common.cc
+++ b/tensorflow/lite/micro/kernels/decompress_common.cc
@@ -326,7 +326,7 @@ void DecompressionState::DecompressToBufferWidthAny(T* buffer) {
       const T* value_table =
           static_cast<const T*>(comp_data_.data.lut_data->value_table);
       for (size_t channel = 0; channel < num_channels_; channel++) {
-        size_t index;
+        size_t index = 0;
         switch (compressed_bit_width_) {
           case 1:
             index = GetNextTableIndexWidth1(current_offset);
@@ -348,6 +348,9 @@ void DecompressionState::DecompressToBufferWidthAny(T* buffer) {
             break;
           case 7:
             index = GetNextTableIndexWidth7(current_offset);
+            break;
+          default:
+            index = 0;
             break;
         }
         current_offset++;
@@ -367,7 +370,7 @@ void DecompressionState::DecompressToBufferWidthAny(T* buffer) {
       size_t count = max_count;
 
       while (count-- > 0) {
-        size_t index;
+        size_t index = 0;
         switch (compressed_bit_width_) {
           case 1:
             index = GetNextTableIndexWidth1(current_offset);
@@ -389,6 +392,9 @@ void DecompressionState::DecompressToBufferWidthAny(T* buffer) {
             break;
           case 7:
             index = GetNextTableIndexWidth7(current_offset);
+            break;
+          default:
+            index = 0;
             break;
         }
         current_offset++;

--- a/tensorflow/lite/micro/kernels/decompress_common.cc
+++ b/tensorflow/lite/micro/kernels/decompress_common.cc
@@ -317,6 +317,8 @@ template <typename T>
 void DecompressionState::DecompressToBufferWidthAny(T* buffer) {
   ScopedMicroProfiler scoped_profiler(__func__, micro_profiler_);
 
+  TFLITE_DCHECK(compressed_bit_width_ > 0 && compressed_bit_width_ < 8);
+
   if (comp_data_.data.lut_data->use_alternate_axis) {
     const size_t stride = comp_data_.data.lut_data->value_table_channel_stride;
     size_t current_offset = 0;
@@ -348,9 +350,6 @@ void DecompressionState::DecompressToBufferWidthAny(T* buffer) {
             break;
           case 7:
             index = GetNextTableIndexWidth7(current_offset);
-            break;
-          default:
-            index = 0;
             break;
         }
         current_offset++;
@@ -392,9 +391,6 @@ void DecompressionState::DecompressToBufferWidthAny(T* buffer) {
             break;
           case 7:
             index = GetNextTableIndexWidth7(current_offset);
-            break;
-          default:
-            index = 0;
             break;
         }
         current_offset++;

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
@@ -95,15 +95,13 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       context, op_data.reference_op_data.filter_buffer_index, filter);
 
 #ifdef USE_TFLM_COMPRESSION
+  [[maybe_unused]] MicroContext* micro_context = GetMicroContext(context);
 
-  MicroContext* micro_context = GetMicroContext(context);
-
-  const CompressionTensorData* filter_comp_td =
+  [[maybe_unused]] const CompressionTensorData* filter_comp_td =
       micro_context->GetTensorCompressionData(node,
                                               kDepthwiseConvWeightsTensor);
-  const CompressionTensorData* bias_comp_td =
+  [[maybe_unused]] const CompressionTensorData* bias_comp_td =
       micro_context->GetTensorCompressionData(node, kDepthwiseConvBiasTensor);
-
 #endif  // USE_TFLM_COMPRESSION
 
   switch (input->type) {  // Already know in/out types are same.

--- a/tensorflow/lite/micro/tools/ci_build/helper_functions.sh
+++ b/tensorflow/lite/micro/tools/ci_build/helper_functions.sh
@@ -17,6 +17,9 @@
 # Collection of helper functions that can be used in the different continuous
 # integration scripts.
 
+# Enable -Werror by default for CI runs, but allow overriding with WERROR=0.
+export WERROR=${WERROR:-1}
+
 # Executes a command with a timeout and formats output for GitHub Actions.
 function readable_run {
   # 1. specific GitHub Actions syntax to start a collapsible section

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -181,6 +181,11 @@ ifneq ($(TOOLCHAIN), gcc)
   CC_WARNINGS += -Wshadow
 endif
 
+WERROR ?= 0
+ifeq ($(WERROR), 1)
+  CC_WARNINGS += -Werror
+endif
+
 COMMON_FLAGS := \
   -fno-unwind-tables \
   -fno-asynchronous-unwind-tables \


### PR DESCRIPTION
Changes:
 
- `Makefile`: Add `WERROR ?= 0` flag to allow enabling `-Werror` without breaking standalone/downstream builds by default.
- `CI Script`: Default `WERROR=1` in `helper_functions.sh` so all CI builds (x86, Xtensa, Cortex-M, Hexagon, RISC-V) enforce warnings-as-errors.
- `Bazel Warning CI`: Run with `--compilation_mode=opt -Wall -Wextra -Wno-unused-parameter` to catch optimizer/dataflow warnings.

BUG=n/a