### PR TITLE
fix(compression): fix .tflite built from scratch

### DIFF
--- a/tensorflow/lite/micro/compression/model_editor.py
+++ b/tensorflow/lite/micro/compression/model_editor.py
@@ -24,6 +24,11 @@ import flatbuffers
 from tflite_micro.tensorflow.lite.micro.compression import tensor_type
 from tflite_micro.tensorflow.lite.python import schema_py_generated as tflite
 
+# The file identifier declared by schema.fbs, at bytes 4-7 of a
+# finished .tflite flatbuffer. Loaders such as the TfLite interpreter
+# verify it before reading the model.
+_TFLITE_FILE_IDENTIFIER = b"TFL3"
+
 
 class _BufferList(list):
   """Custom list that auto-sets buffer.index on append.
@@ -823,8 +828,14 @@ class _ModelCompiler:
   def compile(self) -> bytearray:
     """Compile model using backing ModelT, preserving all fields."""
     # Use the backing ModelT directly---this preserves all fields we don't
-    # explicitly handle (version, signature_defs, etc.)
+    # explicitly handle (signature_defs, etc.)
     root = self.model._fb
+
+    # A .tflite file declares schema version 3. A model built from
+    # scratch leaves the field at the flatbuffer default of 0; a model
+    # from read() keeps the version it declared.
+    if not root.version:
+      root.version = 3
 
     # Initialize buffers
     # If model.buffers exists (from read()), preserve those buffers
@@ -858,7 +869,7 @@ class _ModelCompiler:
 
     # Pack and return
     builder = flatbuffers.Builder(4 * 2**20)
-    builder.Finish(root.Pack(builder))
+    builder.Finish(root.Pack(builder), file_identifier=_TFLITE_FILE_IDENTIFIER)
     return builder.Output()
 
   def _collect_operator_codes(self):

--- a/tensorflow/lite/micro/compression/model_editor_test.py
+++ b/tensorflow/lite/micro/compression/model_editor_test.py
@@ -246,6 +246,28 @@ class TestBasicModel(unittest.TestCase):
                      tflite.BuiltinOperator.FULLY_CONNECTED)
 
 
+class TestFileFormat(unittest.TestCase):
+  """Test the .tflite file-level framing of built flatbuffers."""
+
+  def test_build_writes_file_identifier(self):
+    """A built flatbuffer carries the TFL3 identifier at bytes 4-7."""
+    fb = Model(subgraphs=[Subgraph()]).build()
+    self.assertEqual(bytes(fb[4:8]), b"TFL3")
+
+  def test_build_declares_schema_version(self):
+    """A model built from scratch declares schema version 3."""
+    fb = Model(subgraphs=[Subgraph()]).build()
+    self.assertEqual(tflite.ModelT.InitFromPackedBuf(fb, 0).version, 3)
+
+  def test_build_keeps_declared_version(self):
+    """build() preserves the version a model already declares."""
+    model = model_editor.read(bytes(Model(subgraphs=[Subgraph()]).build()))
+    # The editor exposes no setter for a model's schema version.
+    model._fb.version = 4
+    fb = model.build()
+    self.assertEqual(tflite.ModelT.InitFromPackedBuf(fb, 0).version, 4)
+
+
 class TestAdvancedModel(unittest.TestCase):
   """Test multiple operators, custom ops, shared tensors, and mixed references."""
 


### PR DESCRIPTION
Set schema version 3 on every model built from scratch, and add the file identifier TFL3 to every built flatbuffer. A model built from scratch with the model editor declares schema version 0 and lacks the file identifier. Leave the version of a model read from a file unchanged.

BUG=part of #3256
