### PR TITLE
Migrate example evaluate tests to LiteRT and unittest

### DIFF
--- a/tensorflow/lite/micro/examples/hello_world/evaluate.py
+++ b/tensorflow/lite/micro/examples/hello_world/evaluate.py
@@ -29,12 +29,7 @@ except ImportError:
     import tflite_runtime.interpreter as tflite_interp
     from tflite_runtime.interpreter import OpResolverType
   except ImportError:
-    try:
-      import tensorflow.lite as tflite_interp
-      from tensorflow.lite.experimental import OpResolverType
-    except ImportError:
-      raise ImportError(
-          "Could not import ai_edge_litert, tflite_runtime, or tensorflow.")
+    raise ImportError("Could not import ai_edge_litert or tflite_runtime.")
 
 _USE_TFLITE_INTERPRETER = flags.DEFINE_bool(
     'use_tflite',

--- a/tensorflow/lite/micro/examples/mnist_lstm/BUILD
+++ b/tensorflow/lite/micro/examples/mnist_lstm/BUILD
@@ -43,7 +43,8 @@ py_test(
     target_compatible_with = INCOMPATIBLE_WITH_WINDOWS,
     deps = [
         ":evaluate",
-        ":train",
         "//tensorflow/lite/micro/tools:requantize_flatbuffer",
+        requirement("ai-edge-litert"),
+        requirement("numpy"),
     ],
 )

--- a/tensorflow/lite/micro/examples/mnist_lstm/evaluate_test.py
+++ b/tensorflow/lite/micro/examples/mnist_lstm/evaluate_test.py
@@ -13,40 +13,43 @@
 # limitations under the License.
 # =============================================================================
 import os
+import unittest
 
 import numpy as np
-import tensorflow as tf
 
-from tensorflow.python.framework import test_util
-from tensorflow.python.platform import resource_loader
-from tensorflow.python.platform import test
+try:
+  import ai_edge_litert.interpreter as tflite_interp
+  from ai_edge_litert.interpreter import OpResolverType
+except ImportError:
+  import tflite_runtime.interpreter as tflite_interp
+  from tflite_runtime.interpreter import OpResolverType
+
 from tflite_micro.python.tflite_micro import runtime
 from tflite_micro.tensorflow.lite.micro.examples.mnist_lstm import evaluate
 from tflite_micro.tensorflow.lite.micro.tools import requantize_flatbuffer
 
-PREFIX_PATH = resource_loader.get_path_to_datafile("")
+PREFIX_PATH = os.path.dirname(__file__)
 
 
-class LSTMFloatModelTest(test_util.TensorFlowTestCase):
+class LSTMFloatModelTest(unittest.TestCase):
 
   def setUp(self):
     self.model_path = os.path.join(PREFIX_PATH, "trained_lstm.tflite")
     self.input_shape = (1, 28, 28)
     self.output_shape = (1, 10)
     self.tflm_interpreter = runtime.Interpreter.from_file(self.model_path)
-    np.random.seed(42)  #Seed the random number generator
+    np.random.seed(42)  # Seed the random number generator
 
   def testInputErrHandling(self):
     wrong_size_image_path = os.path.join(PREFIX_PATH, "samples/resized9.png")
-    with self.assertRaisesWithPredicateMatch(ValueError,
-                                             "Invalid input image shape"):
+    with self.assertRaisesRegex(ValueError, "Invalid input image shape"):
       evaluate.predict_image(self.tflm_interpreter, wrong_size_image_path)
 
   def testCompareWithTFLite(self):
-    tflite_interpreter = tf.lite.Interpreter(
-        model_path=self.model_path,
-        experimental_op_resolver_type=\
-        tf.lite.experimental.OpResolverType.BUILTIN_REF)
+    kwargs = {"model_path": self.model_path}
+    if OpResolverType is not None:
+      kwargs["experimental_op_resolver_type"] = OpResolverType.BUILTIN_REF
+    tflite_interpreter = tflite_interp.Interpreter(**kwargs)
     tflite_interpreter.allocate_tensors()
     tflite_output_details = tflite_interpreter.get_output_details()[0]
     tflite_input_details = tflite_interpreter.get_input_details()[0]
@@ -71,9 +74,9 @@ class LSTMFloatModelTest(test_util.TensorFlowTestCase):
       tflm_output = evaluate.tflm_predict(self.tflm_interpreter, data_x)
 
       # Check that TFLM has correct output
-      self.assertDTypeEqual(tflm_output, np.float32)
+      self.assertEqual(tflm_output.dtype, np.float32)
       self.assertEqual(tflm_output.shape, self.output_shape)
-      self.assertAllLess((tflite_output - tflm_output), 1e-5)
+      self.assertTrue(np.all((tflite_output - tflm_output) < 1e-5))
 
   def testModelAccuracy(self):
     # Test prediction accuracy on digits 0-9 using sample images
@@ -88,7 +91,7 @@ class LSTMFloatModelTest(test_util.TensorFlowTestCase):
       self.assertEqual(predicted_category, label)
 
 
-class LSTMInt8ModelTest(test_util.TensorFlowTestCase):
+class LSTMInt8ModelTest(unittest.TestCase):
 
   def setUp(self):
     self.int8_model_path = os.path.join(PREFIX_PATH,
@@ -97,7 +100,7 @@ class LSTMInt8ModelTest(test_util.TensorFlowTestCase):
     self.output_shape = (1, 10)
     self.tflm_interpreter_quant = runtime.Interpreter.from_file(
         self.int8_model_path)
-    np.random.seed(42)  #Seed the random number generator
+    np.random.seed(42)  # Seed the random number generator
 
   def testQuantOutputs(self):
     # Get input/output information of the quantized model
@@ -127,15 +130,15 @@ class LSTMInt8ModelTest(test_util.TensorFlowTestCase):
       tflm_output_quant = evaluate.tflm_predict(self.tflm_interpreter_quant,
                                                 data_x_quant)
       # Check shape and type
-      self.assertDTypeEqual(tflm_output_quant, np.int8)
+      self.assertEqual(tflm_output_quant.dtype, np.int8)
       self.assertEqual(tflm_output_quant.shape, self.output_shape)
 
       # Convert the integer output back to float for comparison
       tflm_output_quant_float = evaluate.dequantize_output_data(
           tflm_output_quant, output_details)
       # Make sure the difference is within the error margin
-      self.assertAllLess(abs(tflm_output_float - tflm_output_quant_float),
-                         1e-2)
+      self.assertTrue(
+          np.all(abs(tflm_output_float - tflm_output_quant_float) < 1e-2))
 
   def testQuantModelAccuracy(self):
     for label in range(10):
@@ -150,7 +153,7 @@ class LSTMInt8ModelTest(test_util.TensorFlowTestCase):
       self.assertEqual(predicted_category, label)
 
 
-class LSTMInt16ModelTest(test_util.TensorFlowTestCase):
+class LSTMInt16ModelTest(unittest.TestCase):
 
   def setUp(self):
     # Convert the int8 model to int16
@@ -164,7 +167,7 @@ class LSTMInt16ModelTest(test_util.TensorFlowTestCase):
     self.output_shape = (1, 10)
     self.tflm_interpreter_quant = runtime.Interpreter.from_bytes(
         self.int16_model)
-    np.random.seed(42)  #Seed the random number generator
+    np.random.seed(42)  # Seed the random number generator
 
   def testQuantOutputs(self):
     # Get input/output information
@@ -194,15 +197,15 @@ class LSTMInt16ModelTest(test_util.TensorFlowTestCase):
       tflm_output_quant = evaluate.tflm_predict(self.tflm_interpreter_quant,
                                                 data_x_quant)
       # Check shape and type
-      self.assertDTypeEqual(tflm_output_quant, np.int16)
+      self.assertEqual(tflm_output_quant.dtype, np.int16)
       self.assertEqual(tflm_output_quant.shape, self.output_shape)
 
       # Convert the integer output back to float for comparison
       tflm_output_quant_float = evaluate.dequantize_output_data(
           tflm_output_quant, output_details)
       # Make sure the difference is within the error margin
-      self.assertAllLess(abs(tflm_output_float - tflm_output_quant_float),
-                         1e-3)
+      self.assertTrue(
+          np.all(abs(tflm_output_float - tflm_output_quant_float) < 1e-3))
 
   def testQuantModelAccuracy(self):
     for label in range(10):
@@ -218,4 +221,4 @@ class LSTMInt16ModelTest(test_util.TensorFlowTestCase):
 
 
 if __name__ == "__main__":
-  test.main()
+  unittest.main()


### PR DESCRIPTION
Decouples mnist_lstm and hello_world evaluation tests from tf.test by migrating to standard unittest and ai-edge-litert.

BUG=https://github.com/tensorflow/tflite-micro/issues/3545
