### PR TITLE
Add Xtensa NNLib-accelerated data-movement kernels

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/batch_to_space_nd.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/batch_to_space_nd.cc
@@ -1,0 +1,132 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/kernels/internal/reference/batch_to_space_nd.h"
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_utils.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+
+namespace tflite {
+
+namespace {
+
+constexpr int kInputTensor = 0;
+constexpr int kBlockShapeTensor = 1;
+constexpr int kCropsTensor = 2;
+constexpr int kOutputTensor = 0;
+
+// Currently, only 3D NHC and 4D NHWC input/output op_context are supported.
+// In case of 3D input, it will be extended to 3D NHWC by adding W=1.
+// The 4D array need to have exactly 2 spatial dimensions.
+// TODO(b/149952582): Support arbitrary dimension in SpaceToBatchND.
+const int kInputOutputMinDimensionNum = 3;
+const int kInputOutputMaxDimensionNum = 4;
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 3);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+
+  MicroContext* micro_context = GetMicroContext(context);
+
+  TfLiteTensor* input =
+      micro_context->AllocateTempInputTensor(node, kInputTensor);
+  TfLiteTensor* output =
+      micro_context->AllocateTempOutputTensor(node, kOutputTensor);
+  TF_LITE_ENSURE(context, input != nullptr && output != nullptr);
+
+  TF_LITE_ENSURE(context, NumDimensions(input) >= kInputOutputMinDimensionNum);
+  TF_LITE_ENSURE(context, NumDimensions(output) >= kInputOutputMinDimensionNum);
+  TF_LITE_ENSURE(context, NumDimensions(input) <= kInputOutputMaxDimensionNum);
+  TF_LITE_ENSURE(context, NumDimensions(output) <= kInputOutputMaxDimensionNum);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
+
+  micro_context->DeallocateTempTfLiteTensor(input);
+  micro_context->DeallocateTempTfLiteTensor(output);
+
+  return kTfLiteOk;
+}
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kInputTensor);
+  const TfLiteEvalTensor* block_shape =
+      tflite::micro::GetEvalInput(context, node, kBlockShapeTensor);
+  const TfLiteEvalTensor* crops =
+      tflite::micro::GetEvalInput(context, node, kCropsTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+
+  switch (input->type) {  // Already know in/out types are same.
+    case kTfLiteFloat32:
+      reference_ops::BatchToSpaceND(
+          tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<float>(input),
+          tflite::micro::GetTensorShape(block_shape),
+          tflite::micro::GetTensorData<int32_t>(block_shape),
+          tflite::micro::GetTensorShape(crops),
+          tflite::micro::GetTensorData<int32_t>(crops),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<float>(output));
+      break;
+    case kTfLiteInt8:
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+      {
+        const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+        const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+        TF_LITE_ENSURE_EQ(
+            context,
+            xa_nn_batch_to_space_nd_8_8(
+                tflite::micro::GetTensorData<int8_t>(output),
+                output_shape.DimsData(),
+                tflite::micro::GetTensorData<int8_t>(input),
+                input_shape.DimsData(),
+                tflite::micro::GetTensorData<int32_t>(block_shape),
+                tflite::micro::GetTensorData<int32_t>(crops),
+                output_shape.DimensionsCount(),
+                input_shape.DimensionsCount()
+                ),
+            0);
+      }
+#else
+      reference_ops::BatchToSpaceND(
+          tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int8_t>(input),
+          tflite::micro::GetTensorShape(block_shape),
+          tflite::micro::GetTensorData<int32_t>(block_shape),
+          tflite::micro::GetTensorShape(crops),
+          tflite::micro::GetTensorData<int32_t>(crops),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int8_t>(output));
+#endif // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+      break;
+    default:
+      TF_LITE_KERNEL_LOG(context, "Type %s (%d) not supported.",
+                         TfLiteTypeGetName(input->type), input->type);
+      return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+}  // namespace.
+
+TFLMRegistration Register_BATCH_TO_SPACE_ND() {
+  return tflite::micro::RegisterOp(nullptr, Prepare, Eval);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/concatenation.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/concatenation.cc
@@ -1,0 +1,374 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/kernels/internal/reference/concatenation.h"
+
+#include <cstdint>
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/micro_log.h"
+
+namespace tflite {
+
+namespace {
+
+constexpr int kMaxInputNum = 10;  // Maximum number of input tensors
+constexpr int kOutputTensor = 0;
+
+struct OpData {
+  ConcatenationParams params;
+};
+
+// Handles negative axis index, coerces to positive index value.
+inline int CalculatePositiveAxis(int axis, const TfLiteTensor* output_tensor) {
+  if (axis >= 0) {
+    return axis;
+  } else {
+    return NumDimensions(output_tensor) + axis;
+  }
+}
+
+// The following functions are helpers to get tensor data in the format that the
+// reference op implementation expects. They provide the same functionality as
+// class VectorOfTensors and class VectorOfQuantizedTensors in TFLite.
+
+// Gets shapes from a list of tensors.
+inline void GetAllInputTensorShapes(const TfLiteContext* context,
+                                    const TfLiteNode* node,
+                                    RuntimeShape all_shapes[kMaxInputNum]) {
+  TFLITE_DCHECK(context != nullptr);
+  TFLITE_DCHECK(node != nullptr);
+  for (int i = 0; i < node->inputs->size; ++i) {
+    const TfLiteEvalTensor* t = tflite::micro::GetEvalInput(context, node, i);
+    RuntimeShape shape = tflite::micro::GetTensorShape(t);
+    all_shapes[i].ReplaceWith(shape.DimensionsCount(), shape.DimsData());
+  }
+}
+
+// Get shape pointers from a list of shapes.
+inline void GetShapesPointers(const RuntimeShape* shapes, size_t num,
+                              const RuntimeShape* pointers[]) {
+  for (size_t i = 0; i < num; ++i) {
+    pointers[i] = &shapes[i];
+  }
+}
+
+#if (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+// Equal to kMaxSmallSize from tensorflow/lite/kernels/internal/runtime_shape.h
+constexpr int kMaxDims = 6;  // Maximum number of dimensions
+
+// Gets Dims from a list of tensors, equivalent to Int8, for higher
+// datatypes multiply last dimension by a factor (ie. 2 for Int16)
+inline void GetAllInputTensorDimsInt8(const TfLiteContext* context,
+                                      const TfLiteNode* node,
+                                      int32_t all_shapes[kMaxInputNum][kMaxDims]) {
+  TFLITE_DCHECK(context != nullptr);
+  TFLITE_DCHECK(node != nullptr);
+  int32_t bytes_per_element = 1;
+  const TfLiteEvalTensor* t0 = tflite::micro::GetEvalInput(context, node, 0);
+  switch (t0->type) {
+    case kTfLiteInt8:
+      bytes_per_element = 1;
+      break;
+    case kTfLiteInt16:
+      bytes_per_element = 2;
+      break;
+    case kTfLiteFloat32:
+    case kTfLiteInt32:
+      bytes_per_element = 4;
+      break;
+    case kTfLiteInt64:
+      bytes_per_element = 8;
+      break;
+    default:
+      bytes_per_element = 0;
+      break;
+  }
+  for (int i = 0; i < node->inputs->size; ++i) {
+    const TfLiteEvalTensor* t = tflite::micro::GetEvalInput(context, node, i);
+    int num_dims = t->dims->size;
+    for(int j = 0; j < num_dims - 1; j++) {
+      all_shapes[i][j] = t->dims->data[j];
+    }
+    all_shapes[i][num_dims - 1] = t->dims->data[num_dims - 1] * bytes_per_element;
+  }
+}
+
+inline void GetAllInputDimsPointers(int32_t all_shapes[kMaxInputNum][kMaxDims],
+                                    size_t num,
+                                    const WORD32* pointers[]) {
+  for (size_t i = 0; i < num; ++i) {
+    pointers[i] = &all_shapes[i][0];
+  }
+}
+#endif // (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+
+// Gets data pointers from a list of tensors.
+template <typename T>
+inline void GetAllInputTensorData(const TfLiteContext* context,
+                                  const TfLiteNode* node,
+                                  T* all_data[kMaxInputNum]) {
+  TFLITE_DCHECK(context != nullptr);
+  TFLITE_DCHECK(node != nullptr);
+  for (int i = 0; i < node->inputs->size; ++i) {
+    const TfLiteEvalTensor* t = tflite::micro::GetEvalInput(context, node, i);
+    all_data[i] = tflite::micro::GetTensorData<T>(t);
+  }
+}
+
+template <typename data_type>
+void EvalUnquantized(TfLiteContext* context, TfLiteNode* node) {
+  // Collect the shapes and data pointer of input tensors
+  RuntimeShape inputs_shape[kMaxInputNum];
+  const RuntimeShape* inputs_shape_ptr[kMaxInputNum];
+  const data_type* inputs_data[kMaxInputNum];
+  GetAllInputTensorShapes(context, node, inputs_shape);
+  GetShapesPointers(inputs_shape, node->inputs->size, inputs_shape_ptr);
+  GetAllInputTensorData(context, node, inputs_data);
+
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const OpData* data = static_cast<const OpData*>(node->user_data);
+
+  reference_ops::Concatenation(data->params, inputs_shape_ptr, inputs_data,
+                               tflite::micro::GetTensorShape(output),
+                               tflite::micro::GetTensorData<data_type>(output));
+}
+
+#if (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+TfLiteStatus EvalUnquantizedHifi(TfLiteContext* context, TfLiteNode* node) {
+  // Collect the shapes and data pointer of input tensors
+  WORD32 inputs_shape[kMaxInputNum][kMaxDims];
+  const WORD8* inputs_data[kMaxInputNum];
+  const WORD32* inputs_dims_ptr[kMaxInputNum];
+  WORD32 output_shape[kMaxDims];
+  GetAllInputTensorDimsInt8(context, node, inputs_shape);
+  GetAllInputDimsPointers(inputs_shape, node->inputs->size, inputs_dims_ptr);
+  GetAllInputTensorData(context, node, inputs_data);
+
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const OpData* data = static_cast<const OpData*>(node->user_data);
+
+  for(int i = 0; i < output->dims->size; i++)
+    output_shape[i] = output->dims->data[i];
+
+  int32_t bytes_per_element = 1;
+  switch (output->type) {
+    case kTfLiteInt8:
+      bytes_per_element = 1;
+      break;
+    case kTfLiteInt16:
+      bytes_per_element = 2;
+      break;
+    case kTfLiteFloat32:
+    case kTfLiteInt32:
+      bytes_per_element = 4;
+      break;
+    case kTfLiteInt64:
+      bytes_per_element = 8;
+      break;
+    default:
+      return kTfLiteError;
+      break;
+  }
+  output_shape[output->dims->size - 1] *= bytes_per_element;
+
+  int32_t ret = 0;
+  ret = xa_nn_concat_8_8(tflite::micro::GetTensorData<int8_t>(output),
+                           output_shape,
+                           inputs_data,
+                           (const int32_t *const *)inputs_dims_ptr,
+                           output->dims->size,
+                           node->inputs->size,
+                           output->dims->size,
+                           data->params.axis);
+  TF_LITE_ENSURE_EQ(context, ret, 0);
+  return kTfLiteOk;
+}
+#endif // (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+
+void* Init(TfLiteContext* context, const char* buffer, size_t length) {
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+  return context->AllocatePersistentBuffer(context, sizeof(OpData));
+}
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  // This function only checks the types. Additional shape validations are
+  // performed in the reference implementation called during Eval().
+  const TfLiteConcatenationParams* params =
+      reinterpret_cast<TfLiteConcatenationParams*>(node->builtin_data);
+
+  MicroContext* micro_context = GetMicroContext(context);
+
+  TfLiteTensor* input_tensor = micro_context->AllocateTempInputTensor(node, 0);
+  TF_LITE_ENSURE(context, input_tensor != nullptr);
+  TfLiteType input_type = input_tensor->type;
+  TfLiteTensor* output_tensor =
+      micro_context->AllocateTempOutputTensor(node, kOutputTensor);
+  TF_LITE_ENSURE(context, output_tensor != nullptr);
+  TfLiteType output_type = output_tensor->type;
+
+  micro_context->DeallocateTempTfLiteTensor(input_tensor);
+  micro_context->DeallocateTempTfLiteTensor(output_tensor);
+
+  // Check activation and input type
+  TF_LITE_ENSURE_EQ(context, params->activation, kTfLiteActNone);
+  TF_LITE_ENSURE(context,
+                 input_type == kTfLiteFloat32 || input_type == kTfLiteInt8 ||
+                     input_type == kTfLiteInt16 || input_type == kTfLiteInt32 ||
+                     input_type == kTfLiteInt64 || input_type == kTfLiteBool);
+
+  // Output type must match input type
+  TF_LITE_ENSURE_EQ(context, output_type, input_type);
+
+  // This implementation does not support large number of input tensors
+  const int num_inputs = NumInputs(node);
+  TF_LITE_ENSURE(context, num_inputs <= kMaxInputNum);
+
+  // Shapes with dimensions >4 are not yet supported with static allocation.
+  for (int i = 0; i < num_inputs; ++i) {
+    TfLiteTensor* input = micro_context->AllocateTempInputTensor(node, i);
+    TF_LITE_ENSURE(context, input != nullptr);
+    int num_dimensions = NumDimensions(input);
+
+    if (num_dimensions > RuntimeShape::kMaxSmallSize) {
+      MicroPrintf(
+          "Op Concatenation does not currently support num dimensions > %d "
+          "Tensor has %d dimensions.",
+          RuntimeShape::kMaxSmallSize, num_dimensions);
+      return kTfLiteError;
+    }
+    micro_context->DeallocateTempTfLiteTensor(input);
+  }
+
+  // Calculate OpData.
+  TFLITE_DCHECK(node->user_data != nullptr);
+  OpData* data = static_cast<OpData*>(node->user_data);
+
+  TfLiteTensor* output =
+      micro_context->AllocateTempOutputTensor(node, kOutputTensor);
+  TF_LITE_ENSURE(context, output != nullptr);
+
+  switch (output_type) {  // Already know in/outtypes are same.
+    case kTfLiteBool:
+    case kTfLiteFloat32:
+    case kTfLiteInt16:
+    case kTfLiteInt32:
+    case kTfLiteInt64: {
+      data->params.axis = CalculatePositiveAxis(params->axis, output);
+      data->params.inputs_count = node->inputs->size;
+      break;
+    }
+    case kTfLiteInt8: {
+      data->params.axis = CalculatePositiveAxis(params->axis, output);
+      data->params.inputs_count = node->inputs->size;
+
+      float* input_scales =
+          reinterpret_cast<float*>(context->AllocatePersistentBuffer(
+              context, node->inputs->size * sizeof(float)));
+
+      int32_t* input_zero_points =
+          reinterpret_cast<int32_t*>(context->AllocatePersistentBuffer(
+              context, node->inputs->size * sizeof(int32_t)));
+
+      // Allocate persistent scale and zeropoint buffers.
+      // Store input scale and zero point values in OpParams:
+      for (int i = 0; i < node->inputs->size; ++i) {
+        TfLiteTensor* t = micro_context->AllocateTempInputTensor(node, i);
+        TF_LITE_ENSURE(context, t != nullptr);
+        input_scales[i] = t->params.scale;
+        input_zero_points[i] = t->params.zero_point;
+        micro_context->DeallocateTempTfLiteTensor(t);
+      }
+
+      data->params.input_scale = input_scales;
+      data->params.input_zeropoint = input_zero_points;
+      data->params.output_zeropoint = output->params.zero_point;
+      data->params.output_scale = output->params.scale;
+      break;
+    }
+    default:
+      MicroPrintf("Op Concatenation does not currently support Type '%s'.",
+                  TfLiteTypeGetName(output_type));
+      return kTfLiteError;
+  }
+
+  micro_context->DeallocateTempTfLiteTensor(output);
+
+  return kTfLiteOk;
+}
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  const TfLiteEvalTensor* output_tensor =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+  TF_LITE_ENSURE(context, output_tensor != nullptr);
+  TfLiteType output_type = output_tensor->type;
+
+  switch (output_type) {  // Already know in/outtypes are same.
+#if !(defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)) 
+    case kTfLiteFloat32:
+      EvalUnquantized<float>(context, node);
+      break;
+    case kTfLiteInt32:
+      EvalUnquantized<int32_t>(context, node);
+      break;
+    case kTfLiteInt8:
+      EvalUnquantized<int8_t>(context, node);
+      break;
+    case kTfLiteInt64:
+      EvalUnquantized<int64_t>(context, node);
+      break;
+    case kTfLiteInt16:
+      EvalUnquantized<int16_t>(context, node);
+      break;
+#else
+    case kTfLiteFloat32:
+    case kTfLiteInt32:
+    case kTfLiteInt8:
+    case kTfLiteInt64:
+    case kTfLiteInt16:
+      return EvalUnquantizedHifi(context, node);
+      break;
+#endif // !(defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+    case kTfLiteBool:
+      EvalUnquantized<bool>(context, node);
+      break;
+
+    default:
+      MicroPrintf("Op Concatenation does not currently support Type '%s'.",
+                  TfLiteTypeGetName(output_type));
+      return kTfLiteError;
+  }
+
+  return kTfLiteOk;
+}
+
+}  // namespace
+
+TFLMRegistration Register_CONCATENATION() {
+  return tflite::micro::RegisterOp(Init, Prepare, Eval);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/depth_to_space.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depth_to_space.cc
@@ -1,0 +1,175 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/kernels/internal/reference/depth_to_space.h"
+
+#include <stdint.h>
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+
+namespace tflite {
+namespace {
+
+constexpr int kInputTensor = 0;
+constexpr int kOutputTensor = 0;
+
+// input/output tensor shape rank associations
+constexpr int kBatchRank = 0;
+constexpr int kHeightRank = 1;
+constexpr int kWidthRank = 2;
+constexpr int kDepthRank = 3;
+
+TfLiteStatus CalculateOpData(TfLiteContext* context, TfLiteNode* node) {
+  auto* params =
+      reinterpret_cast<TfLiteDepthToSpaceParams*>(node->builtin_data);
+
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 1);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+
+  MicroContext* micro_context = GetMicroContext(context);
+
+  TfLiteTensor* input =
+      micro_context->AllocateTempInputTensor(node, kInputTensor);
+  TF_LITE_ENSURE(context, input != nullptr);
+  TfLiteTensor* output =
+      micro_context->AllocateTempOutputTensor(node, kOutputTensor);
+  TF_LITE_ENSURE(context, output != nullptr);
+
+  TF_LITE_ENSURE_EQ(context, NumDimensions(input), 4);
+
+  auto data_type = output->type;
+  TF_LITE_ENSURE(context,
+                 data_type == kTfLiteFloat32 || data_type == kTfLiteInt8);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
+
+  const int block_size = params->block_size;
+  TF_LITE_ENSURE(context, block_size > 0);
+  const int input_height = input->dims->data[kHeightRank];
+  const int input_width = input->dims->data[kWidthRank];
+  const int input_channels = input->dims->data[kDepthRank];
+  int output_height = input_height * block_size;
+  int output_width = input_width * block_size;
+  int output_channels = input_channels / block_size / block_size;
+
+  TF_LITE_ENSURE_EQ(context, input_height, output_height / block_size);
+  TF_LITE_ENSURE_EQ(context, input_width, output_width / block_size);
+  TF_LITE_ENSURE_EQ(context, input_channels,
+                    output_channels * block_size * block_size);
+
+  // We must update the output tensor dimensions.
+  // The dims storage is expected to be the same area in memory
+  // for both TfLiteTensor and TfLiteEvalTensor.  This is important
+  // because TfLiteTensor in the MicroInterpreter is a temporary
+  // allocation.  For the KernelRunner interpreter, TfLiteEvalTensor
+  // is a temporary allocation.  We must therefore relocate the dims
+  // from the FlatBuffer to the persistant storage arena.
+  TfLiteEvalTensor* output_eval =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+  TF_LITE_ENSURE_OK(context, tflite::micro::CreateWritableTensorDimsWithCopy(
+                                 context, output, output_eval));
+  output->dims->data[kBatchRank] = input->dims->data[kBatchRank];
+  output->dims->data[kHeightRank] = output_height;
+  output->dims->data[kWidthRank] = output_width;
+  output->dims->data[kDepthRank] = output_channels;
+
+  micro_context->DeallocateTempTfLiteTensor(input);
+  micro_context->DeallocateTempTfLiteTensor(output);
+
+  return kTfLiteOk;
+}
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  return CalculateOpData(context, node);
+}
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  auto* params =
+      reinterpret_cast<TfLiteDepthToSpaceParams*>(node->builtin_data);
+
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kInputTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+
+  tflite::DepthToSpaceParams op_params;
+  op_params.block_size = static_cast<int32_t>(params->block_size);
+
+  switch (input->type) {  // Already know in/out types are same.
+    case kTfLiteFloat32:
+      reference_ops::DepthToSpace(op_params,
+                                  tflite::micro::GetTensorShape(input),
+                                  tflite::micro::GetTensorData<float>(input),
+                                  tflite::micro::GetTensorShape(output),
+                                  tflite::micro::GetTensorData<float>(output));
+      break;
+    case kTfLiteInt8:
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+      {
+        const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+        const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+        const int num_batches = input_shape.Dims(0);
+        const int input_height = input_shape.Dims(1);
+        const int input_width = input_shape.Dims(2);
+        const int input_depth = input_shape.Dims(3);
+        const int output_height = output_shape.Dims(1);
+        const int output_width = output_shape.Dims(2);
+        const int output_depth = output_shape.Dims(3);
+        int input_cube_size = input_height * input_width * input_depth;
+        int output_cube_size = output_height * output_width * output_depth;
+        int8_t *p_output;
+        const int8_t *p_input;
+        p_output = tflite::micro::GetTensorData<int8_t>(output);
+        p_input = tflite::micro::GetTensorData<int8_t>(input);
+        for(int b = 0; b < num_batches; b++)
+        {
+          TF_LITE_ENSURE_EQ(
+              context,
+              xa_nn_depth_to_space_8_8(
+                  (p_output + b * output_cube_size),
+                  (p_input + b * input_cube_size),
+                  input_height, input_width, input_depth,
+                  op_params.block_size,
+                  output_height, output_width, output_depth, 0, 0),
+              0);
+        }
+      }
+#else
+      reference_ops::DepthToSpace(op_params,
+                                  tflite::micro::GetTensorShape(input),
+                                  tflite::micro::GetTensorData<int8_t>(input),
+                                  tflite::micro::GetTensorShape(output),
+                                  tflite::micro::GetTensorData<int8_t>(output));
+#endif // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+      break;
+    default:
+      TF_LITE_KERNEL_LOG(
+          context, "DEPTH_TO_SPACE only supports FLOAT32 and INT8, got %s.",
+          TfLiteTypeGetName(output->type));
+      return kTfLiteError;
+  }
+
+  return kTfLiteOk;
+}
+
+}  // namespace
+
+TFLMRegistration Register_DEPTH_TO_SPACE() {
+  return tflite::micro::RegisterOp(nullptr, Prepare, Eval);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/slice.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/slice.cc
@@ -1,0 +1,247 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/kernels/internal/reference/slice.h"
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
+#include "tensorflow/lite/micro/memory_helpers.h"
+#include "tensorflow/lite/micro/micro_utils.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+
+namespace tflite {
+
+namespace {
+
+constexpr int kInputTensor = 0;
+constexpr int kBeginTensor = 1;
+constexpr int kSizeTensor = 2;
+constexpr int kOutputTensor = 0;
+
+const int kMaxDim = 5;
+
+template <typename T>
+void GetBeginAndSizeVectors(int dimensions, const TfLiteEvalTensor* begin,
+                            const TfLiteEvalTensor* size, int32_t* begins,
+                            int32_t* sizes) {
+  int offset = kMaxDim - dimensions;
+  for (int idx = 0; idx < dimensions; ++idx) {
+    begins[offset + idx] = tflite::micro::GetTensorData<T>(begin)[idx];
+    sizes[offset + idx] = tflite::micro::GetTensorData<T>(size)[idx];
+  }
+}
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  MicroContext* micro_context = GetMicroContext(context);
+
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 3);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+
+  TfLiteTensor* input =
+      micro_context->AllocateTempInputTensor(node, kInputTensor);
+  TFLITE_DCHECK(input != nullptr);
+  TfLiteTensor* begin =
+      micro_context->AllocateTempInputTensor(node, kBeginTensor);
+  TFLITE_DCHECK(begin != nullptr);
+  TfLiteTensor* size =
+      micro_context->AllocateTempInputTensor(node, kSizeTensor);
+  TFLITE_DCHECK(size != nullptr);
+  TfLiteTensor* output =
+      micro_context->AllocateTempOutputTensor(node, kOutputTensor);
+  TFLITE_DCHECK(output != nullptr);
+
+  // Ensure validity of input tensor and its dimension.
+  TFLITE_DCHECK(input->type == output->type);
+  TFLITE_DCHECK(begin->type == size->type);
+  TFLITE_DCHECK(begin->type == kTfLiteInt32 || begin->type == kTfLiteInt64);
+  TFLITE_DCHECK(size->type == kTfLiteInt32 || size->type == kTfLiteInt64);
+  TFLITE_DCHECK(NumDimensions(begin) == 1);
+  TFLITE_DCHECK(NumDimensions(size) == 1);
+  TFLITE_DCHECK(NumElements(begin) == NumElements(size));
+  TFLITE_DCHECK(NumDimensions(input) <= kMaxDim);
+
+  micro_context->DeallocateTempTfLiteTensor(input);
+  micro_context->DeallocateTempTfLiteTensor(begin);
+  micro_context->DeallocateTempTfLiteTensor(size);
+  micro_context->DeallocateTempTfLiteTensor(output);
+
+  return kTfLiteOk;
+}
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kInputTensor);
+  const TfLiteEvalTensor* begin =
+      tflite::micro::GetEvalInput(context, node, kBeginTensor);
+  const TfLiteEvalTensor* size =
+      tflite::micro::GetEvalInput(context, node, kSizeTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+
+  tflite::SliceParams op_params;
+  op_params.begin_count = kMaxDim;
+  op_params.size_count = kMaxDim;
+  for (int i = 0; i < kMaxDim; ++i) {
+    op_params.begin[i] = 0;
+    op_params.size[i] = 1;
+  }
+
+  if (begin->type == kTfLiteInt32) {
+    GetBeginAndSizeVectors<int32_t>(input->dims->size, begin, size,
+                                    op_params.begin, op_params.size);
+  } else if (begin->type == kTfLiteInt64) {
+    GetBeginAndSizeVectors<int64_t>(input->dims->size, begin, size,
+                                    op_params.begin, op_params.size);
+  } else {
+    MicroPrintf("Begin tensor type %s (%d) not supported.",
+                TfLiteTypeGetName(input->type), input->type);
+    return kTfLiteError;
+  }
+
+  switch (input->type) {
+    case kTfLiteFloat32:
+      reference_ops::Slice<float>(op_params,
+                                  tflite::micro::GetTensorShape(input),
+                                  tflite::micro::GetTensorData<float>(input),
+                                  tflite::micro::GetTensorShape(output),
+                                  tflite::micro::GetTensorData<float>(output));
+      break;
+    case kTfLiteInt32:
+      reference_ops::Slice<int32_t>(
+          op_params, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int32_t>(input),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int32_t>(output));
+      break;
+    case kTfLiteInt8: {
+#if (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+      const RuntimeShape input_shape = tflite::micro::GetTensorShape(input);
+      const RuntimeShape output_shape = tflite::micro::GetTensorShape(output);
+      const RuntimeShape extended_input_shape = RuntimeShape::ExtendedShape(5, input_shape);
+      int err;
+      
+      size_t output_bytes;
+      TF_LITE_ENSURE_STATUS(TfLiteTypeSizeOf(output->type, &output_bytes));
+      output_bytes *= ElementCount(*output->dims);
+      
+      const int8_t *input_data = tflite::micro::GetTensorData<int8_t>(input);
+      int8_t *output_data = tflite::micro::GetTensorData<int8_t>(output);
+    
+      /* Slice operator is Strided Slice operation with stride = 1 in all dimensions */
+      int unit_stride = 1;
+      /* Evaluate start and stop indices */
+      int start[5];
+      int stop[5];
+      for (int i = 0; i < 5; ++i) 
+      {
+        int padded_i = 5 - i;
+        start[i] =
+            op_params.begin_count < padded_i ? 0 : op_params.begin[op_params.begin_count - padded_i];
+        stop[i] =
+            (op_params.size[op_params.size_count - padded_i] == -1)
+                ? extended_input_shape.Dims(i)
+                : start[i] + op_params.size[op_params.size_count - padded_i];
+      }
+
+      err = xa_nn_strided_slice_int8(
+        output_data, input_data, start[0], stop[0], start[1],
+        stop[1], start[2], stop[2], start[3], stop[3],
+        start[4], stop[4], unit_stride, unit_stride, unit_stride, unit_stride, unit_stride,
+        extended_input_shape.Dims(1), extended_input_shape.Dims(2), extended_input_shape.Dims(3),
+        extended_input_shape.Dims(4)
+      );
+      TF_LITE_ENSURE(context, err == 0);
+#else
+      reference_ops::Slice<int8_t>(
+          op_params, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int8_t>(input),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int8_t>(output));
+#endif // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+      break;
+    }
+    case kTfLiteInt16: {
+#if (defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+      const RuntimeShape input_shape = tflite::micro::GetTensorShape(input);
+      const RuntimeShape output_shape = tflite::micro::GetTensorShape(output);
+      const RuntimeShape extended_input_shape = RuntimeShape::ExtendedShape(5, input_shape);
+      int err;
+
+      size_t output_bytes;
+      TF_LITE_ENSURE_STATUS(TfLiteTypeSizeOf(output->type, &output_bytes));
+      output_bytes *= ElementCount(*output->dims);
+
+      const int16_t *input_data = tflite::micro::GetTensorData<int16_t>(input);
+      int16_t *output_data = tflite::micro::GetTensorData<int16_t>(output);
+
+      /* Slice operator is Strided Slice operation with stride = 1 in all dimensions */
+      int unit_stride = 1;
+      /* Evaluate start and stop indices */
+      int start[5];
+      int stop[5];
+      for (int i = 0; i < 5; ++i)
+      {
+        int padded_i = 5 - i;
+        start[i] =
+            op_params.begin_count < padded_i ? 0 : op_params.begin[op_params.begin_count - padded_i];
+        stop[i] =
+            (op_params.size[op_params.size_count - padded_i] == -1)
+                ? extended_input_shape.Dims(i)
+                : start[i] + op_params.size[op_params.size_count - padded_i];
+      }
+
+      err = xa_nn_strided_slice_int16(
+        output_data, input_data, start[0], stop[0], start[1],
+        stop[1], start[2], stop[2], start[3], stop[3],
+        start[4], stop[4], unit_stride, unit_stride, unit_stride, unit_stride, unit_stride,
+        extended_input_shape.Dims(1), extended_input_shape.Dims(2), extended_input_shape.Dims(3),
+        extended_input_shape.Dims(4)
+      );
+      TF_LITE_ENSURE(context, err == 0);
+#else // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+      reference_ops::Slice<int16_t>(
+          op_params, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int16_t>(input),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int16_t>(output));
+#endif // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ))
+      break;
+    }
+    case kTfLiteBool:
+      reference_ops::Slice<bool>(op_params,
+                                 tflite::micro::GetTensorShape(input),
+                                 tflite::micro::GetTensorData<bool>(input),
+                                 tflite::micro::GetTensorShape(output),
+                                 tflite::micro::GetTensorData<bool>(output));
+      break;
+    default:
+      MicroPrintf("Input tensor type %s (%d) not supported.",
+                  TfLiteTypeGetName(input->type), input->type);
+      return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+}  // namespace
+
+TFLMRegistration Register_SLICE() {
+  return tflite::micro::RegisterOp(nullptr, Prepare, Eval);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/space_to_batch_nd.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/space_to_batch_nd.cc
@@ -1,0 +1,142 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/kernels/internal/reference/space_to_batch_nd.h"
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_utils.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+
+namespace tflite {
+
+namespace {
+
+constexpr int kInputTensor = 0;
+constexpr int kBlockShapeTensor = 1;
+constexpr int kCropsTensor = 2;
+constexpr int kOutputTensor = 0;
+
+// Currently, only 3D NHC and 4D NHWC input/output op_context are supported.
+// In case of 3D input, it will be extended to 3D NHWC by adding W=1.
+// The 4D array need to have exactly 2 spatial dimensions.
+// TODO(b/149952582): Support arbitrary dimension in SpaceToBatchND.
+const int kInputOutputMinDimensionNum = 3;
+const int kInputOutputMaxDimensionNum = 4;
+
+void* Init(TfLiteContext* context, const char* buffer, size_t length) {
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+  return context->AllocatePersistentBuffer(context, sizeof(SpaceToBatchParams));
+}
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  MicroContext* micro_context = GetMicroContext(context);
+
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 3);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+
+  TfLiteTensor* input =
+      micro_context->AllocateTempInputTensor(node, kInputTensor);
+  TfLiteTensor* output =
+      micro_context->AllocateTempOutputTensor(node, kOutputTensor);
+  TF_LITE_ENSURE(context, input != nullptr && output != nullptr);
+
+  TF_LITE_ENSURE(context, NumDimensions(input) >= kInputOutputMinDimensionNum);
+  TF_LITE_ENSURE(context, NumDimensions(output) >= kInputOutputMinDimensionNum);
+  TF_LITE_ENSURE(context, NumDimensions(input) <= kInputOutputMaxDimensionNum);
+  TF_LITE_ENSURE(context, NumDimensions(output) <= kInputOutputMaxDimensionNum);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
+
+  micro_context->DeallocateTempTfLiteTensor(input);
+  micro_context->DeallocateTempTfLiteTensor(output);
+  return kTfLiteOk;
+}
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  const SpaceToBatchParams& params =
+      *(static_cast<const SpaceToBatchParams*>(node->user_data));
+
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kInputTensor);
+  const TfLiteEvalTensor* block_shape =
+      tflite::micro::GetEvalInput(context, node, kBlockShapeTensor);
+  const TfLiteEvalTensor* crops =
+      tflite::micro::GetEvalInput(context, node, kCropsTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+
+  switch (input->type) {  // Already know in/out types are same.
+    case kTfLiteFloat32:
+      reference_ops::SpaceToBatchND(
+          params, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<float>(input),
+          tflite::micro::GetTensorShape(block_shape),
+          tflite::micro::GetTensorData<int32_t>(block_shape),
+          tflite::micro::GetTensorShape(crops),
+          tflite::micro::GetTensorData<int32_t>(crops),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<float>(output));
+      break;
+    case kTfLiteInt8:
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+      {
+        const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+        const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+        TF_LITE_ENSURE_EQ(
+            context,
+            xa_nn_space_to_batch_nd_8_8(
+                tflite::micro::GetTensorData<int8_t>(output),
+                output_shape.DimsData(),
+                tflite::micro::GetTensorData<int8_t>(input),
+                input_shape.DimsData(),
+                tflite::micro::GetTensorData<int32_t>(block_shape),
+                tflite::micro::GetTensorData<int32_t>(crops),
+                output_shape.DimensionsCount(),
+                input_shape.DimensionsCount(),
+                params.output_offset
+                ),
+            0);
+      }
+#else
+      reference_ops::SpaceToBatchND(
+          params, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int8_t>(input),
+          tflite::micro::GetTensorShape(block_shape),
+          tflite::micro::GetTensorData<int32_t>(block_shape),
+          tflite::micro::GetTensorShape(crops),
+          tflite::micro::GetTensorData<int32_t>(crops),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int8_t>(output));
+#endif // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+      break;
+    default:
+      TF_LITE_KERNEL_LOG(context, "Type %s (%d) not supported.",
+                         TfLiteTypeGetName(input->type), input->type);
+      return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+}  // namespace.
+
+TFLMRegistration Register_SPACE_TO_BATCH_ND() {
+  return tflite::micro::RegisterOp(Init, Prepare, Eval);
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/transpose.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/transpose.cc
@@ -1,0 +1,157 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/kernels/internal/reference/transpose.h"
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_log.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+
+namespace tflite {
+namespace {
+
+constexpr int kInputTensor = 0;
+constexpr int kPermTensor = 1;
+constexpr int kOutputTensor = 0;
+
+struct TransposeContext {
+  TransposeContext(TfLiteContext* context, TfLiteNode* node) {
+    micro_context = GetMicroContext(context);
+    input = micro_context->AllocateTempInputTensor(node, kInputTensor);
+    perm = micro_context->AllocateTempInputTensor(node, kPermTensor);
+    output = micro_context->AllocateTempOutputTensor(node, kOutputTensor);
+  }
+  ~TransposeContext() {
+    micro_context->DeallocateTempTfLiteTensor(input);
+    micro_context->DeallocateTempTfLiteTensor(perm);
+    micro_context->DeallocateTempTfLiteTensor(output);
+  }
+  MicroContext* micro_context;
+  TfLiteTensor* input;
+  TfLiteTensor* perm;
+  TfLiteTensor* output;
+};
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 2);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+
+  TransposeContext op_context(context, node);
+
+  // Ensure validity of input tensor.
+  TF_LITE_ENSURE_MSG(context, NumDimensions(op_context.input) <= 5,
+                     "Transpose op only supports 1D-5D input arrays.");
+  TF_LITE_ENSURE_TYPES_EQ(context, op_context.input->type,
+                          op_context.output->type);
+
+  int dims = NumDimensions(op_context.input);
+  const int32_t* perm_data = GetTensorData<int32_t>(op_context.perm);
+
+  // Ensure validity of the permutations tensor as a 1D tensor.
+  TF_LITE_ENSURE_EQ(context, NumDimensions(op_context.perm), 1);
+  TF_LITE_ENSURE_EQ(context, op_context.perm->dims->data[0], dims);
+  for (int idx = 0; idx < dims; ++idx) {
+    TF_LITE_ENSURE_MSG(context, (perm_data[idx] >= 0 && perm_data[idx] < dims),
+                       "Transpose op permutations array is out of bounds.");
+  }
+
+  return kTfLiteOk;
+}
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  int err;
+  const TfLiteEvalTensor* perm_tensor =
+      tflite::micro::GetEvalInput(context, node, kPermTensor);
+  const int32_t* perm_data = perm_tensor->data.i32;
+  const int size = perm_tensor->dims->data[0];
+  TransposeParams params;
+  params.perm_count = size;
+  for (int i = 0; i < size; ++i) {
+    params.perm[i] = perm_data[i];
+  }
+
+  // Transpose kernel only does rearranging values not numeric evaluations
+  // on each cell. It's safe to implement per size of scalar type and this
+  // trick keeps the total code size in a reasonable range.
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kInputTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+  switch (input->type) {
+    case kTfLiteFloat32:
+      reference_ops::Transpose(params, tflite::micro::GetTensorShape(input),
+                               tflite::micro::GetTensorData<float>(input),
+                               tflite::micro::GetTensorShape(output),
+                               tflite::micro::GetTensorData<float>(output));
+      break;
+    case kTfLiteInt8 : {
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+      err = xa_nn_transpose_8_8(
+        tflite::micro::GetTensorData<int8_t>(output),
+        tflite::micro::GetTensorShape(output).DimsData(),
+        tflite::micro::GetTensorData<int8_t>(input),
+        tflite::micro::GetTensorShape(input).DimsData(),
+        params.perm,
+        tflite::micro::GetTensorShape(output).DimensionsCount(),
+        tflite::micro::GetTensorShape(input).DimensionsCount()
+      );
+      TF_LITE_ENSURE(context, err == 0);
+#else    
+      reference_ops::Transpose(params, tflite::micro::GetTensorShape(input),
+                               tflite::micro::GetTensorData<int8_t>(input),
+                               tflite::micro::GetTensorShape(output),
+                               tflite::micro::GetTensorData<int8_t>(output));
+#endif   // defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+      }                        
+      break;
+    case kTfLiteInt16:
+#if defined(HIFI4) || defined(HIFI5) || defined(HIFI_IQ)
+      err = xa_nn_transpose_16_16(
+        tflite::micro::GetTensorData<int16_t>(output),
+        tflite::micro::GetTensorShape(output).DimsData(),
+        tflite::micro::GetTensorData<int16_t>(input),
+        tflite::micro::GetTensorShape(input).DimsData(),
+        params.perm,
+        tflite::micro::GetTensorShape(output).DimensionsCount(),
+        tflite::micro::GetTensorShape(input).DimensionsCount()
+      );
+      TF_LITE_ENSURE(context, err == 0);
+#else    
+      reference_ops::Transpose(params, tflite::micro::GetTensorShape(input),
+                               tflite::micro::GetTensorData<int16_t>(input),
+                               tflite::micro::GetTensorShape(output),
+                               tflite::micro::GetTensorData<int16_t>(output));
+#endif
+      break;
+    default:
+      MicroPrintf(
+          "Type %s is currently not supported by Transpose. "
+          "Only float32 ,int8 and int16 is supported",
+          TfLiteTypeGetName(input->type));
+      return kTfLiteError;
+  }
+
+  return kTfLiteOk;
+}
+
+}  // namespace
+
+TFLMRegistration Register_TRANSPOSE() {
+  return tflite::micro::RegisterOp(nullptr, Prepare, Eval);
+}
+}  // namespace tflite


### PR DESCRIPTION
Adds NNLib-accelerated Xtensa implementations for data-movement ops:
batch_to_space_nd, concatenation, depth_to_space, slice, space_to_batch_nd and transpose. 

@cad-audio @joshih-cad 