### PR TITLE
Validate DECODE LUT ancillary, input, and stride bounds in Setup

### DIFF
--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -720,6 +720,22 @@ tflm_cc_test(
 )
 
 tflm_cc_test(
+    name = "decode_lut_bounds_test",
+    srcs = [
+        "decode_lut_bounds_test.cc",
+    ],
+    deps = [
+        ":decode_test_helpers",
+        ":kernel_runner",
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/micro:debug_log",
+        "//tensorflow/lite/micro:op_resolvers",
+        "//tensorflow/lite/micro:test_helpers",
+        "//tensorflow/lite/micro/testing:micro_test",
+    ],
+)
+
+tflm_cc_test(
     name = "decode_test",
     srcs = [
         "decode_test.cc",

--- a/tensorflow/lite/micro/kernels/Makefile.inc
+++ b/tensorflow/lite/micro/kernels/Makefile.inc
@@ -126,6 +126,7 @@ $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/cumsum_test.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/decode_state_huffman_test.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/decode_state_lut_test.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/decode_state_prune_test.cc \
+$(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/decode_lut_bounds_test.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/decode_test.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/depth_to_space_test.cc \
 $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/depthwise_conv_test.cc \

--- a/tensorflow/lite/micro/kernels/decode.cc
+++ b/tensorflow/lite/micro/kernels/decode.cc
@@ -92,6 +92,8 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 
     TF_LITE_ENSURE(context, IsConstantTensor(input));
     TF_LITE_ENSURE(context, IsConstantTensor(ancillary));
+    TF_LITE_ENSURE(context,
+                   ancillary->bytes >= DecodeState::kDcmSizeInBytes);
 
     if (DecodeState::Version(*ancillary) != 1) {
       MicroPrintf("version %u != 1", DecodeState::Version(*ancillary));

--- a/tensorflow/lite/micro/kernels/decode_lut_bounds_test.cc
+++ b/tensorflow/lite/micro/kernels/decode_lut_bounds_test.cc
@@ -1,0 +1,134 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Fails on unpatched HEAD (Prepare succeeds) and passes after Setup bounds.
+#include <cstdint>
+#include <initializer_list>
+
+#include "tensorflow/lite/core/c/common.h"
+#include "tensorflow/lite/micro/kernels/decode_state.h"
+#include "tensorflow/lite/micro/kernels/decode_test_helpers.h"
+#include "tensorflow/lite/micro/kernels/kernel_runner.h"
+#include "tensorflow/lite/micro/testing/micro_test_v2.h"
+
+namespace {
+
+constexpr int kBitWidthLUT = 2;
+constexpr int8_t kAncillaryDataLUT0[] = {1, 2, 3, 4};
+constexpr uint8_t kDcmLUT0[tflite::DecodeState::kDcmSizeInBytes] = {
+    tflite::DecodeState::kDcmTypeLUT, 1, 0, 0, 1, kBitWidthLUT,
+    std::size(kAncillaryDataLUT0),
+};
+alignas(16) const uint8_t kEncodedLUT[] = {0x1B, 0xE4};
+constexpr int kAttackIndexOutputShape[] = {2, 1, 64};
+constexpr int kAttackIndexEncodedShape[] = {1, 2};
+
+constexpr int kBitWidth7 = 7;
+constexpr int kStrideChannels = 8;
+constexpr int kAttackStrideOutputShape[] = {2, 1, 8};
+constexpr int kAttackStrideEncodedShape[] = {1, 7};
+alignas(16) const uint8_t kEncodedStride[] = {0x7F, 0x5A, 0x7F, 0x5A, 0x7F,
+                                              0x5A, 0x7F};
+constexpr uint8_t kDcmStride[tflite::DecodeState::kDcmSizeInBytes] = {
+    tflite::DecodeState::kDcmTypeLUT, 1, 0, 0, 1, kBitWidth7, 255,
+};
+constexpr int8_t kStrideTable[8] = {10, 20, 30, 40, 50, 60, 70, 80};
+
+TfLiteStatus PrepareOnly(TfLiteTensor* tensors, int n_in, int n_out) {
+  int in_data[8] = {n_in};
+  for (int i = 0; i < n_in; ++i) in_data[i + 1] = i;
+  TfLiteIntArray* inputs = tflite::testing::IntArrayFromInts(in_data);
+  int out_data[8] = {n_out};
+  for (int i = 0; i < n_out; ++i) out_data[i + 1] = i + n_in;
+  TfLiteIntArray* outputs = tflite::testing::IntArrayFromInts(out_data);
+  tflite::micro::KernelRunner runner(tflite::Register_DECODE(), tensors,
+                                     n_in + n_out, inputs, outputs, nullptr);
+  return runner.InitAndPrepare();
+}
+
+}  // namespace
+
+using tflite::testing::AncillaryData;
+
+TEST(DecodeLutBounds, UndersizedInputRejected) {
+  alignas(16) int8_t output_data[64] = {};
+  alignas(16) const AncillaryData<int8_t, std::size(kAncillaryDataLUT0)>
+      kAncillaryData = {{kDcmLUT0}, {kAncillaryDataLUT0}};
+  constexpr int kAncillaryShape[] = {1, sizeof(kAncillaryData)};
+
+  const TfLiteIntArray* encoded_dims =
+      tflite::testing::IntArrayFromInts(kAttackIndexEncodedShape);
+  const TfLiteIntArray* ancillary_dims =
+      tflite::testing::IntArrayFromInts(kAncillaryShape);
+  const TfLiteIntArray* output_dims =
+      tflite::testing::IntArrayFromInts(kAttackIndexOutputShape);
+
+  TfLiteTensor tensors[3] = {};
+  tensors[0] = tflite::testing::CreateTensor(
+      kEncodedLUT, const_cast<TfLiteIntArray*>(encoded_dims), false,
+      kTfLiteUInt8);
+  tensors[0].allocation_type = kTfLiteMmapRo;
+  tensors[1] = tflite::testing::CreateTensor(
+      &kAncillaryData, const_cast<TfLiteIntArray*>(ancillary_dims), false,
+      kTfLiteUInt8);
+  tensors[1].allocation_type = kTfLiteMmapRo;
+  tensors[2] = tflite::testing::CreateTensor(
+      output_data, const_cast<TfLiteIntArray*>(output_dims), false,
+      kTfLiteInt8);
+
+  ASSERT_EQ(PrepareOnly(tensors, 2, 1), kTfLiteError);
+}
+
+TEST(DecodeLutBounds, OversizeStrideRejected) {
+  alignas(16) int8_t output_data[8] = {};
+  alignas(16) const AncillaryData<int8_t, std::size(kStrideTable)> kAncillaryData =
+      {{kDcmStride}, {kStrideTable}};
+  constexpr int kAncillaryShape[] = {1, sizeof(kAncillaryData)};
+
+  const TfLiteIntArray* encoded_dims =
+      tflite::testing::IntArrayFromInts(kAttackStrideEncodedShape);
+  const TfLiteIntArray* ancillary_dims =
+      tflite::testing::IntArrayFromInts(kAncillaryShape);
+  const TfLiteIntArray* output_dims =
+      tflite::testing::IntArrayFromInts(kAttackStrideOutputShape);
+
+  static float scales_data[kStrideChannels + 1];
+  scales_data[0] = static_cast<float>(kStrideChannels);
+  for (int i = 1; i <= kStrideChannels; ++i) scales_data[i] = 1.0f;
+  const TfLiteFloatArray* scales =
+      tflite::testing::FloatArrayFromFloats(scales_data);
+  static int zp_data[kStrideChannels + 1];
+  zp_data[0] = kStrideChannels;
+  const TfLiteIntArray* zps = tflite::testing::IntArrayFromInts(zp_data);
+  TfLiteAffineQuantization aq = {};
+
+  TfLiteTensor tensors[3] = {};
+  tensors[0] = tflite::testing::CreateTensor(
+      kEncodedStride, const_cast<TfLiteIntArray*>(encoded_dims), false,
+      kTfLiteUInt8);
+  tensors[0].allocation_type = kTfLiteMmapRo;
+  tensors[1] = tflite::testing::CreateTensor(
+      &kAncillaryData, const_cast<TfLiteIntArray*>(ancillary_dims), false,
+      kTfLiteUInt8);
+  tensors[1].allocation_type = kTfLiteMmapRo;
+  tensors[2] = tflite::testing::CreatePerChannelQuantizedTensor(
+      output_data, const_cast<TfLiteIntArray*>(output_dims),
+      const_cast<TfLiteFloatArray*>(scales), const_cast<TfLiteIntArray*>(zps),
+      &aq, /*quantized_dimension=*/0, false, kTfLiteInt8);
+
+  ASSERT_EQ(PrepareOnly(tensors, 2, 1), kTfLiteError);
+}
+
+TF_LITE_MICRO_TESTS_MAIN

--- a/tensorflow/lite/micro/kernels/decode_state_lut.cc
+++ b/tensorflow/lite/micro/kernels/decode_state_lut.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/compatibility.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/micro_log.h"
 #include "tensorflow/lite/micro/micro_profiler.h"
 
@@ -29,6 +30,9 @@ namespace tflite {
 TfLiteStatus DecodeStateLut::Setup(const TfLiteTensor& input,
                                    const TfLiteTensor& ancillary,
                                    const TfLiteTensor& output) {
+  TfLiteContext* ctx = const_cast<TfLiteContext*>(context_);
+  TF_LITE_ENSURE(ctx, ancillary.bytes >= kDcmSizeInBytes);
+
   const uint8_t* const ancillary_data = GetTensorData<uint8_t>(&ancillary);
   if (ancillary_data[kDcmVersionOffset] != 1) {
     MicroPrintf("unsupported version %u", ancillary_data[kDcmVersionOffset]);
@@ -51,15 +55,55 @@ TfLiteStatus DecodeStateLut::Setup(const TfLiteTensor& input,
     }
   }
 
+  TF_LITE_ENSURE(ctx, num_channels_ > 0);
+
   compressed_indices_ = GetTensorData<uint8_t>(&input);
   count_indices_ = NumElements(&output);
-  elements_per_channel_ =
-      use_alternate_axis_ ? 1 : count_indices_ / num_channels_;
-  value_table_ = &ancillary_data[kDcmSizeInBytes];
-  value_table_channel_stride_ = ancillary_data[kDcmValueTableStrideOffset];
   compressed_bit_width_ =
       ancillary_data[kDcmParamsOffset] & kDcmParamsBitWidthMask;
+  value_table_channel_stride_ = ancillary_data[kDcmValueTableStrideOffset];
 
+  TF_LITE_ENSURE(ctx, compressed_bit_width_ >= 1 &&
+                          compressed_bit_width_ <= kMaxBitWidth);
+  TF_LITE_ENSURE(ctx, value_table_channel_stride_ >= 1 &&
+                          value_table_channel_stride_ <=
+                              kMaxValueTableChannelStride);
+
+  if (!use_alternate_axis_) {
+    TF_LITE_ENSURE(ctx, count_indices_ % num_channels_ == 0);
+    elements_per_channel_ = count_indices_ / num_channels_;
+  } else {
+    elements_per_channel_ = 1;
+  }
+
+  const size_t elt = static_cast<size_t>(TfLiteTypeGetSize(output.type));
+  TF_LITE_ENSURE(ctx, elt > 0);
+
+  // Both axes walk at most (num_channels-1)*stride + (stride-1) when the
+  // compressor's contract holds (index < stride). Do not require
+  // stride >= 2^bit_width: official tests use 2^n-1 and min(table, elements).
+  size_t table_count = 0;
+  TF_LITE_ENSURE(
+      ctx, !__builtin_mul_overflow(
+               static_cast<size_t>(value_table_channel_stride_), num_channels_,
+               &table_count));
+  size_t table_bytes = 0;
+  TF_LITE_ENSURE(ctx, !__builtin_mul_overflow(table_count, elt, &table_bytes));
+  size_t need = 0;
+  TF_LITE_ENSURE(ctx, !__builtin_add_overflow(
+                          static_cast<size_t>(kDcmSizeInBytes), table_bytes,
+                          &need));
+  TF_LITE_ENSURE(ctx, ancillary.bytes >= need);
+
+  size_t index_bits = 0;
+  TF_LITE_ENSURE(ctx,
+                 !__builtin_mul_overflow(
+                     count_indices_, static_cast<size_t>(compressed_bit_width_),
+                     &index_bits));
+  const size_t index_bytes = (index_bits + 7) / 8;
+  TF_LITE_ENSURE(ctx, input.bytes >= index_bytes);
+
+  value_table_ = &ancillary_data[kDcmSizeInBytes];
   return kTfLiteOk;
 }
 
@@ -101,14 +145,18 @@ T* DecodeStateLut::DecompressToBuffer(void* buffer) {
   TFLITE_DCHECK(compressed_bit_width_ <= kMaxBitWidth);
   TFLITE_DCHECK(compressed_bit_width_ > 0);
 
+  // Optimized unpackers mask the index to 2^bit_width. Only safe when the
+  // per-channel table is at least that large.
+  const bool fast_table =
+      value_table_channel_stride_ >= (1u << compressed_bit_width_);
   if (std::is_same<T, int8_t>::value && compressed_bit_width_ == 4 &&
-      !use_alternate_axis_) {
+      !use_alternate_axis_ && fast_table) {
     DecompressToBufferWidth4_16(static_cast<int8_t*>(buffer));
   } else if (std::is_same<T, int8_t>::value && compressed_bit_width_ == 3 &&
-             !use_alternate_axis_) {
+             !use_alternate_axis_ && fast_table) {
     DecompressToBufferWidth3_32(static_cast<int8_t*>(buffer));
   } else if (std::is_same<T, int8_t>::value && compressed_bit_width_ == 2 &&
-             !use_alternate_axis_) {
+             !use_alternate_axis_ && fast_table) {
     DecompressToBufferWidth2_16(static_cast<int8_t*>(buffer));
   } else {
     DecompressToBufferWidthAny<T>(static_cast<T*>(buffer));
@@ -453,7 +501,11 @@ void DecodeStateLut::DecompressToBufferWidthAny(T* buffer) {
             break;
         }
         current_offset++;
-        *buffer++ = value_table[index];
+        if (index < stride) {
+          *buffer++ = value_table[index];
+        } else {
+          *buffer++ = static_cast<T>(0);
+        }
         value_table += stride;
       }
       count -= num_channels_;
@@ -497,7 +549,11 @@ void DecodeStateLut::DecompressToBufferWidthAny(T* buffer) {
             break;
         }
         current_offset++;
-        *buffer++ = value_table[index];
+        if (index < stride) {
+          *buffer++ = value_table[index];
+        } else {
+          *buffer++ = static_cast<T>(0);
+        }
       }
       value_table += stride;
     }


### PR DESCRIPTION
BUG=none

`DecodeStateLut::Setup` used `NumElements(output)` as the decompress loop bound without checking `input.bytes`, took the value table as `ancillary + 16` without checking `ancillary.bytes`, and stored the DCM stride byte (0–255) without enforcing `kMaxValueTableChannelStride` (128). A structurally valid FlatBuffer that only mismatches those sizes therefore OOBs in `Eval`.

This change rejects those shapes in `Prepare`/`Setup` with `TF_LITE_ENSURE` (TFLM `docs/error_handling_guide.md`: semantic malformation belongs there). Optimized Width2/3/4 unpackers run only when `stride >= 2^bit_width`; otherwise `WidthAny` with `index < stride`. Official LUT tests use `2^n-1` tables, so this does not require `stride >= 2^bit_width`.

New test `decode_lut_bounds_test` fails before the fix (`Prepare` succeeds) and passes after (`kTfLiteError`). Existing `decode_test` and `decode_state_lut_test` still pass.

```text
make -f tensorflow/lite/micro/tools/make/Makefile test_decode_test
make -f tensorflow/lite/micro/tools/make/Makefile test_decode_state_lut_test
make -f tensorflow/lite/micro/tools/make/Makefile test_decode_lut_bounds_test
```
