### PR TITLE
Migrate recipe and testdata tests to unittest

### DIFF
--- a/tensorflow/lite/micro/examples/recipes/BUILD
+++ b/tensorflow/lite/micro/examples/recipes/BUILD
@@ -37,6 +37,7 @@ py_test(
     target_compatible_with = INCOMPATIBLE_WITH_WINDOWS,
     deps = [
         ":resource_variables_lib",
+        requirement("numpy"),
         "//python/tflite_micro:runtime",
     ],
 )

--- a/tensorflow/lite/micro/examples/recipes/resource_variables_test.py
+++ b/tensorflow/lite/micro/examples/recipes/resource_variables_test.py
@@ -29,7 +29,7 @@ class ResourceVariablesTest(unittest.TestCase):
     tflm_interpreter = tflm_runtime.Interpreter.from_bytes(model_keras)
 
     tflm_interpreter.set_input([[True]], 0)
-    tflm_interpreter.set_input([np.full((100,), 15.0, dtype=np.float32)], 1)
+    tflm_interpreter.set_input([np.full((100, ), 15.0, dtype=np.float32)], 1)
     tflm_interpreter.invoke()
     np.testing.assert_array_equal(
         tflm_interpreter.get_output(0),
@@ -37,7 +37,7 @@ class ResourceVariablesTest(unittest.TestCase):
     )
 
     tflm_interpreter.set_input([[False]], 0)
-    tflm_interpreter.set_input([np.full((100,), 9.0, dtype=np.float32)], 1)
+    tflm_interpreter.set_input([np.full((100, ), 9.0, dtype=np.float32)], 1)
     tflm_interpreter.invoke()
     np.testing.assert_array_equal(
         tflm_interpreter.get_output(0),
@@ -47,7 +47,7 @@ class ResourceVariablesTest(unittest.TestCase):
     # resets variables to initial value
     tflm_interpreter.reset()
     tflm_interpreter.set_input([[True]], 0)
-    tflm_interpreter.set_input([np.full((100,), 5.0, dtype=np.float32)], 1)
+    tflm_interpreter.set_input([np.full((100, ), 5.0, dtype=np.float32)], 1)
     tflm_interpreter.invoke()
     np.testing.assert_array_equal(
         tflm_interpreter.get_output(0),
@@ -57,4 +57,3 @@ class ResourceVariablesTest(unittest.TestCase):
 
 if __name__ == "__main__":
   unittest.main()
-

--- a/tensorflow/lite/micro/examples/recipes/resource_variables_test.py
+++ b/tensorflow/lite/micro/examples/recipes/resource_variables_test.py
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =============================================================================
+import unittest
 import numpy as np
 
-from tensorflow.python.framework import test_util
-from tensorflow.python.platform import test
+from tflite_micro.python.tflite_micro import runtime as tflm_runtime
 from tflite_micro.tensorflow.lite.micro.examples.recipes import resource_variables_lib
 
-from tflite_micro.python.tflite_micro import runtime as tflm_runtime
 
-
-class ResourceVariablesTest(test_util.TensorFlowTestCase):
+class ResourceVariablesTest(unittest.TestCase):
 
   # Tests the custom accumulator model. Input conditional is [True], and
   # accumulator value is array of 5.0. Given these inputs, we expect the output
@@ -33,7 +31,7 @@ class ResourceVariablesTest(test_util.TensorFlowTestCase):
     tflm_interpreter.set_input([[True]], 0)
     tflm_interpreter.set_input([np.full((100,), 15.0, dtype=np.float32)], 1)
     tflm_interpreter.invoke()
-    self.assertAllEqual(
+    np.testing.assert_array_equal(
         tflm_interpreter.get_output(0),
         np.full((1, 100), 15.0, dtype=np.float32),
     )
@@ -41,7 +39,7 @@ class ResourceVariablesTest(test_util.TensorFlowTestCase):
     tflm_interpreter.set_input([[False]], 0)
     tflm_interpreter.set_input([np.full((100,), 9.0, dtype=np.float32)], 1)
     tflm_interpreter.invoke()
-    self.assertAllEqual(
+    np.testing.assert_array_equal(
         tflm_interpreter.get_output(0),
         np.full((1, 100), 6.0, dtype=np.float32),
     )
@@ -51,11 +49,12 @@ class ResourceVariablesTest(test_util.TensorFlowTestCase):
     tflm_interpreter.set_input([[True]], 0)
     tflm_interpreter.set_input([np.full((100,), 5.0, dtype=np.float32)], 1)
     tflm_interpreter.invoke()
-    self.assertAllEqual(
+    np.testing.assert_array_equal(
         tflm_interpreter.get_output(0),
         np.full((1, 100), 5.0, dtype=np.float32),
     )
 
 
 if __name__ == "__main__":
-  test.main()
+  unittest.main()
+

--- a/tensorflow/lite/micro/kernels/testdata/lstm_test_data_generator_test.py
+++ b/tensorflow/lite/micro/kernels/testdata/lstm_test_data_generator_test.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =============================================================================
+import unittest
 import numpy as np
 import tensorflow as tf
 
-from tensorflow.python.framework import test_util
-from tensorflow.python.platform import test
 from tflite_micro.tensorflow.lite.micro.kernels.testdata import lstm_test_data_utils
 
 _KERNEL_CONFIG = {
@@ -77,7 +76,7 @@ def create_keras_lstm(stateful=True):
   return tf.keras.Model(input_layer, lstm_output, name="LSTM")
 
 
-class QuantizedLSTMDebuggerTest(test_util.TensorFlowTestCase):
+class QuantizedLSTMDebuggerTest(unittest.TestCase):
 
   # only the float output from the debugger is used to setup the test data in .cc
   def testFloatCompareWithKeras(self):
@@ -101,8 +100,8 @@ class QuantizedLSTMDebuggerTest(test_util.TensorFlowTestCase):
       output_keras, _, _ = keras_lstm.predict(test_data.reshape(1, 1, 2))
 
       diff = abs(output_float.flatten() - output_keras.flatten())
-      self.assertAllLess(diff, 1e-6)
+      self.assertTrue(np.all(diff < 1e-6))
 
 
 if __name__ == "__main__":
-  test.main()
+  unittest.main()


### PR DESCRIPTION
Replaces internal tensorflow.python test utilities with standard unittest in resource_variables_test and lstm_test_data_generator_test.

BUG=https://github.com/tensorflow/tflite-micro/issues/3545