### PR TITLE
Fix CALL_ONCE subgraph tensor lifetimes

### DIFF
--- a/tensorflow/lite/micro/micro_allocation_info.cc
+++ b/tensorflow/lite/micro/micro_allocation_info.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/memory_helpers.h"
 #include "tensorflow/lite/micro/memory_planner/greedy_memory_planner.h"
 #include "tensorflow/lite/micro/micro_log.h"
+#include "tensorflow/lite/schema/schema_utils.h"
 
 namespace tflite {
 
@@ -59,7 +60,7 @@ TfLiteStatus AllocationInfoBuilder::MarkSubgraphLifetimesIfNecessary(
   int second_subgraph_index = -1;
   const OperatorCode* opcode =
       model_->operator_codes()->Get(op->opcode_index());
-  switch (opcode->builtin_code()) {
+  switch (GetBuiltinCode(opcode)) {
     case BuiltinOperator_IF: {
       first_subgraph_index =
           op->builtin_options_as_IfOptions()->then_subgraph_index();


### PR DESCRIPTION
@tensorflow/micro

The MarkSubgraphLifetimesIfNecessary method used during arena memory planning, was not handling CALL_ONCE subgraphs.  This could result in all tensors of that subgraph to not be assigned any memory by the memory planner.

Currently, CALL_ONCE is primarily used by Keras for resource tensor initialization.  Because resource tensors do not have their memory assigned through the memory planner, no issue resulted.

This PR is a reimplementation of PR #3643

bug=cadence updates