### PR TITLE
Fix out-of-bounds memory access in CIRCULAR_BUFFER with zero slot count

### DIFF
--- a/tensorflow/lite/micro/kernels/circular_buffer_common.cc
+++ b/tensorflow/lite/micro/kernels/circular_buffer_common.cc
@@ -53,6 +53,12 @@ TfLiteStatus CircularBufferPrepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_EQ(context, 1, input->dims->data[1]);
   TF_LITE_ENSURE_EQ(context, input->dims->data[2], output->dims->data[2]);
   TF_LITE_ENSURE_EQ(context, output->dims->data[3], input->dims->data[3]);
+  // The number of slots in the circular buffer (output->dims->data[1]) must be
+  // at least 1. CircularBufferEval computes the shift size as
+  // (num_slots - 1) * depth and passes it to memmove; a num_slots of 0 makes
+  // that size negative, which wraps to a huge size_t and causes an
+  // out-of-bounds read/write on the output tensor.
+  TF_LITE_ENSURE(context, output->dims->data[1] >= 1);
 
   TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
 

--- a/tensorflow/lite/micro/kernels/circular_buffer_test.cc
+++ b/tensorflow/lite/micro/kernels/circular_buffer_test.cc
@@ -256,4 +256,27 @@ TEST(CircularBufferTest, Reset) {
   EXPECT_EQ(kTfLiteOk, runner.Invoke());
 }
 
+TEST(CircularBufferTest, ZeroNumSlotsRejectedInPrepare) {
+  // With num_slots == 0, CircularBufferEval computes the buffer shift size as
+  // (num_slots - 1) * depth, which is negative and wraps to a huge size_t when
+  // passed to memmove, causing an out-of-bounds read/write on the output
+  // tensor. Since all dimensions come from the model, Prepare must reject a
+  // zero slot count.
+  int8_t in = 0, out = 0;
+  int in_dims[] = {4, 1, 1, 1, 1}, out_dims[] = {4, 1, 0, 1, 1};
+  TfLiteTensor tensors[] = {
+      tflite::testing::CreateQuantizedTensor(
+          &in, tflite::testing::IntArrayFromInts(in_dims), 1, 0),
+      tflite::testing::CreateQuantizedTensor(
+          &out, tflite::testing::IntArrayFromInts(out_dims), 1, 0),
+  };
+  int ins[] = {1, 0}, outs[] = {1, 1};
+  tflite::micro::KernelRunner runner(
+      *tflite::Register_CIRCULAR_BUFFER(), tensors, 2,
+      tflite::testing::IntArrayFromInts(ins),
+      tflite::testing::IntArrayFromInts(outs), nullptr);
+
+  EXPECT_NE(kTfLiteOk, runner.InitAndPrepare());
+}
+
 TF_LITE_MICRO_TESTS_MAIN


### PR DESCRIPTION
BUG=tensorflow/tflite-micro#3695

## What

`CircularBufferEval` computes the buffer shift size as `(num_slots - 1) * depth`, where `num_slots = output->dims->data[1]`. `CircularBufferPrepare` validated the other dimensions but never checked that the output slot count is at least 1.

## Why

With `num_slots == 0`, `(num_slots - 1) * depth` evaluates to `-depth` as an `int` and wraps to a huge `size_t` when passed to `memmove` in `EvalInt8`:

```c
memmove(output, &output[depth], (num_slots - 1) * depth);
memcpy(&output[(num_slots - 1) * depth], input, depth);
```

This performs a large out-of-bounds read from `output + depth` and a large out-of-bounds write starting at `output`. All tensor dimensions come from the model file, so a crafted `.tflite` model can trigger this (reproduced under ASan as `negative-size-param`, see #3695). On microcontroller targets, which typically run without mitigations, this is an out-of-bounds write primitive.

## Fix

Reject slot counts < 1 in `CircularBufferPrepare`:

```c
TF_LITE_ENSURE(context, output->dims->data[1] >= 1);
```

## Testing

Added `CircularBufferTest.ZeroNumSlotsRejectedInPrepare`:
- Fails without the fix (`InitAndPrepare` returns `kTfLiteOk` for a `[1,0,1,1]` output, where it must fail).
- Passes with the fix (`Prepare` rejects the shape).

Existing tests (4) continue to pass.