### PR TITLE
Add Xtensa HiFi depthwise conv int8/int16/float32 kernels

### DIFF
--- a/tensorflow/lite/micro/kernels/depthwise_conv.h
+++ b/tensorflow/lite/micro/kernels/depthwise_conv.h
@@ -54,7 +54,7 @@ TfLiteStatus DepthwiseConvPrepare(TfLiteContext* context, TfLiteNode* node);
 // implementation (reference or optimized) must define this function.
 TFLMRegistration Register_DEPTHWISE_CONV_2D();
 
-#if defined(CMSIS_NN)
+#if defined(CMSIS_NN) || defined(XTENSA)
 // Returns a TFLMRegistration struct for kernel variant that only supports
 // int8 activations and int8 weights and uses the latency optimized
 // implementations.
@@ -84,6 +84,14 @@ inline TFLMRegistration Register_DEPTHWISE_CONV_2D_INT4() {
 }
 
 #endif
+
+#if defined(XTENSA)
+TFLMRegistration Register_DEPTHWISE_CONV_2D_FLOAT32();
+#endif
+
+TFLMRegistration Register_DEPTHWISE_CONV_2D_INT8REF();
+TFLMRegistration Register_DEPTHWISE_CONV_2D_INT16REF();
+TFLMRegistration Register_DEPTHWISE_CONV_2D_FLOAT32REF();
 
 }  // namespace tflite
 

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
@@ -52,9 +52,10 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TfLiteTensor* input =
       micro_context->AllocateTempInputTensor(node, kConvInputTensor);
   TF_LITE_ENSURE(context, input != nullptr);
-#ifndef HIFI5
-  // Int16 input is only supported by HIFI5 for now.
-  // So there is no need to prepare the Hifi/Vision kernel for other targets.
+
+  // For int16 input, only fallback to the reference kernel is used
+  // so there is no need to prepare the Vision kernel.
+#if defined(VISION_P6)  
   if (input->type == kTfLiteInt16) {
     micro_context->DeallocateTempTfLiteTensor(input);
     return kTfLiteOk;
@@ -62,9 +63,9 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 #endif
   micro_context->DeallocateTempTfLiteTensor(input);
 
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
   TF_LITE_ENSURE_OK(context, DepthwiseConvPrepareHifi(context, node));
-#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
 
 #if defined(VISION_P6)
   TF_LITE_ENSURE_OK(context, DepthwiseConvPrepareVision(context, node));
@@ -73,73 +74,42 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 }
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
-  TFLITE_DCHECK(node->user_data != nullptr);
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
   TFLITE_DCHECK(node->builtin_data != nullptr);
   const auto& params =
       *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));
-  const auto& op_data =
-      *(reinterpret_cast<XtensaDepthwiseConvOpData*>(node->user_data));
 
   TfLiteEvalTensor* output =
       tflite::micro::GetEvalOutput(context, node, kDepthwiseConvOutputTensor);
+  const TfLiteEvalTensor* bias =
+      (NumInputs(node) == 3)
+          ? tflite::micro::GetEvalInput(context, node, kDepthwiseConvBiasTensor)
+          : nullptr;      
+#endif      
   const TfLiteEvalTensor* input =
       tflite::micro::GetEvalInput(context, node, kDepthwiseConvInputTensor);
   const TfLiteEvalTensor* filter =
       tflite::micro::GetEvalInput(context, node, kDepthwiseConvWeightsTensor);
-  const TfLiteEvalTensor* bias =
-      (NumInputs(node) == 3)
-          ? tflite::micro::GetEvalInput(context, node, kDepthwiseConvBiasTensor)
-          : nullptr;
 
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const auto& op_data =
+      *(reinterpret_cast<XtensaDepthwiseConvOpData*>(node->user_data));
   TfLiteEvalTensor filter_int8 = tflite::micro::MakeUnpackedInt4Tensor(
       context, op_data.reference_op_data.filter_buffer_index, filter);
-
-#ifdef USE_TFLM_COMPRESSION
-
-  MicroContext* micro_context = GetMicroContext(context);
-
-  const CompressionTensorData* filter_comp_td =
-      micro_context->GetTensorCompressionData(node,
-                                              kDepthwiseConvWeightsTensor);
-  const CompressionTensorData* bias_comp_td =
-      micro_context->GetTensorCompressionData(node, kDepthwiseConvBiasTensor);
-
-#endif  // USE_TFLM_COMPRESSION
 
   switch (input->type) {  // Already know in/out types are same.
     case kTfLiteInt8: {
       switch (filter_int8.type) {
         case kTfLiteInt8: {
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
-          DepthwiseConvEvalHifiInt8(context, node, params, op_data, input,
-                                    &filter_int8, bias, output);
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+          return DepthwiseConvEvalInt8Hifi(context, node, params, op_data, input,
+                                &filter_int8, bias, output);
 #elif defined(VISION_P6)
-          DepthwiseConvEvalVision(context, node, params, op_data, input,
+          return DepthwiseConvEvalVision(context, node, params, op_data, input,
                                   &filter_int8, bias, output);
 #else
-          reference_integer_ops::DepthwiseConvPerChannel(
-              DepthwiseConvParamsQuantized(params, op_data.reference_op_data),
-              op_data.reference_op_data.per_channel_output_multiplier,
-              op_data.reference_op_data.per_channel_output_shift,
-              tflite::micro::GetTensorShape(input),
-              tflite::micro::GetTensorData<int8_t>(input),
-              tflite::micro::GetTensorShape(filter),
-#ifdef USE_TFLM_COMPRESSION
-              tflite::micro::GetTensorData<int8_t>(
-                  micro_context, &filter_int8, filter_comp_td,
-                  op_data.reference_op_data.weights_scratch_index),
-              tflite::micro::GetTensorShape(bias),
-              tflite::micro::GetOptionalTensorData<int32_t>(
-                  micro_context, bias, bias_comp_td,
-                  op_data.reference_op_data.bias_scratch_index),
-#else   // USE_TFLM_COMPRESSION
-              tflite::micro::GetTensorData<int8_t>(&filter_int8),
-              tflite::micro::GetTensorShape(bias),
-              tflite::micro::GetOptionalTensorData<int32_t>(bias),
-#endif  // USE_TFLM_COMPRESSION
-              tflite::micro::GetTensorShape(output),
-              tflite::micro::GetTensorData<int8_t>(output));
-#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+          return DepthwiseConvReferenceEvalInt8(context, node);
+#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
           break;
         }
         default:
@@ -152,33 +122,12 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     case kTfLiteInt16: {
       switch (filter->type) {
         case kTfLiteInt8: {
-#if defined(HIFI5)
-          DepthwiseConvEvalHifiInt16(context, node, params, op_data, input,
-                                     filter, bias, output);
-#else
-          reference_integer_ops::DepthwiseConvPerChannel(
-              DepthwiseConvParamsQuantized(params, op_data.reference_op_data),
-              op_data.reference_op_data.per_channel_output_multiplier,
-              op_data.reference_op_data.per_channel_output_shift,
-              tflite::micro::GetTensorShape(input),
-              tflite::micro::GetTensorData<int16_t>(input),
-              tflite::micro::GetTensorShape(filter),
-#ifdef USE_TFLM_COMPRESSION
-              tflite::micro::GetTensorData<int8_t>(
-                  micro_context, &filter_int8, filter_comp_td,
-                  op_data.reference_op_data.weights_scratch_index),
-              tflite::micro::GetTensorShape(bias),
-              tflite::micro::GetOptionalTensorData<int64_t>(
-                  micro_context, bias, bias_comp_td,
-                  op_data.reference_op_data.bias_scratch_index),
-#else   // USE_TFLM_COMPRESSION
-              tflite::micro::GetTensorData<int8_t>(&filter_int8),
-              tflite::micro::GetTensorShape(bias),
-              tflite::micro::GetOptionalTensorData<int64_t>(bias),
-#endif  // USE_TFLM_COMPRESSION
-              tflite::micro::GetTensorShape(output),
-              tflite::micro::GetTensorData<int16_t>(output));
-#endif  // defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+          return DepthwiseConvEvalInt16Hifi(context, node, params, op_data, input,
+                                &filter_int8, bias, output);
+#else          
+          return DepthwiseConvReferenceEvalInt16(context, node);
+#endif              
           break;
         }
         default:
@@ -188,6 +137,15 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           return kTfLiteError;
       }
       break;
+    }
+    case kTfLiteFloat32: {
+#if defined(INCLUDE_FLOAT_OPT) && (defined(HIFI3) || defined(HIFI4) || defined(HIFI5))
+      return DepthwiseConvEvalFloat32Hifi(context, node, params, op_data, input,
+                                &filter_int8, bias, output);
+#else       
+      return DepthwiseConvReferenceEvalFloat32(context, node);
+#endif          
+      break;      
     }
     default:
       MicroPrintf("Type %s (%d) not supported.", TfLiteTypeGetName(input->type),

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_common_xtensa.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_common_xtensa.cc
@@ -1,0 +1,44 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/depthwise_conv.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h"
+
+namespace tflite {
+
+void* DepthwiseConvInitXtensa(TfLiteContext* context, const char* buffer,
+                     size_t length) {
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+  void* data =
+      context->AllocatePersistentBuffer(context, sizeof(XtensaDepthwiseConvOpData));
+  return data;
+}
+
+TfLiteStatus DepthwiseConvPrepareXtensa(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_OK(context, DepthwiseConvPrepare(context, node));
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+  TF_LITE_ENSURE_OK(context, DepthwiseConvPrepareHifi(context, node));
+#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+  return kTfLiteOk;
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_float32_reference.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_float32_reference.cc
@@ -1,0 +1,70 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/portable_tensor_utils.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/depthwiseconv_float.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/padding.h"
+#include "tensorflow/lite/micro/kernels/depthwise_conv.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+
+namespace tflite {
+
+TfLiteStatus DepthwiseConvReferenceEvalFloat32(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  TFLITE_DCHECK(node->builtin_data != nullptr);
+  const auto& params =
+      *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));
+  const OpDataConv& data = *(static_cast<const OpDataConv*>(node->user_data));
+
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kConvOutputTensor);
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kConvInputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kConvWeightsTensor);
+  const TfLiteEvalTensor* bias =
+      (NumInputs(node) == 3)
+          ? tflite::micro::GetEvalInput(context, node, kConvBiasTensor)
+          : nullptr;
+
+   tflite::reference_ops::DepthwiseConv(
+       DepthwiseConvParamsFloat(params, data),
+       tflite::micro::GetTensorShape(input),
+       tflite::micro::GetTensorData<float>(input),
+       tflite::micro::GetTensorShape(filter),
+       tflite::micro::GetTensorData<float>(filter),
+       tflite::micro::GetTensorShape(bias),
+       tflite::micro::GetOptionalTensorData<float>(bias),
+       tflite::micro::GetTensorShape(output),
+       tflite::micro::GetTensorData<float>(output));
+
+  return kTfLiteOk;
+}
+
+// TODO(b/189981943): This variant can be used for a smaller binary
+// since the optimized conv implementation currently adds a lot to
+// the binary size (~30KB to text section).
+TFLMRegistration Register_DEPTHWISE_CONV_2D_FLOAT32REF() {
+  return tflite::micro::RegisterOp(ConvInit, ConvPrepare,
+                                   DepthwiseConvReferenceEvalFloat32);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc
@@ -28,7 +28,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h"
 
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
 namespace tflite {
 TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
                                       TfLiteNode* node) {
@@ -69,14 +69,59 @@ TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
   const int pad_height = data->reference_op_data.padding.height;
 
   int required_scratch = 0;
-  // Dilation is currently not supported on HiFi 4 NN Library
+
   if ((params.dilation_width_factor == 1) &&
       (params.dilation_height_factor == 1)) {
-    required_scratch = xa_nn_conv2d_depthwise_getsize(
-        input_height, input_width, input_depth, filter_height, filter_width,
-        depth_multiplier, stride_width, stride_height, pad_width, pad_height,
-        output_height, output_width, PREC_ASYM8S, 0 /* NHWC */);
-    TF_LITE_ENSURE(context, required_scratch > 0);
+        if(input->type == kTfLiteInt8){           
+        required_scratch = xa_nn_conv2d_depthwise_getsize(
+            input_height, input_width, input_depth, filter_height, filter_width,
+            depth_multiplier, stride_width, stride_height, pad_width, pad_height,
+            output_height, output_width, PREC_ASYM8S, 0 /* NHWC */);
+        }
+        else if(input->type == kTfLiteInt16){
+        required_scratch = xa_nn_conv2d_depthwise_getsize(
+            input_height, input_width, input_depth, filter_height, filter_width,
+            depth_multiplier, stride_width, stride_height, pad_width, pad_height,
+            output_height, output_width, PREC_SYM16S, 0 /* NHWC */);
+        }
+#if defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
+        else if(input->type == kTfLiteFloat32){
+        required_scratch = xa_nn_conv2d_depthwise_getsize(
+            input_height, input_width, input_depth, filter_height, filter_width,
+            depth_multiplier, stride_width, stride_height, pad_width, pad_height,
+            output_height, output_width, PREC_F32, 0 /* NHWC */);
+        }
+#endif       
+#ifndef HIFI_IQ
+        TF_LITE_ENSURE(context, required_scratch > 0);
+#endif       
+  }
+  else{
+    int dilation_height = params.dilation_height_factor;
+    int dilation_width  = params.dilation_width_factor; 
+    if(input->type == kTfLiteInt8){
+      required_scratch = xa_nn_dilated_conv2d_depthwise_getsize(
+      input_height, input_width, input_depth, filter_height, filter_width,
+      depth_multiplier, dilation_height, dilation_width, stride_width, stride_height, pad_width, pad_height,
+      output_height, output_width, PREC_ASYM8S, 0 /* NHWC */);
+      TF_LITE_ENSURE(context, required_scratch > 0);        
+    }  
+    else if(input->type == kTfLiteInt16){
+      required_scratch = xa_nn_dilated_conv2d_depthwise_getsize(
+      input_height, input_width, input_depth, filter_height, filter_width,
+      depth_multiplier, dilation_height, dilation_width, stride_width, stride_height, pad_width, pad_height,
+      output_height, output_width, PREC_SYM16S, 0 /* NHWC */);
+      TF_LITE_ENSURE(context, required_scratch > 0);
+    }
+#if defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
+        else if(input->type == kTfLiteFloat32){
+            required_scratch = xa_nn_dilated_conv2d_depthwise_getsize(
+            input_height, input_width, input_depth, filter_height, filter_width,
+            depth_multiplier, dilation_height, dilation_width, stride_width, stride_height, pad_width, pad_height,
+            output_height, output_width, PREC_F32, 0 /* NHWC */);
+            TF_LITE_ENSURE(context, required_scratch > 0);           
+        }
+#endif         
   }
   TF_LITE_ENSURE_OK(
       context, context->RequestScratchBufferInArena(
@@ -88,13 +133,13 @@ TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context,
   return kTfLiteOk;
 }
 
-TfLiteStatus DepthwiseConvEvalHifiInt8(TfLiteContext* context, TfLiteNode* node,
-                                       const TfLiteDepthwiseConvParams& params,
-                                       const XtensaDepthwiseConvOpData& data,
-                                       const TfLiteEvalTensor* input,
-                                       const TfLiteEvalTensor* filter,
-                                       const TfLiteEvalTensor* bias,
-                                       TfLiteEvalTensor* output) {
+TfLiteStatus DepthwiseConvEvalInt8Hifi(TfLiteContext* context, TfLiteNode* node,
+                                   const TfLiteDepthwiseConvParams& params,
+                                   const XtensaDepthwiseConvOpData& data,
+                                   const TfLiteEvalTensor* input,
+                                   const TfLiteEvalTensor* filter,
+                                   const TfLiteEvalTensor* bias,
+                                   TfLiteEvalTensor* output) {
 #ifdef USE_TFLM_COMPRESSION
 
   MicroContext* micro_context = GetMicroContext(context);
@@ -107,10 +152,8 @@ TfLiteStatus DepthwiseConvEvalHifiInt8(TfLiteContext* context, TfLiteNode* node,
 
 #endif  // USE_TFLM_COMPRESSION
 
-  // If dilation is not required use the optimized NN Library kernel.
-  // Otherwise call the reference implementation.
   if ((params.dilation_width_factor == 1) &&
-      (params.dilation_height_factor == 1) && bias != nullptr) {
+      (params.dilation_height_factor == 1)) {
     const int stride_width = params.stride_width;
     const int stride_height = params.stride_height;
     const int pad_width = data.reference_op_data.padding.width;
@@ -165,7 +208,7 @@ TfLiteStatus DepthwiseConvEvalHifiInt8(TfLiteContext* context, TfLiteNode* node,
     for (int i = 0; i < batches; i++) {
       TF_LITE_ENSURE_EQ(
           context,
-          xa_nn_conv2d_depthwise_per_chan_sym8sxasym8s(
+          xa_nn_conv2d_depthwise_v2_per_chan_sym8sxasym8s(
               &output_data[i * output_height * output_width * output_depth],
               filter_data,
               &input_data[i * input_height * input_width * input_depth],
@@ -176,54 +219,97 @@ TfLiteStatus DepthwiseConvEvalHifiInt8(TfLiteContext* context, TfLiteNode* node,
               data.reference_op_data.per_channel_output_multiplier,
               data.reference_op_data.per_channel_output_shift,
               data.reference_op_data.output_zero_point, input_data_format,
-              output_data_format, p_scratch),
+              output_data_format, p_scratch,
+              output_activation_min, output_activation_max, NULL),
           0);
     }
 
-    int out_length = batches * output_height * output_width * output_depth;
-    TF_LITE_ENSURE_EQ(context,
-                      xa_nn_vec_activation_min_max_8_8(
-                          output_data, output_data, output_activation_min,
-                          output_activation_max, out_length),
-                      0);
-
     return kTfLiteOk;
   }
+  else{
+    const int stride_width = params.stride_width;
+    const int stride_height = params.stride_height;
+    const int pad_width = data.reference_op_data.padding.width;
+    const int pad_height = data.reference_op_data.padding.height;
+    const int depth_multiplier = params.depth_multiplier;
+    const int dilated_width = params.dilation_width_factor;
+    const int dilated_height = params.dilation_height_factor;    
+    const int32_t output_activation_min =
+        data.reference_op_data.output_activation_min;
+    const int32_t output_activation_max =
+        data.reference_op_data.output_activation_max;
+    TFLITE_DCHECK_LE(output_activation_min, output_activation_max);
 
-  reference_integer_ops::DepthwiseConvPerChannel(
-      DepthwiseConvParamsQuantized(params, data.reference_op_data),
-      data.reference_op_data.per_channel_output_multiplier,
-      data.reference_op_data.per_channel_output_shift,
-      tflite::micro::GetTensorShape(input),
-      tflite::micro::GetTensorData<int8_t>(input),
-      tflite::micro::GetTensorShape(filter),
+    const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+    const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
+    const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+    const RuntimeShape& bias_shape = tflite::micro::GetTensorShape(bias);
+    TFLITE_DCHECK_EQ(input_shape.DimensionsCount(), 4);
+    TFLITE_DCHECK_EQ(filter_shape.DimensionsCount(), 4);
+    TFLITE_DCHECK_EQ(output_shape.DimensionsCount(), 4);
+
+    const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+    const int output_depth = MatchingDim(filter_shape, 3, output_shape, 3);
+    const int input_height = input_shape.Dims(1);
+    const int input_width = input_shape.Dims(2);
+    const int input_depth = input_shape.Dims(3);
+    const int filter_height = filter_shape.Dims(1);
+    const int filter_width = filter_shape.Dims(2);
+    const int output_height = output_shape.Dims(1);
+    const int output_width = output_shape.Dims(2);
+    TFLITE_DCHECK_EQ(output_depth, input_depth * depth_multiplier);
+    TFLITE_DCHECK_EQ(bias_shape.FlatSize(), output_depth);
+
+    const int8_t* input_data = tflite::micro::GetTensorData<int8_t>(input);
 #ifdef USE_TFLM_COMPRESSION
-      tflite::micro::GetTensorData<int8_t>(
-          micro_context, filter, filter_comp_td,
-          data.reference_op_data.weights_scratch_index),
-      tflite::micro::GetTensorShape(bias),
-      tflite::micro::GetOptionalTensorData<int32_t>(
-          micro_context, bias, bias_comp_td,
-          data.reference_op_data.bias_scratch_index),
+    const int8_t* filter_data = tflite::micro::GetTensorData<int8_t>(
+        micro_context, filter, filter_comp_td,
+        data.reference_op_data.weights_scratch_index);
+    const int32_t* bias_data = tflite::micro::GetTensorData<int32_t>(
+        micro_context, bias, bias_comp_td,
+        data.reference_op_data.bias_scratch_index);
 #else   // USE_TFLM_COMPRESSION
-      tflite::micro::GetTensorData<int8_t>(filter),
-      tflite::micro::GetTensorShape(bias),
-      tflite::micro::GetOptionalTensorData<int32_t>(bias),
+    const int8_t* filter_data = tflite::micro::GetTensorData<int8_t>(filter);
+    const int32_t* bias_data = tflite::micro::GetTensorData<int32_t>(bias);
 #endif  // USE_TFLM_COMPRESSION
-      tflite::micro::GetTensorShape(output),
-      tflite::micro::GetTensorData<int8_t>(output));
+    int8_t* output_data = tflite::micro::GetTensorData<int8_t>(output);
 
-  return kTfLiteOk;
+    int32_t input_data_format = 0;
+    int32_t output_data_format = 0;
+
+    uint8_t* p_scratch = static_cast<uint8_t*>(
+        context->GetScratchBuffer(context, data.scratch_tensor_index));
+
+    for (int i = 0; i < batches; i++) {
+      TF_LITE_ENSURE_EQ(
+          context,
+          xa_nn_dilated_conv2d_depthwise_v2_per_chan_sym8sxasym8s(
+              &output_data[i * output_height * output_width * output_depth],
+              filter_data,
+              &input_data[i * input_height * input_width * input_depth],
+              bias_data, input_height, input_width, input_depth, filter_height,
+              filter_width, depth_multiplier, dilated_height, dilated_width, stride_width, stride_height,
+              pad_width, pad_height, output_height, output_width,
+              -data.reference_op_data.input_zero_point,
+              data.reference_op_data.per_channel_output_multiplier,
+              data.reference_op_data.per_channel_output_shift,
+              data.reference_op_data.output_zero_point, input_data_format,
+              output_data_format, p_scratch,
+              output_activation_min, output_activation_max, NULL),
+          0);
+    }
+
+    return kTfLiteOk;     
+  }
 }
 
-TfLiteStatus DepthwiseConvEvalHifiInt16(TfLiteContext* context,
-                                        TfLiteNode* node,
-                                        const TfLiteDepthwiseConvParams& params,
-                                        const XtensaDepthwiseConvOpData& data,
-                                        const TfLiteEvalTensor* input,
-                                        const TfLiteEvalTensor* filter,
-                                        const TfLiteEvalTensor* bias,
-                                        TfLiteEvalTensor* output) {
+TfLiteStatus DepthwiseConvEvalInt16Hifi(TfLiteContext* context, TfLiteNode* node,
+                                   const TfLiteDepthwiseConvParams& params,
+                                   const XtensaDepthwiseConvOpData& data,
+                                   const TfLiteEvalTensor* input,
+                                   const TfLiteEvalTensor* filter,
+                                   const TfLiteEvalTensor* bias,
+                                   TfLiteEvalTensor* output) {
 #ifdef USE_TFLM_COMPRESSION
 
   MicroContext* micro_context = GetMicroContext(context);
@@ -236,15 +322,88 @@ TfLiteStatus DepthwiseConvEvalHifiInt16(TfLiteContext* context,
 
 #endif  // USE_TFLM_COMPRESSION
 
-  // If dilation is not required use the optimized NN Library kernel.
-  // Otherwise call the reference implementation.
   if ((params.dilation_width_factor == 1) &&
-      (params.dilation_height_factor == 1) && bias != nullptr) {
+      (params.dilation_height_factor == 1)) {
     const int stride_width = params.stride_width;
     const int stride_height = params.stride_height;
     const int pad_width = data.reference_op_data.padding.width;
     const int pad_height = data.reference_op_data.padding.height;
     const int depth_multiplier = params.depth_multiplier;
+    const int32_t output_activation_min =
+        data.reference_op_data.output_activation_min;
+    const int32_t output_activation_max =
+        data.reference_op_data.output_activation_max;
+    TFLITE_DCHECK_LE(output_activation_min, output_activation_max);
+
+    const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+    const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
+    const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+    const RuntimeShape& bias_shape = tflite::micro::GetTensorShape(bias);
+    TFLITE_DCHECK_EQ(input_shape.DimensionsCount(), 4);
+    TFLITE_DCHECK_EQ(filter_shape.DimensionsCount(), 4);
+    TFLITE_DCHECK_EQ(output_shape.DimensionsCount(), 4);
+
+    const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+    const int output_depth = MatchingDim(filter_shape, 3, output_shape, 3);
+    const int input_height = input_shape.Dims(1);
+    const int input_width = input_shape.Dims(2);
+    const int input_depth = input_shape.Dims(3);
+    const int filter_height = filter_shape.Dims(1);
+    const int filter_width = filter_shape.Dims(2);
+    const int output_height = output_shape.Dims(1);
+    const int output_width = output_shape.Dims(2);
+    TFLITE_DCHECK_EQ(output_depth, input_depth * depth_multiplier);
+    TFLITE_DCHECK_EQ(bias_shape.FlatSize(), output_depth);
+
+    const int16_t* input_data = tflite::micro::GetTensorData<int16_t>(input);
+#ifdef USE_TFLM_COMPRESSION
+    const int8_t* filter_data = tflite::micro::GetTensorData<int8_t>(
+        micro_context, filter, filter_comp_td,
+        data.reference_op_data.weights_scratch_index);
+    const int64_t* bias_data = tflite::micro::GetTensorData<int64_t>(
+        micro_context, bias, bias_comp_td,
+        data.reference_op_data.bias_scratch_index);
+#else   // USE_TFLM_COMPRESSION
+    const int8_t* filter_data = tflite::micro::GetTensorData<int8_t>(filter);
+    const int64_t* bias_data = tflite::micro::GetTensorData<int64_t>(bias);
+#endif   // USE_TFLM_COMPRESSION
+    int16_t* output_data = tflite::micro::GetTensorData<int16_t>(output);
+
+    int32_t input_data_format = 0;
+    int32_t output_data_format = 0;
+
+    void* p_scratch = static_cast<void*>(
+        context->GetScratchBuffer(context, data.scratch_tensor_index));
+
+    for (int i = 0; i < batches; i++) {
+      TF_LITE_ENSURE_EQ(
+          context,
+          xa_nn_conv2d_depthwise_v2_per_chan_sym8sxsym16s(
+              &output_data[i * output_height * output_width * output_depth],
+              filter_data,
+              &input_data[i * input_height * input_width * input_depth],
+              bias_data, input_height, input_width, input_depth, filter_height,
+              filter_width, depth_multiplier, stride_width, stride_height,
+              pad_width, pad_height, output_height, output_width,
+              -data.reference_op_data.input_zero_point,
+              data.reference_op_data.per_channel_output_multiplier,
+              data.reference_op_data.per_channel_output_shift,
+              data.reference_op_data.output_zero_point, input_data_format,
+              output_data_format, p_scratch,
+              output_activation_min, output_activation_max, NULL),
+          0);
+    }
+
+    return kTfLiteOk;
+  }
+  else{
+    const int stride_width = params.stride_width;
+    const int stride_height = params.stride_height;
+    const int pad_width = data.reference_op_data.padding.width;
+    const int pad_height = data.reference_op_data.padding.height;
+    const int depth_multiplier = params.depth_multiplier;
+    const int dilated_width = params.dilation_width_factor;
+    const int dilated_height = params.dilation_height_factor;
     const int32_t output_activation_min =
         data.reference_op_data.output_activation_min;
     const int32_t output_activation_max =
@@ -288,62 +447,173 @@ TfLiteStatus DepthwiseConvEvalHifiInt16(TfLiteContext* context,
     int32_t input_data_format = 0;
     int32_t output_data_format = 0;
 
-    uint8_t* p_scratch = static_cast<uint8_t*>(
+    void* p_scratch = static_cast<void*>(
         context->GetScratchBuffer(context, data.scratch_tensor_index));
 
     for (int i = 0; i < batches; i++) {
       TF_LITE_ENSURE_EQ(
           context,
-          xa_nn_conv2d_depthwise_per_chan_sym8sxsym16s(
+          xa_nn_dilated_conv2d_depthwise_v2_per_chan_sym8sxsym16s(
               &output_data[i * output_height * output_width * output_depth],
               filter_data,
               &input_data[i * input_height * input_width * input_depth],
               bias_data, input_height, input_width, input_depth, filter_height,
-              filter_width, depth_multiplier, stride_width, stride_height,
+              filter_width, depth_multiplier, dilated_height, dilated_width, stride_width, stride_height,
               pad_width, pad_height, output_height, output_width,
               -data.reference_op_data.input_zero_point,
               data.reference_op_data.per_channel_output_multiplier,
               data.reference_op_data.per_channel_output_shift,
               data.reference_op_data.output_zero_point, input_data_format,
-              output_data_format, p_scratch),
+              output_data_format, p_scratch,
+              output_activation_min, output_activation_max, NULL),
           0);
     }
 
-    int out_length = batches * output_height * output_width * output_depth;
-    TF_LITE_ENSURE_EQ(context,
-                      xa_nn_vec_activation_min_max_16_16(
-                          output_data, output_data, output_activation_min,
-                          output_activation_max, out_length),
-                      0);
-
     return kTfLiteOk;
   }
-
-  reference_integer_ops::DepthwiseConvPerChannel(
-      DepthwiseConvParamsQuantized(params, data.reference_op_data),
-      data.reference_op_data.per_channel_output_multiplier,
-      data.reference_op_data.per_channel_output_shift,
-      tflite::micro::GetTensorShape(input),
-      tflite::micro::GetTensorData<int16_t>(input),
-      tflite::micro::GetTensorShape(filter),
-#ifdef USE_TFLM_COMPRESSION
-      tflite::micro::GetTensorData<int8_t>(
-          micro_context, filter, filter_comp_td,
-          data.reference_op_data.weights_scratch_index),
-      tflite::micro::GetTensorShape(bias),
-      tflite::micro::GetOptionalTensorData<int64_t>(
-          micro_context, bias, bias_comp_td,
-          data.reference_op_data.bias_scratch_index),
-#else   // USE_TFLM_COMPRESSION
-      tflite::micro::GetTensorData<int8_t>(filter),
-      tflite::micro::GetTensorShape(bias),
-      tflite::micro::GetOptionalTensorData<int64_t>(bias),
-#endif  // USE_TFLM_COMPRESSION
-      tflite::micro::GetTensorShape(output),
-      tflite::micro::GetTensorData<int16_t>(output));
-
-  return kTfLiteOk;
 }
 
+#if defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
+TfLiteStatus DepthwiseConvEvalFloat32Hifi(TfLiteContext* context, TfLiteNode* node,
+                                   const TfLiteDepthwiseConvParams& params,
+                                   const XtensaDepthwiseConvOpData& data,
+                                   const TfLiteEvalTensor* input,
+                                   const TfLiteEvalTensor* filter,
+                                   const TfLiteEvalTensor* bias,
+                                   TfLiteEvalTensor* output) {
+#ifdef USE_TFLM_COMPRESSION
+
+  MicroContext* micro_context = GetMicroContext(context);
+
+  const CompressionTensorData* filter_comp_td =
+      micro_context->GetTensorCompressionData(node,
+                                              kDepthwiseConvWeightsTensor);
+  const CompressionTensorData* bias_comp_td =
+      micro_context->GetTensorCompressionData(node, kDepthwiseConvBiasTensor);
+
+#endif  // USE_TFLM_COMPRESSION
+  // If dilation is not required use the optimized NN Library kernel.
+  // Otherwise call the reference implementation.
+  if ((params.dilation_width_factor == 1) &&
+      (params.dilation_height_factor == 1)) {
+    const int stride_width = params.stride_width;
+    const int stride_height = params.stride_height;
+    const int pad_width = data.reference_op_data.padding.width;
+    const int pad_height = data.reference_op_data.padding.height;
+    const int depth_multiplier = params.depth_multiplier;
+
+    const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+    const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
+    const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+    const RuntimeShape& bias_shape = tflite::micro::GetTensorShape(bias);
+    TFLITE_DCHECK_EQ(input_shape.DimensionsCount(), 4);
+    TFLITE_DCHECK_EQ(filter_shape.DimensionsCount(), 4);
+    TFLITE_DCHECK_EQ(output_shape.DimensionsCount(), 4);
+
+    const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+    const int output_depth = MatchingDim(filter_shape, 3, output_shape, 3);
+    const int input_height = input_shape.Dims(1);
+    const int input_width = input_shape.Dims(2);
+    const int input_depth = input_shape.Dims(3);
+    const int filter_height = filter_shape.Dims(1);
+    const int filter_width = filter_shape.Dims(2);
+    const int output_height = output_shape.Dims(1);
+    const int output_width = output_shape.Dims(2);
+    TFLITE_DCHECK_EQ(output_depth, input_depth * depth_multiplier);
+    TFLITE_DCHECK_EQ(bias_shape.FlatSize(), output_depth);
+
+    const float32_t* input_data = tflite::micro::GetTensorData<float32_t>(input);
+#ifdef USE_TFLM_COMPRESSION
+    const float32_t* filter_data = tflite::micro::GetTensorData<float32_t>(
+        micro_context, filter, filter_comp_td,
+        data.reference_op_data.weights_scratch_index);
+    const float32_t* bias_data = tflite::micro::GetTensorData<float32_t>(
+        micro_context, bias, bias_comp_td,
+        data.reference_op_data.bias_scratch_index);
+#else   // USE_TFLM_COMPRESSION
+    const float32_t* filter_data = tflite::micro::GetTensorData<float32_t>(filter);
+    const float32_t* bias_data = tflite::micro::GetTensorData<float32_t>(bias);
+#endif  // USE_TFLM_COMPRESSION
+    float32_t* output_data = tflite::micro::GetTensorData<float32_t>(output);
+
+    int32_t input_data_format = 0;
+    int32_t output_data_format = 0;
+
+    void* p_scratch = static_cast<void*>(
+        context->GetScratchBuffer(context, data.scratch_tensor_index));
+
+    for (int i = 0; i < batches; i++) {
+      TF_LITE_ENSURE_EQ(
+          context,
+          xa_nn_conv2d_depthwise_f32(
+              &output_data[i * output_height * output_width * output_depth],
+              filter_data,
+              &input_data[i * input_height * input_width * input_depth],
+              bias_data, input_height, input_width, input_depth, filter_height,
+              filter_width, depth_multiplier, stride_width, stride_height,
+              pad_width, pad_height, output_height, output_width, input_data_format,
+              output_data_format, p_scratch),
+          0);
+    }
+    return kTfLiteOk;
+  }
+  else{
+    const int stride_width = params.stride_width;
+    const int stride_height = params.stride_height;
+    const int pad_width = data.reference_op_data.padding.width;
+    const int pad_height = data.reference_op_data.padding.height;
+    const int depth_multiplier = params.depth_multiplier;
+    const int dilated_width = params.dilation_width_factor;
+    const int dilated_height = params.dilation_height_factor;    
+
+    const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+    const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
+    const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+    const RuntimeShape& bias_shape = tflite::micro::GetTensorShape(bias);
+    TFLITE_DCHECK_EQ(input_shape.DimensionsCount(), 4);
+    TFLITE_DCHECK_EQ(filter_shape.DimensionsCount(), 4);
+    TFLITE_DCHECK_EQ(output_shape.DimensionsCount(), 4);
+
+    const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+    const int output_depth = MatchingDim(filter_shape, 3, output_shape, 3);
+    const int input_height = input_shape.Dims(1);
+    const int input_width = input_shape.Dims(2);
+    const int input_depth = input_shape.Dims(3);
+    const int filter_height = filter_shape.Dims(1);
+    const int filter_width = filter_shape.Dims(2);
+    const int output_height = output_shape.Dims(1);
+    const int output_width = output_shape.Dims(2);
+    TFLITE_DCHECK_EQ(output_depth, input_depth * depth_multiplier);
+    TFLITE_DCHECK_EQ(bias_shape.FlatSize(), output_depth);
+
+    const float32_t* input_data = tflite::micro::GetTensorData<float32_t>(input);
+    const float32_t* filter_data = tflite::micro::GetTensorData<float32_t>(filter);
+    const float32_t* bias_data = tflite::micro::GetTensorData<float32_t>(bias);
+    float32_t* output_data = tflite::micro::GetTensorData<float32_t>(output);
+
+    int32_t input_data_format = 0;
+    int32_t output_data_format = 0;
+
+    void* p_scratch = static_cast<void*>(
+        context->GetScratchBuffer(context, data.scratch_tensor_index));
+
+    for (int i = 0; i < batches; i++) {
+      TF_LITE_ENSURE_EQ(
+          context,
+          xa_nn_dilated_conv2d_depthwise_f32(
+              &output_data[i * output_height * output_width * output_depth],
+              filter_data,
+              &input_data[i * input_height * input_width * input_depth],
+              bias_data, input_height, input_width, input_depth, filter_height,
+              filter_width, depth_multiplier, dilated_height, dilated_width, stride_width, stride_height,
+              pad_width, pad_height, output_height, output_width, input_data_format,
+              output_data_format, p_scratch),
+          0);
+    }
+    return kTfLiteOk;     
+  }
+}
+#endif
+
 }  // namespace tflite
-#endif  // defined(HIFI3) ||defined(HIFI4) || defined(HIFI5)
+#endif  // defined(HIFI3) ||defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int16_reference.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int16_reference.cc
@@ -1,0 +1,70 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/portable_tensor_utils.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/integer_ops/depthwise_conv.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/padding.h"
+#include "tensorflow/lite/micro/kernels/depthwise_conv.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+
+namespace tflite {
+
+TfLiteStatus DepthwiseConvReferenceEvalInt16(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  TFLITE_DCHECK(node->builtin_data != nullptr);
+  const auto& params =
+      *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));
+  const OpDataConv& data = *(static_cast<const OpDataConv*>(node->user_data));
+
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kConvOutputTensor);
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kConvInputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kConvWeightsTensor);
+  const TfLiteEvalTensor* bias =
+      (NumInputs(node) == 3)
+          ? tflite::micro::GetEvalInput(context, node, kConvBiasTensor)
+          : nullptr;
+
+   reference_integer_ops::DepthwiseConvPerChannel(
+       DepthwiseConvParamsQuantized(params, data),
+       data.per_channel_output_multiplier, data.per_channel_output_shift,
+       tflite::micro::GetTensorShape(input),
+       tflite::micro::GetTensorData<int16_t>(input),
+       tflite::micro::GetTensorShape(filter),
+       tflite::micro::GetTensorData<int8_t>(filter),
+       tflite::micro::GetTensorShape(bias),
+       tflite::micro::GetOptionalTensorData<int64_t>(bias),
+       tflite::micro::GetTensorShape(output),
+       tflite::micro::GetTensorData<int16_t>(output));
+  return kTfLiteOk;
+}
+
+// TODO(b/189981943): This variant can be used for a smaller binary
+// since the optimized conv implementation currently adds a lot to
+// the binary size (~30KB to text section).
+TFLMRegistration Register_DEPTHWISE_CONV_2D_INT16REF() {
+  return tflite::micro::RegisterOp(ConvInit, ConvPrepare,
+                                   DepthwiseConvReferenceEvalInt16);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_int16_float32.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_int16_float32.cc
@@ -1,0 +1,113 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h"
+
+namespace tflite {
+namespace {
+
+TfLiteStatus EvalInt8(TfLiteContext* context, TfLiteNode* node) {
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ) 
+  const auto& op_data = *(reinterpret_cast<XtensaDepthwiseConvOpData*>(node->user_data));
+  const auto& params =
+      *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));
+
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kConvInputTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kConvOutputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kConvWeightsTensor);
+  const TfLiteEvalTensor* bias =
+      tflite::micro::GetEvalInput(context, node, kConvBiasTensor);
+
+  TfLiteEvalTensor filter_int8 = tflite::micro::MakeUnpackedInt4Tensor(
+      context, op_data.reference_op_data.filter_buffer_index, filter);
+
+  return DepthwiseConvEvalInt8Hifi(context, node, params, op_data, input, &filter_int8, bias,
+                          output);
+#else
+  return DepthwiseConvReferenceEvalInt8(context, node);
+#endif
+}
+
+TfLiteStatus EvalInt16(TfLiteContext* context, TfLiteNode* node) {
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+  const auto& op_data = *(reinterpret_cast<XtensaDepthwiseConvOpData*>(node->user_data));
+  const auto& params =
+      *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));
+
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kConvInputTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kConvOutputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kConvWeightsTensor);
+  const TfLiteEvalTensor* bias =
+      tflite::micro::GetEvalInput(context, node, kConvBiasTensor);
+
+  return DepthwiseConvEvalInt16Hifi(context, node, params, op_data, input, filter, bias,
+                           output);
+#else
+  return DepthwiseConvReferenceEvalInt16(context, node);
+#endif
+}
+
+TfLiteStatus EvalFloat32(TfLiteContext* context, TfLiteNode* node) {
+#if defined(INCLUDE_FLOAT_OPT) && (defined(HIFI3) || defined(HIFI4) || defined(HIFI5))
+  const auto& op_data = *(reinterpret_cast<XtensaDepthwiseConvOpData*>(node->user_data));
+  const auto& params =
+      *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));
+
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kConvInputTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kConvOutputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kConvWeightsTensor);
+  const TfLiteEvalTensor* bias =
+      tflite::micro::GetEvalInput(context, node, kConvBiasTensor);
+
+  return DepthwiseConvEvalFloat32Hifi(context, node, params, op_data, input, filter, bias,
+                           output);
+#else
+  return DepthwiseConvReferenceEvalFloat32(context, node);
+#endif
+}
+
+}  // namespace
+
+TFLMRegistration Register_DEPTHWISE_CONV_2D_INT8() {
+  return tflite::micro::RegisterOp(DepthwiseConvInitXtensa, DepthwiseConvPrepareXtensa, EvalInt8);
+}
+
+TFLMRegistration Register_DEPTHWISE_CONV_2D_INT16() {
+  return tflite::micro::RegisterOp(DepthwiseConvInitXtensa, DepthwiseConvPrepareXtensa,
+                                   EvalInt16);
+}
+
+TFLMRegistration Register_DEPTHWISE_CONV_2D_FLOAT32() {
+  return tflite::micro::RegisterOp(DepthwiseConvInitXtensa, DepthwiseConvPrepareXtensa,
+                                   EvalFloat32);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_reference.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_reference.cc
@@ -1,0 +1,83 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/portable_tensor_utils.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/integer_ops/depthwise_conv.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/padding.h"
+#include "tensorflow/lite/micro/kernels/depthwise_conv.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+
+namespace tflite {
+
+TfLiteStatus DepthwiseConvReferenceEvalInt8(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  TFLITE_DCHECK(node->builtin_data != nullptr);
+  const auto& params =
+      *(reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data));
+  const auto& op_data = *(reinterpret_cast<OpDataConv*>(node->user_data));
+  const OpDataConv& data = *(static_cast<const OpDataConv*>(node->user_data));
+
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kConvOutputTensor);
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kConvInputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kConvWeightsTensor);
+  const TfLiteEvalTensor* bias =
+      (NumInputs(node) == 3)
+          ? tflite::micro::GetEvalInput(context, node, kConvBiasTensor)
+          : nullptr;
+
+  const int8_t* filter_data;
+  if (filter->type == kTfLiteInt4) {
+    int8_t* unpacked_filter_data = static_cast<int8_t*>(
+        context->GetScratchBuffer(context, op_data.filter_buffer_index));
+    tflite::tensor_utils::UnpackDenseInt4IntoInt8(
+        tflite::micro::GetTensorData<int8_t>(filter),
+        tflite::micro::GetTensorShape(filter).FlatSize(), unpacked_filter_data);
+    filter_data = unpacked_filter_data;
+  } else {
+    filter_data = tflite::micro::GetTensorData<int8_t>(filter);
+  }
+
+  reference_integer_ops::DepthwiseConvPerChannel(
+      DepthwiseConvParamsQuantized(params, data),
+      data.per_channel_output_multiplier, data.per_channel_output_shift,
+      tflite::micro::GetTensorShape(input),
+      tflite::micro::GetTensorData<int8_t>(input),
+      tflite::micro::GetTensorShape(filter), filter_data,
+      tflite::micro::GetTensorShape(bias),
+      tflite::micro::GetOptionalTensorData<int32_t>(bias),
+      tflite::micro::GetTensorShape(output),
+      tflite::micro::GetTensorData<int8_t>(output));
+
+  return kTfLiteOk;
+}
+
+// TODO(b/189981943): This variant can be used for a smaller binary
+// since the optimized conv implementation currently adds a lot to
+// the binary size (~30KB to text section).
+TFLMRegistration Register_DEPTHWISE_CONV_2D_INT8REF() {
+  return tflite::micro::RegisterOp(ConvInit, ConvPrepare,
+                                   DepthwiseConvReferenceEvalInt8);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_depthwise_conv.h
@@ -25,7 +25,7 @@ namespace tflite {
 struct XtensaDepthwiseConvOpData {
   OpDataConv reference_op_data;
 
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
   int scratch_tensor_index;
 #endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
 
@@ -39,29 +39,42 @@ struct XtensaDepthwiseConvOpData {
 #endif  // VISION_P6
 };
 
-#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+#if defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
 TfLiteStatus DepthwiseConvPrepareHifi(TfLiteContext* context, TfLiteNode* node);
 
-TfLiteStatus DepthwiseConvEvalHifiInt8(TfLiteContext* context, TfLiteNode* node,
-                                       const TfLiteDepthwiseConvParams& params,
-                                       const XtensaDepthwiseConvOpData& data,
-                                       const TfLiteEvalTensor* input,
-                                       const TfLiteEvalTensor* filter,
-                                       const TfLiteEvalTensor* bias,
-                                       TfLiteEvalTensor* output);
+TfLiteStatus DepthwiseConvEvalInt8Hifi(TfLiteContext* context, TfLiteNode* node,
+                                   const TfLiteDepthwiseConvParams& params,
+                                   const XtensaDepthwiseConvOpData& data,
+                                   const TfLiteEvalTensor* input,
+                                   const TfLiteEvalTensor* filter,
+                                   const TfLiteEvalTensor* bias,
+                                   TfLiteEvalTensor* output);
 
-TfLiteStatus DepthwiseConvEvalHifiInt16(TfLiteContext* context,
-                                        TfLiteNode* node,
-                                        const TfLiteDepthwiseConvParams& params,
-                                        const XtensaDepthwiseConvOpData& data,
-                                        const TfLiteEvalTensor* input,
-                                        const TfLiteEvalTensor* filter,
-                                        const TfLiteEvalTensor* bias,
-                                        TfLiteEvalTensor* output);
+TfLiteStatus DepthwiseConvEvalInt16Hifi(TfLiteContext* context, TfLiteNode* node,
+                                   const TfLiteDepthwiseConvParams& params,
+                                   const XtensaDepthwiseConvOpData& data,
+                                   const TfLiteEvalTensor* input,
+                                   const TfLiteEvalTensor* filter,
+                                   const TfLiteEvalTensor* bias,
+                                   TfLiteEvalTensor* output);
+
+#if defined(INCLUDE_FLOAT_OPT) && !(defined(HIFI_IQ))
+TfLiteStatus DepthwiseConvEvalFloat32Hifi(TfLiteContext* context, TfLiteNode* node,
+                                   const TfLiteDepthwiseConvParams& params,
+                                   const XtensaDepthwiseConvOpData& data,
+                                   const TfLiteEvalTensor* input,
+                                   const TfLiteEvalTensor* filter,
+                                   const TfLiteEvalTensor* bias,
+                                   TfLiteEvalTensor* output);
+#endif
 
 TfLiteStatus DepthwiseConvReferenceEvalInt8(TfLiteContext* context,
                                             TfLiteNode* node);
-#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5)
+TfLiteStatus DepthwiseConvReferenceEvalInt16(TfLiteContext* context,
+                                            TfLiteNode* node);
+TfLiteStatus DepthwiseConvReferenceEvalFloat32(TfLiteContext* context,
+                                            TfLiteNode* node);                                                                                        
+#endif  // defined(HIFI3) || defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
 
 #if defined(VISION_P6)
 
@@ -77,6 +90,9 @@ TfLiteStatus DepthwiseConvEvalVision(TfLiteContext* context, TfLiteNode* node,
                                      TfLiteEvalTensor* output);
 
 #endif  // VISION_P6
+
+void* DepthwiseConvInitXtensa(TfLiteContext* context, const char* buffer, size_t length);
+TfLiteStatus DepthwiseConvPrepareXtensa(TfLiteContext* context, TfLiteNode* node);
 
 }  // namespace tflite
 

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -1,5 +1,46 @@
 
+# Explicitly add kernel sources specific to the Xtensa optimized
+# implementations.
+MICROLITE_CC_KERNEL_SRCS += \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/add_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_common_xtensa.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_hifi.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int16_reference.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int8_reference.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_common_xtensa.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_float32_reference.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_hifi.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int16_reference.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_int16_float32.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_int8_reference.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/depthwise_conv_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_common_xtensa.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_int8.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/pad_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/pooling_int8.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/pooling_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/reduce_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/reshape_vision.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/softmax_int8_int16.cc \
+  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/softmax_vision.cc
+
+# Temporarily disabled: source files not yet added on this branch.
+# Re-enable each entry when its corresponding kernel PR lands.
+#  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_float32_reference.cc
+#  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/conv_int8_int16_float32.cc
+#  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_int16.cc
+#  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/fully_connected_float32.cc
+#  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/pooling_int16.cc
+#  $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/reduce_hifi.cc
+
 ifeq ($(TARGET_ARCH), hifimini)
+  # hifimini optimizations are implemented in the TFLM repository itself.
+  THIRD_PARTY_KERNEL_CC_SRCS += \
+    $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/hifimini/svdf.cc \
+    $(TENSORFLOW_ROOT)tensorflow/lite/micro/kernels/xtensa/hifimini/fully_connected.cc
+
   FFT_PATH := $(MAKEFILE_DIR)/downloads/hifi_fft
   INCLUDES += -I$(FFT_PATH)/
 
@@ -7,6 +48,36 @@ ifeq ($(TARGET_ARCH), hifimini)
     $(shell find $(FFT_PATH)/hifi2_fft -name "*.c")
   THIRD_PARTY_CC_HDRS += \
     $(shell find $(FFT_PATH)/hifi2_fft -name "*.h")
+
+else ifeq ($(TARGET_ARCH), hifi_iq)
+
+  PLATFORM_FLAGS = \
+    -Wno-shadow\
+
+  CCFLAGS += $(PLATFORM_FLAGS)
+  CXXFLAGS += $(PLATFORM_FLAGS)
+
+  NNLIB_PATH := $(MAKEFILE_DIR)/downloads/xa_nnlib_hifi_iq
+
+  THIRD_PARTY_KERNEL_CC_SRCS += \
+    $(shell find $(NNLIB_PATH) -name "*.c")
+
+  EXCLUDED_NNLIB_SRCS = \
+    $(NNLIB_PATH)/algo/layers/cnn/src/xa_nn_cnn_api.c \
+    $(NNLIB_PATH)/algo/layers/gru/src/xa_nn_gru_api.c \
+    $(NNLIB_PATH)/algo/layers/lstm/src/xa_nn_lstm_api.c \
+
+  THIRD_PARTY_KERNEL_CC_SRCS := $(filter-out $(EXCLUDED_NNLIB_SRCS), $(THIRD_PARTY_KERNEL_CC_SRCS))
+
+  THIRD_PARTY_CC_HDRS += \
+    $(shell find $(NNLIB_PATH) -name "*.h") \
+
+  INCLUDES += \
+    -I$(NNLIB_PATH)/ \
+    -I$(NNLIB_PATH)/algo/kernels/ \
+    -I$(NNLIB_PATH)/include/nnlib/ \
+    -I$(NNLIB_PATH)/include/ \
+    -I$(NNLIB_PATH)/algo/common/include/ \
 
 else ifeq ($(TARGET_ARCH), hifi5)
   DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/xtensa_download.sh ${DOWNLOADS_DIR} hifi5 $(TENSORFLOW_ROOT))
@@ -23,8 +94,12 @@ else ifeq ($(TARGET_ARCH), hifi5)
   # not have separate cflags (or the concept of modular build targets) with the
   # Makefile, -Wno-shadow will be used for everything.
 
+  # TODO: Adding HIFI_SIMD_WIDTH here to avoid error in ndsp lib compilation,
+  # once ndsp headers are removed from NNLib, this won't be needed
+
   PLATFORM_FLAGS = \
     -DNNLIB_HIFI5 \
+    -DHIFI_SIMD_WIDTH=16 \
     -Wno-shadow
 
   CCFLAGS += $(PLATFORM_FLAGS)
@@ -61,9 +136,11 @@ else ifeq ($(TARGET_ARCH), hifi5)
     -I$(NNLIB_PATH)/include/nnlib/ \
     -I$(NNLIB_PATH)/include/ \
     -I$(NNLIB_PATH)/algo/common/include/ \
+    -I$(NNLIB_PATH)/algo/ndsp/hifi5/include/ \
     -I$(NDSPLIB_PATH)/library/include/ \
     -I$(NDSPLIB_PATH)/library/include_private/
-else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi3 hifi4))
+
+else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi4 hifi4_internal hifi3 hifi3z fusion_f1 hifi1))
   # NNLib hifi4 also supports hifi3
   DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/xtensa_download.sh ${DOWNLOADS_DIR} hifi4 $(TENSORFLOW_ROOT))
   ifneq ($(DOWNLOAD_RESULT), SUCCESS)
@@ -78,9 +155,13 @@ else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi3 hifi4))
   # TODO(b/161489252): -Wno-shadow is only needed for xannlib. But since we do
   # not have separate cflags (or the concept of modular build targets) with the
   # Makefile, -Wno-shadow will be used for everything.
+  
+  # TODO: Adding HIFI_SIMD_WIDTH here to avoid error in ndsp lib compilation,
+  # once ndsp headers are removed from NNLib, this won't be needed
 
   PLATFORM_FLAGS = \
     -DNNLIB_V2 \
+    -DHIFI_SIMD_WIDTH=8 \
     -Wno-shadow
 
   CCFLAGS += $(PLATFORM_FLAGS)
@@ -104,7 +185,7 @@ else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi3 hifi4))
   EXCLUDED_NNLIB_SRCS = \
     $(NNLIB_PATH)/algo/layers/cnn/src/xa_nn_cnn_api.c \
     $(NNLIB_PATH)/algo/layers/gru/src/xa_nn_gru_api.c \
-    $(NNLIB_PATH)/algo/layers/lstm/src/xa_nn_lstm_api.c
+    $(NNLIB_PATH)/algo/layers/lstm/src/xa_nn_lstm_api.c 
 
   ifeq ($(TARGET_ARCH), hifi3)
     EXCLUDED_NNLIB_SRCS += \
@@ -116,7 +197,6 @@ else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi3 hifi4))
   
   ifeq ($(TARGET_ARCH), hifi4)
     EXCLUDED_NNLIB_SRCS += \
-      $(NNLIB_PATH)/algo/kernels/activations/hifi4/xa_nn_activations_asym8_asym8.c \
       $(NNLIB_PATH)/algo/kernels/norm/hifi4/xa_nn_norm3D_16.c
   endif
 
@@ -132,6 +212,7 @@ else ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi3 hifi4))
     -I$(NNLIB_PATH)/include/nnlib/ \
     -I$(NNLIB_PATH)/include/ \
     -I$(NNLIB_PATH)/algo/common/include/ \
+    -I$(NNLIB_PATH)/algo/ndsp/hifi4/include/ \
     -I$(NDSPLIB_PATH)/library/include/ \
     -I$(NDSPLIB_PATH)/library/include_private/
 
@@ -167,4 +248,22 @@ else ifeq ($(TARGET_ARCH), vision_p6)
   LDFLAGS += -lidma
 else
   $(error Unsupported TARGET_ARCH=$(TARGET_ARCH))
+endif
+
+FFT_PATH := $(MAKEFILE_DIR)/downloads/hifi_fft
+
+INCLUDES += -I$(FFT_PATH)/
+
+ifeq ($(TARGET_ARCH), $(filter $(TARGET_ARCH), hifi3 hifi3z hifi4 hifi4_internal hifi5 hifi1))
+THIRD_PARTY_KERNEL_CC_SRCS += \
+    $(shell find $(FFT_PATH)/hifi3_fft -name "*.c")
+
+THIRD_PARTY_CC_HDRS += \
+    $(shell find $(FFT_PATH)/hifi3_fft -name "*.h")
+else ifeq ($(TARGET_ARCH), hifimini)
+THIRD_PARTY_KERNEL_CC_SRCS += \
+    $(shell find $(FFT_PATH)/hifi2_fft -name "*.c")
+
+THIRD_PARTY_CC_HDRS += \
+    $(shell find $(FFT_PATH)/hifi2_fft -name "*.h")
 endif


### PR DESCRIPTION
Adds HiFi-optimized depthwise conv kernels for int8, int16 and float32, split into per-type helper files with reference fallbacks. Registers the new helper sources in xtensa.inc and adds XTENSA-specific registrations in the shared depthwise_conv.h.

@cad-audio @joshih-cad 